### PR TITLE
CRS-610 Do not propogate error if publishing the event fails - simply log it

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
@@ -162,10 +162,19 @@ class CalculationService(
       log.error("Nomis write failed: ${ex.message}")
       throw EntityNotFoundException(
         "Writing release dates to NOMIS failed for prisonerId $prisonerId " +
-          "and bookingId $booking.bookingId"
+          "and bookingId $booking"
       )
     }
-    domainEventPublisher.publishReleaseDateChange(prisonerId, booking.bookingId)
+    try {
+      domainEventPublisher.publishReleaseDateChange(prisonerId, booking.bookingId)
+    } catch (ex: Exception) {
+      // This doesn't constitute a failure at the moment because we are writing back to NOMIS using a POST endpoint.
+      // Eventually the event will be used to write back to NOMIS and then this will need refactoring
+      log.info(
+        "Publishing the release date change to the domain event topic failed for prisonerId $prisonerId " +
+          "and bookingId $booking"
+      )
+    }
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
@@ -162,7 +162,7 @@ class CalculationService(
       log.error("Nomis write failed: ${ex.message}")
       throw EntityNotFoundException(
         "Writing release dates to NOMIS failed for prisonerId $prisonerId " +
-          "and bookingId $booking"
+          "and bookingId ${booking.bookingId}"
       )
     }
     try {
@@ -172,7 +172,7 @@ class CalculationService(
       // Eventually the event will be used to write back to NOMIS and then this will need refactoring
       log.info(
         "Publishing the release date change to the domain event topic failed for prisonerId $prisonerId " +
-          "and bookingId $booking"
+          "and bookingId ${booking.bookingId}"
       )
     }
   }


### PR DESCRIPTION
Publishing the event doesn't constitute a failure at the moment because we are writing back to NOMIS using a POST endpoint.
Eventually the event will be used to write back to NOMIS in an async fashion and then this will need refactoring