### PR TITLE
CRS-170 Add endpoint to pass a JSON string to test our calculation engine - will be used for testing purposes only

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/PrisonerDetails.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 data class PrisonerDetails(
-  val bookingId: String,
+  val bookingId: Long,
   val offenderNo: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
@@ -54,7 +54,8 @@ class TestController(
   @ResponseBody
   @Operation(
     summary = "Calculate release dates based on a prisoners booking data",
-    description = "This endpoint will calculate release dates based on a prisoners booking data (e.g. sentences and adjustments)",
+    description = "This endpoint will calculate release dates based on a prisoners booking data " +
+      "(e.g. sentences and adjustments)",
     security = [
       SecurityRequirement(name = "SYSTEM_USER"),
       SecurityRequirement(name = "CRD_ADMIN"),
@@ -68,7 +69,7 @@ class TestController(
     ]
   )
   fun calculate(@RequestBody @NotEmpty booking: String): BookingCalculation {
-    log.info("Calculate booking for  $booking")
+    log.info("Request received to calculate booking for $booking")
     return calculationService.calculate(testService.jsonToBooking(booking))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
@@ -4,18 +4,28 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BookingCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.TestData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.TestService
+import javax.validation.constraints.NotEmpty
 
 @RestController
 @RequestMapping("/test", produces = [MediaType.APPLICATION_JSON_VALUE])
-class TestController(private val testService: TestService) {
+class TestController(
+  private val testService: TestService,
+  private val calculationService: CalculationService,
+) {
 
   @GetMapping(value = ["/data"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CRD_ADMIN', 'PRISON')")
@@ -37,5 +47,32 @@ class TestController(private val testService: TestService) {
   )
   fun getTestData(): List<TestData> {
     return testService.getTestData()
+  }
+
+  @PostMapping(value = ["/calculation-by-booking"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CRD_ADMIN', 'PRISON')")
+  @ResponseBody
+  @Operation(
+    summary = "Calculate release dates based on a prisoners booking data",
+    description = "This endpoint will calculate release dates based on a prisoners booking data (e.g. sentences and adjustments)",
+    security = [
+      SecurityRequirement(name = "SYSTEM_USER"),
+      SecurityRequirement(name = "CRD_ADMIN"),
+      SecurityRequirement(name = "PRISON")
+    ],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role")
+    ]
+  )
+  fun calculate(@RequestBody @NotEmpty booking: String): BookingCalculation {
+    log.info("Calculate booking for  $booking")
+    return calculationService.calculate(testService.jsonToBooking(booking))
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TestService.kt
@@ -1,8 +1,19 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.TestData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.TestRepository
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.*
 
 @Service
 class TestService(
@@ -10,10 +21,75 @@ class TestService(
   private val prisonService: PrisonService,
 ) {
 
+  var moshi: Moshi = Moshi.Builder()
+    .addLast(KotlinJsonAdapterFactory())
+    .add(LocalDate::class.java, LocalDateAdapter().nullSafe())
+    .add(OptionalLocalDateAdapter())
+    .add(UUID::class.java, UUIDAdapter().nullSafe())
+    .build()
+
   fun getTestData(): List<TestData> {
     val prisoner = prisonService.getOffenderDetail("A1234AA")
     val testData = testRepository.findAll().map { transform(it) }.toMutableList()
-    testData.add(TestData(prisoner.offenderNo, prisoner.bookingId))
+    testData.add(TestData(prisoner.offenderNo, prisoner.bookingId.toString()))
     return testData
   }
+
+  fun jsonToBooking(json: String): Booking {
+    val jsonAdapter = moshi.adapter(Booking::class.java)
+    return jsonAdapter.fromJson(json)!!
+  }
+  class LocalDateAdapter : JsonAdapter<LocalDate>() {
+    override fun toJson(writer: JsonWriter, value: LocalDate?) {
+      value?.let { writer.value(it.format(formatter)) }
+    }
+
+    override fun fromJson(reader: JsonReader): LocalDate? {
+      return if (reader.peek() != JsonReader.Token.NULL) {
+        fromNonNullString(reader.nextString())
+      } else {
+        reader.nextNull<Any>()
+        null
+      }
+    }
+    private val formatter = DateTimeFormatter.ISO_LOCAL_DATE
+    private fun fromNonNullString(nextString: String): LocalDate = LocalDate.parse(nextString, formatter)
+  }
+
+  class UUIDAdapter : JsonAdapter<UUID>() {
+    override fun toJson(writer: JsonWriter, value: UUID?) {
+      value?.let { writer.value(it.toString()) }
+    }
+
+    override fun fromJson(jsonReader: JsonReader): UUID? {
+      val value = jsonReader.nextString()
+      return UUID.fromString(value)
+    }
+  }
+
+  class OptionalLocalDateAdapter : JsonAdapter<Optional<LocalDate>>() {
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: Optional<LocalDate>?) {
+      value?.let {
+        if (value.isEmpty) {
+          writer.value("")
+        } else {
+          writer.value(value.get().format(formatter))
+        }
+      }
+    }
+
+    @FromJson
+    override fun fromJson(reader: JsonReader): Optional<LocalDate> {
+      return if (reader.peek() != JsonReader.Token.NULL) {
+        fromNonNullString(reader.nextString())
+      } else {
+        Optional.empty<LocalDate>()
+      }
+    }
+    private val formatter = DateTimeFormatter.ISO_LOCAL_DATE
+    private fun fromNonNullString(nextString: String): Optional<LocalDate> =
+      Optional.of(LocalDate.parse(nextString, formatter))
+  }
 }
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TestService.kt
@@ -13,7 +13,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.TestData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.TestRepository
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 @Service
 class TestService(
@@ -39,6 +40,7 @@ class TestService(
     val jsonAdapter = moshi.adapter(Booking::class.java)
     return jsonAdapter.fromJson(json)!!
   }
+
   class LocalDateAdapter : JsonAdapter<LocalDate>() {
     override fun toJson(writer: JsonWriter, value: LocalDate?) {
       value?.let { writer.value(it.format(formatter)) }
@@ -52,6 +54,7 @@ class TestService(
         null
       }
     }
+
     private val formatter = DateTimeFormatter.ISO_LOCAL_DATE
     private fun fromNonNullString(nextString: String): LocalDate = LocalDate.parse(nextString, formatter)
   }
@@ -87,9 +90,9 @@ class TestService(
         Optional.empty<LocalDate>()
       }
     }
+
     private val formatter = DateTimeFormatter.ISO_LOCAL_DATE
     private fun fromNonNullString(nextString: String): Optional<LocalDate> =
       Optional.of(LocalDate.parse(nextString, formatter))
   }
 }
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
@@ -15,6 +15,7 @@ import org.springframework.test.context.jdbc.SqlMergeMode
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.OAuthExtension
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.PrisonApiExtension
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
 import java.time.LocalDate
 import java.util.UUID
@@ -38,7 +39,7 @@ import java.util.UUID
   "classpath:test_data/reset-base-data.sql",
   "classpath:test_data/load-base-data.sql"
 )
-@ExtendWith(OAuthExtension::class)
+@ExtendWith(OAuthExtension::class, PrisonApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 class IntegrationTestBase internal constructor() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/TestDataIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/TestDataIntTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/TestDataIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/TestDataIntTest.kt
@@ -1,20 +1,25 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BookingCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.TestData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
 
 class TestDataIntTest : IntegrationTestBase() {
+  private val jsonTransformation = JsonTransformation()
 
   @Test
   fun `Get a list of test data items`() {
     val result = webTestClient.get()
       .uri("/test/data")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CALCULATE_SENTENCE_ADMIN")))
+      .headers(setAuthorisation(roles = listOf("ROLE_CRD_ADMIN")))
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -22,8 +27,8 @@ class TestDataIntTest : IntegrationTestBase() {
       .returnResult().responseBody
 
     log.info("Expect OK: Result returned $result")
-    assertThat(result?.size).isEqualTo(3)
-    assertThat(result).extracting("key").containsAll(listOf("A", "B", "C"))
+    assertThat(result?.size).isEqualTo(4)
+    assertThat(result).extracting("key").containsAll(listOf("A", "B", "C", "A1234AA"))
   }
 
   @Test
@@ -48,5 +53,22 @@ class TestDataIntTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED.value())
+  }
+
+  @Test
+  fun `Test example 9 against direct calculation endpoint`() {
+    val result = webTestClient.post()
+      .uri("/test/calculation-by-booking")
+      .bodyValue(jsonTransformation.getJsonTest("psi-examples/9.json", "overall_calculation"))
+      .headers(setAuthorisation(roles = listOf("ROLE_CRD_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody(BookingCalculation::class.java)
+      .returnResult().responseBody
+
+    assertEquals(
+      jsonTransformation.loadBookingCalculation("9"),
+      result
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -39,7 +39,6 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 8332
   }
 
-//  private val gson = GsonBuilder().setPrettyPrinting().create()
   var moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
   var jsonAdapter: JsonAdapter<PrisonerDetails> = moshi.adapter<PrisonerDetails>(PrisonerDetails::class.java)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.PrisonerDetails
+
+class PrisonApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val prisonApi = PrisonApiMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    prisonApi.start()
+    prisonApi.stubGetPrisonerDetails("A1234AA")
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    prisonApi.resetRequests()
+    prisonApi.stubGetPrisonerDetails("A1234AA")
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    prisonApi.stop()
+  }
+}
+
+class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8332
+  }
+
+//  private val gson = GsonBuilder().setPrettyPrinting().create()
+  var moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+  var jsonAdapter: JsonAdapter<PrisonerDetails> = moshi.adapter<PrisonerDetails>(PrisonerDetails::class.java)
+
+  private val prisonerDetails = PrisonerDetails(1L, "A1234AA")
+
+  fun stubHealthPing(status: Int) {
+    stubFor(
+      get("/health/ping").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(if (status == 200) "pong" else "some error")
+          .withStatus(status)
+      )
+    )
+  }
+
+  fun stubGetPrisonerDetails(prisonerId: String): StubMapping =
+    stubFor(
+      get("/api/offenders/$prisonerId")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonAdapter.toJson(prisonerDetails))
+            .withStatus(200)
+        )
+    )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -44,17 +44,6 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   private val prisonerDetails = PrisonerDetails(1L, "A1234AA")
 
-  fun stubHealthPing(status: Int) {
-    stubFor(
-      get("/health/ping").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(if (status == 200) "pong" else "some error")
-          .withStatus(status)
-      )
-    )
-  }
-
   fun stubGetPrisonerDetails(prisonerId: String): StubMapping =
     stubFor(
       get("/api/offenders/$prisonerId")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/JsonTransformation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/JsonTransformation.kt
@@ -67,7 +67,7 @@ class JsonTransformation {
     return jsonAdapter.fromJson(json)
   }
 
-  private fun getJsonTest(fileName: String, calculationType: String): String {
+  fun getJsonTest(fileName: String, calculationType: String): String {
     return getResourceAsText("/test_data/$calculationType/$fileName")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestDataControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestDataControllerTest.kt
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.ControllerAdvice
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.TestData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.TestService
 
 @ExtendWith(SpringExtension::class)
@@ -38,6 +39,9 @@ class TestDataControllerTest {
   @MockBean
   private lateinit var testService: TestService
 
+  @MockBean
+  private lateinit var calculationService: CalculationService
+
   @Autowired
   private lateinit var mvc: MockMvc
 
@@ -49,7 +53,7 @@ class TestDataControllerTest {
     reset(testService)
 
     mvc = MockMvcBuilders
-      .standaloneSetup(TestController(testService))
+      .standaloneSetup(TestController(testService, calculationService))
       .setControllerAdvice(ControllerAdvice())
       .build()
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -49,3 +49,9 @@ management.endpoint:
 hmpps:
   auth:
     url: http://localhost:8090/auth
+
+# Wiremock prison-api
+prison:
+  api:
+    url: http://localhost:8332
+


### PR DESCRIPTION
This adds another test endpoint so that the calculation engine can be tested via postman / the front end

Will probably only be a temporary endpoint to aid testing by the wider team until our app is more mature