### PR TITLE
CRS-516 remove client id and client secret from values.yaml - had already been removed from elsewhere

### DIFF
--- a/helm_deploy/calculate-release-dates-api/values.yaml
+++ b/helm_deploy/calculate-release-dates-api/values.yaml
@@ -32,8 +32,6 @@ generic-service:
   namespace_secrets:
     calculate-release-dates-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
-      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
     rds-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"


### PR DESCRIPTION
These keys are not required by our service any more - as we pass through the users token and this service does not require any extra roles