### PR TITLE
CRS-139

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Sentence.kt
@@ -69,7 +69,10 @@ data class Sentence(
       "Date of $expiryDateType\t:\t${sentenceCalculation.unadjustedExpiryDate.format(formatter)}\n" +
       "Number of days to $releaseDateType\t:\t${sentenceCalculation.numberOfDaysToReleaseDate}\n" +
       "Date of $releaseDateType\t:\t${sentenceCalculation.unadjustedReleaseDate.format(formatter)}\n" +
-      "Total number of days of remand / tagged bail time / UAL\t:\t${sentenceCalculation.calculatedTotalRemandDays}\n" +
+      "Total number of days of deducted (remand / tagged bail)\t:" +
+      "\t${sentenceCalculation.calculatedTotalDeductedDays}\n" +
+      "Total number of days of added (ADA) \t:\t${sentenceCalculation.calculatedTotalAddedDays}\n" +
+      "Total number of days to licence expiry\t:\t${sentenceCalculation.numberOfDaysToLicenceExpiry}\n" +
       "LED\t:\t${sentenceCalculation.licenceExpiryDate?.format(formatter)}\n" +
       "Effective $expiryDateType\t:\t${sentenceCalculation.expiryDate?.format(formatter)}\n" +
       "Effective $releaseDateType\t:\t${sentenceCalculation.releaseDate?.format(formatter)}\n" +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculation.kt
@@ -8,11 +8,14 @@ data class SentenceCalculation(
   val numberOfDaysToReleaseDate: Int,
   val unadjustedExpiryDate: LocalDate,
   val unadjustedReleaseDate: LocalDate,
-  val calculatedTotalRemandDays: Int,
+  val calculatedTotalDeductedDays: Int,
+  val calculatedTotalAddedDays: Int,
   val adjustedExpiryDate: LocalDate,
   val adjustedReleaseDate: LocalDate
 ) {
 
+  var numberOfDaysToNonParoleDate: Long = 0
+  var numberOfDaysToLicenceExpiry: Long = 0
   var nonParoleDate: LocalDate? = null
 
   // public values here are used to populate final calculation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationService.kt
@@ -145,15 +145,23 @@ class SentenceCalculationService {
     }
 
     if (sentence.sentenceTypes.contains(SentenceType.NPD)) {
+      sentenceCalculation.numberOfDaysToNonParoleDate =
+        ceil(sentenceCalculation.numberOfDaysToSentenceExpiryDate.toDouble().times(THREE).div(FOUR)).toLong()
+          .plus(sentenceCalculation.calculatedTotalAddedDays)
+          .minus(sentenceCalculation.calculatedTotalDeductedDays)
       sentenceCalculation.nonParoleDate = sentence.sentencedAt.plusDays(
-        ceil(sentenceCalculation.numberOfDaysToSentenceExpiryDate.toDouble().times(TWO.div(THREE))).toLong()
-      )
+        sentenceCalculation.numberOfDaysToNonParoleDate
+      ).minusDays(ONE)
     }
 
     if (sentence.sentenceTypes.contains(SentenceType.LED)) {
-      sentenceCalculation.nonParoleDate = sentence.sentencedAt.plusDays(
-        ceil(sentenceCalculation.numberOfDaysToSentenceExpiryDate.toDouble().times(THREE.div(FOUR))).toLong()
-      )
+      sentenceCalculation.numberOfDaysToLicenceExpiry =
+        ceil(sentenceCalculation.numberOfDaysToSentenceExpiryDate.toDouble().times(THREE).div(FOUR)).toLong()
+          .plus(sentenceCalculation.calculatedTotalAddedDays)
+          .minus(sentenceCalculation.calculatedTotalDeductedDays)
+      sentenceCalculation.licenceExpiryDate = sentence.sentencedAt.plusDays(
+        sentenceCalculation.numberOfDaysToLicenceExpiry
+      ).minusDays(ONE)
     }
 
     // create association between the sentence and it's calculation
@@ -206,6 +214,7 @@ class SentenceCalculationService {
       unadjustedExpiryDate,
       unadjustedReleaseDate,
       calculatedTotalDeductedDays,
+      calculatedTotalAddedDays,
       adjustedExpiryDate,
       adjustedReleaseDate
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculationTest.kt
@@ -25,6 +25,7 @@ internal class SentenceCalculationTest {
       date,
       date,
       1,
+      0,
       date,
       date
     )
@@ -32,7 +33,8 @@ internal class SentenceCalculationTest {
     assertEquals(sentenceCalculation.sentence, sentence)
     assertEquals(3, sentenceCalculation.numberOfDaysToSentenceExpiryDate)
     assertEquals(4, sentenceCalculation.numberOfDaysToReleaseDate)
-    assertEquals(1, sentenceCalculation.calculatedTotalRemandDays)
+    assertEquals(1, sentenceCalculation.calculatedTotalDeductedDays)
+    assertEquals(0, sentenceCalculation.calculatedTotalAddedDays)
     assertEquals(date, sentenceCalculation.unadjustedExpiryDate)
     assertEquals(date, sentenceCalculation.unadjustedReleaseDate)
     assertEquals(date, sentenceCalculation.adjustedExpiryDate)

--- a/src/test/resources/test_data/overall_calculation/psi-examples/28.json
+++ b/src/test/resources/test_data/overall_calculation/psi-examples/28.json
@@ -1,0 +1,24 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "name": "AN. Other",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "startedAt": "2005-01-01"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 2
+        }
+      },
+      "sentencedAt": "2009-10-09"
+    }
+  ],
+  "adjustments": {
+    "REMAND": 20,
+    "TAGGED_BAIL" : 10
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/28.json
+++ b/src/test/resources/test_data/overall_calculation_response/28.json
@@ -1,0 +1,6 @@
+{
+  "releaseDate": "2010-09-08",
+  "sentenceExpiryDate": "2011-09-08",
+  "licenceExpiryDate": "2011-03-10",
+  "isReleaseDateConditional": true
+}


### PR DESCRIPTION
PSI Example 28
- Addition of test expectation input and output.
- Addition of intermediate calculation values
- Rename of existing values for clarity
- Amendment to LED and NPD calculations. Was previously incorrect for 2 reasons:
  -  The calculation was always returning zero days
  -  The calculation was using the sentence length before days were subtracted