### PR TITLE
CRS 659 update to latest version of plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
   implementation("org.springframework.cloud:spring-cloud-aws-messaging:2.2.6.RELEASE")
   implementation("org.springframework:spring-jms")
   implementation("com.google.code.gson:gson:2.8.9")
+  implementation("ch.qos.logback:logback-core:1.2.9")
+  implementation("ch.qos.logback:logback-classic:1.2.9")
 
   // Test dependencies
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.16"
-  kotlin("plugin.spring") version "1.5.30"
-  kotlin("plugin.jpa") version "1.5.30"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.0"
+  kotlin("plugin.spring") version "1.6.10"
+  kotlin("plugin.jpa") version "1.6.10"
   id("io.gitlab.arturbosch.detekt").version("1.18.0-RC2")
   id("jacoco")
 }
@@ -53,7 +53,7 @@ dependencies {
   implementation("uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE")
 
   // Enable kotlin reflect
-  implementation("org.jetbrains.kotlin:kotlin-reflect:1.5.21")
+  implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
 
   // Three Ten Date Calculations
   implementation("org.threeten:threeten-extra:1.7.0")
@@ -62,17 +62,17 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql:42.3.1")
 
-  implementation("com.squareup.moshi:moshi-kotlin:1.12.0")
+  implementation("com.squareup.moshi:moshi-kotlin:1.13.0")
   implementation("io.arrow-kt:arrow-core:1.0.1")
   implementation("com.vladmihalcea:hibernate-types-52:2.14.0")
 
   // OpenAPI
-  implementation("org.springdoc:springdoc-openapi-ui:1.5.12")
-  implementation("org.springdoc:springdoc-openapi-data-rest:1.5.12")
-  implementation("org.springdoc:springdoc-openapi-kotlin:1.5.12")
+  implementation("org.springdoc:springdoc-openapi-ui:1.6.2")
+  implementation("org.springdoc:springdoc-openapi-data-rest:1.6.2")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.6.2")
 
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
-  implementation("com.amazonaws:aws-java-sdk-sns:1.12.122")
+  implementation("com.amazonaws:aws-java-sdk-sns:1.12.131")
   implementation("org.springframework.cloud:spring-cloud-aws-messaging:2.2.6.RELEASE")
   implementation("org.springframework:spring-jms")
   implementation("com.google.code.gson:gson:2.8.9")
@@ -83,8 +83,8 @@ dependencies {
   testImplementation("org.awaitility:awaitility-kotlin:4.1.1")
   testImplementation("io.jsonwebtoken:jjwt:0.9.1")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.28.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser-v2-converter:2.0.28")
-  testImplementation("org.mockito:mockito-inline:4.1.0")
+  testImplementation("io.swagger.parser.v3:swagger-parser-v2-converter:2.0.29")
+  testImplementation("org.mockito:mockito-inline:4.2.0")
   testImplementation("io.projectreactor:reactor-test")
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   testImplementation("com.h2database:h2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity
 import com.fasterxml.jackson.databind.JsonNode
 import com.vladmihalcea.hibernate.type.json.JsonType
 import com.vladmihalcea.hibernate.type.json.internal.JacksonUtil
+import org.hibernate.Hibernate
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import org.hibernate.annotations.Type
@@ -20,6 +21,7 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
+@Suppress("DEPRECATION")
 @Entity
 @Table
 @TypeDefs(
@@ -57,4 +59,22 @@ data class CalculationRequest(
   @OneToMany
   @Fetch(FetchMode.JOIN)
   val calculationOutcomes: List<CalculationOutcome> = ArrayList(),
-)
+) {
+
+  @Override
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as CalculationRequest
+
+    return id == other.id
+  }
+
+  @Override
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  @Override
+  override fun toString(): String {
+    return this::class.simpleName + "(calculationReference = $calculationReference )"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/health/HealthCheckTest.kt
@@ -25,7 +25,8 @@ class HealthCheckTest : IntegrationTestBase() {
     webTestClient.get().uri("/health")
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("components.healthInfo.details.version").value(
+      .expectBody()
+      .jsonPath("components.healthInfo.details.version").value(
         Consumer<String> {
           assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/health/InfoTest.kt
@@ -10,21 +10,27 @@ class InfoTest : IntegrationTestBase() {
 
   @Test
   fun `Info page is accessible`() {
-    webTestClient.get()
+    webTestClient
+      .get()
       .uri("/info")
       .exchange()
       .expectStatus()
       .isOk
       .expectBody()
-      .jsonPath("app.name").isEqualTo("Calculate Release Dates Api")
+      .jsonPath("build.name")
+      .isEqualTo("calculate-release-dates-api")
   }
 
   @Test
   fun `Info page reports version`() {
-    webTestClient.get().uri("/info")
+    webTestClient
+      .get()
+      .uri("/info")
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("build.version").value<String> {
+      .expectBody()
+      .consumeWith(System.out::println)
+      .jsonPath("build.version").value<String> {
         assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -1,15 +1,15 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.reset
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/WorkingDayControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/WorkingDayControllerTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.reset
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.reset
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.ADDITIONAL_DAYS_AWARDED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.REMAND
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationServiceTest.kt
@@ -1,10 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import com.vladmihalcea.hibernate.type.json.internal.JacksonUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
@@ -14,6 +10,10 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.context.SecurityContextHolder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/WorkingDayServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/WorkingDayServiceTest.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.reset
-import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BankHoliday
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BankHolidays
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RegionBankHolidays


### PR DESCRIPTION
- Principally, the Gradle-spring-boot version
- Update path to Kotlin mockito
- Overrode the equals/hashcode/toString to avoid performance warning
- Added logback at specific version to force version push from 1.2.7 to 1.2.9 to avoid a vulnerability.
- Changes to the way tests for info endpoint
