### PR TITLE
CVL-27: Update gradle and spring boot plugin to fix overnight Trivy scan failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.5"
   kotlin("plugin.spring") version "1.5.21"
   kotlin("plugin.jpa") version "1.5.21"
   id("io.gitlab.arturbosch.detekt").version("1.18.0-RC2")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates gradle plugin to 3.3.5
Updates gradle to 7.1.1-bin