### PR TITLE
CRS-861 SDS plus backend.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://api-dev.prison.service.justice.gov.uk
     EDS_FEATURE_TOGGLE: true
+    PCSC_START_DATE: 2022-05-01
 
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://api-preprod.prison.service.justice.gov.uk
     EDS_FEATURE_TOGGLE: true
+    PCSC_START_DATE: 2022-06-27
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://api.prison.service.justice.gov.uk
     EDS_FEATURE_TOGGLE: false
+    PCSC_START_DATE: 2022-06-27
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 @ConfigurationProperties(prefix = "feature-toggles")
 data class FeatureToggles(
   var eds: Boolean = false,
+  /* This will allow us to change the comencement date of PCSC in order to test the functionality. */
   private var pcscStartDateString: String = "2022-06-27"
 ) {
   val pcscStartDate = LocalDate.parse(pcscStartDateString)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
@@ -1,8 +1,12 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.LocalDate
 
 @ConfigurationProperties(prefix = "feature-toggles")
 data class FeatureToggles(
-  var eds: Boolean = false
-)
+  var eds: Boolean = false,
+  private var pcscStartDateString: String = "2022-06-27"
+) {
+  val pcscStartDate = LocalDate.parse(pcscStartDateString)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
@@ -11,6 +11,7 @@ import org.hibernate.annotations.TypeDef
 import org.hibernate.annotations.TypeDefs
 import java.time.LocalDateTime
 import java.util.UUID
+import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
@@ -84,7 +85,14 @@ data class CalculationRequest(
   @OneToMany
   @Fetch(FetchMode.JOIN)
   val calculationOutcomes: List<CalculationOutcome> = ArrayList(),
+
+  @OneToMany(mappedBy = "calculationRequest", cascade = [CascadeType.ALL])
+  val calculationRequestUserInputs: List<CalculationRequestUserInput> = ArrayList()
 ) {
+
+  init {
+    calculationRequestUserInputs.forEach { it.calculationRequest = this }
+  }
 
   @Override
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequestUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequestUserInput.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+import javax.validation.constraints.NotNull
+
+@Entity
+@Table
+data class CalculationRequestUserInput(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val id: Long = -1,
+  @NotNull
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "calculationRequestId", nullable = false, updatable = false)
+  var calculationRequest: CalculationRequest? = null,
+  @NotNull
+  val sentenceSequence: Int,
+  @NotNull
+  val offenceCode: String,
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  var type: UserInputType,
+  @NotNull
+  var userChoice: Boolean,
+  @NotNull
+  var nomisMatches: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequestUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequestUserInput.kt
@@ -21,7 +21,7 @@ data class CalculationRequestUserInput(
   @NotNull
   @ManyToOne(optional = false)
   @JoinColumn(name = "calculationRequestId", nullable = false, updatable = false)
-  var calculationRequest: CalculationRequest? = null,
+  var calculationRequest: CalculationRequest = CalculationRequest(),
   @NotNull
   val sentenceSequence: Int,
   @NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceQuestion.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
+/**
+ * A class representing questions that will need clarification for each sentence from the user before we start the calculation
+ */
 data class CalculationSentenceQuestion(
   val sentenceSequence: Int,
   val userInputType: UserInputType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceQuestion.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+data class CalculationSentenceQuestion(
+  val sentenceSequence: Int,
+  val userInputType: UserInputType
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationSentenceUserInput.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
-data class SentenceCalculationUserInput(
+data class CalculationSentenceUserInput(
   val sentenceSequence: Int,
   val offenceCode: String,
   var isScheduleFifteenMaximumLife: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInput.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
-
-data class CalculationUserInput(
-  val sentenceCalculationUserInputs: List<SentenceCalculationUserInput>
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInput.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+data class CalculationUserInput(
+  val sentenceCalculationUserInputs: List<SentenceCalculationUserInput>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInputs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserInputs.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+/**
+ * A class representing the users input to questions {@see CalculationUserQuestions} we've asked before calculation.
+ */
+data class CalculationUserInputs(
+  val sentenceCalculationUserInputs: List<CalculationSentenceUserInput>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserQuestions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserQuestions.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
+/**
+ * A class representing questions that will need clarification from the user before we start the calculation
+ */
 data class CalculationUserQuestions(
   val sentenceQuestions: List<CalculationSentenceQuestion>
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserQuestions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationUserQuestions.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+data class CalculationUserQuestions(
+  val sentenceQuestions: List<CalculationSentenceQuestion>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculationUserInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculationUserInput.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+data class SentenceCalculationUserInput(
+  val sentenceSequence: Int,
+  val offenceCode: String,
+  var isScheduleFifteenMaximumLife: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/UserInputType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/UserInputType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+enum class UserInputType {
+  SCHEDULE_15_ATTRACTING_LIFE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/OffenderOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/OffenderOffence.kt
@@ -10,6 +10,10 @@ data class OffenderOffence(
   val offenceDescription: String,
   var indicators: List<String> = listOf()
 ) {
+  val isScheduleFifteenMaximumLife: Boolean get() {
+    return this.indicators.any { it == SCHEDULE_15_LIFE_INDICATOR }
+  }
+
   companion object {
     const val SCHEDULE_15_LIFE_INDICATOR = "SCH15/CJIB/L"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -24,6 +24,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CrdCalcu
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -32,6 +34,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationTransactionalService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationUserQuestionService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessages
@@ -46,7 +49,8 @@ class CalculationController(
   private val prisonService: PrisonService,
   private val calculationTransactionalService: CalculationTransactionalService,
   private val calculationService: CalculationService,
-  private val validationService: ValidationService
+  private val validationService: ValidationService,
+  private val calculationUserQuestionService: CalculationUserQuestionService
 ) {
   @PostMapping(value = ["/{prisonerId}"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
@@ -70,14 +74,16 @@ class CalculationController(
     @Parameter(required = true, example = "A1234AB", description = "The prisoners ID (aka nomsId)")
     @PathVariable("prisonerId")
     prisonerId: String,
+    @RequestBody
+    calculationUserInput: CalculationUserInput?
   ): CalculatedReleaseDates {
     log.info("Request received to calculate release dates for $prisonerId")
     val sourceData = prisonService.getPrisonApiSourceData(prisonerId)
-    val booking = bookingService.getBooking(sourceData)
+    val booking = bookingService.getBooking(sourceData, calculationUserInput)
     try {
-      return calculationTransactionalService.calculate(booking, PRELIMINARY, sourceData)
+      return calculationTransactionalService.calculate(booking, PRELIMINARY, sourceData, calculationUserInput)
     } catch (error: Exception) {
-      calculationTransactionalService.recordError(booking, sourceData, error)
+      calculationTransactionalService.recordError(booking, sourceData, calculationUserInput, error)
       throw error
     }
   }
@@ -118,20 +124,20 @@ class CalculationController(
     )
     @PathVariable("calculationRequestId")
     calculationRequestId: Long,
-    // TODO this shouldn't be optional once we've done the frontend work.
     @RequestBody
-    calculationFragments: CalculationFragments?
+    calculationFragments: CalculationFragments
   ): CalculatedReleaseDates {
     log.info("Request received to confirm release dates calculation for $prisonerId")
     val sourceData = prisonService.getPrisonApiSourceData(prisonerId)
-    val booking = bookingService.getBooking(sourceData)
+    val userInput = calculationTransactionalService.findUserInput(calculationRequestId)
+    val booking = bookingService.getBooking(sourceData, userInput)
     calculationTransactionalService.validateConfirmationRequest(calculationRequestId, booking)
     try {
-      val calculation = calculationTransactionalService.calculate(booking, CONFIRMED, sourceData, calculationFragments)
+      val calculation = calculationTransactionalService.calculate(booking, CONFIRMED, sourceData, userInput, calculationFragments)
       calculationTransactionalService.writeToNomisAndPublishEvent(prisonerId, booking, calculation)
       return calculation
     } catch (error: Exception) {
-      calculationTransactionalService.recordError(booking, sourceData, error)
+      calculationTransactionalService.recordError(booking, sourceData, userInput, error)
       throw error
     }
   }
@@ -222,12 +228,13 @@ class CalculationController(
     val adjustments = calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(calculationRequestId)
     val returnToCustodyDate = calculationTransactionalService.findReturnToCustodyDateFromCalculation(calculationRequestId)
     val calculation = calculationTransactionalService.findCalculationResults(calculationRequestId)
+    val userInput = calculationTransactionalService.findUserInput(calculationRequestId)
     val sourceData = PrisonApiSourceData(sentencesAndOffences, prisonerDetails, adjustments, returnToCustodyDate)
 
-    return calculationTransactionalService.calculateWithBreakdown(bookingService.getBooking(sourceData), calculation)
+    return calculationTransactionalService.calculateWithBreakdown(bookingService.getBooking(sourceData, userInput), calculation)
   }
 
-  @GetMapping(value = ["/{prisonerId}/validate"])
+  @PostMapping(value = ["/{prisonerId}/validate"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
   @ResponseBody
   @Operation(
@@ -250,13 +257,15 @@ class CalculationController(
     @Parameter(required = true, example = "A1234AB", description = "The prisoners ID (aka nomsId)")
     @PathVariable("prisonerId")
     prisonerId: String,
+    @RequestBody
+    calculationUserInput: CalculationUserInput?
   ): ResponseEntity<ValidationMessages?> {
     log.info("Request received to validate $prisonerId")
     val sourceData = prisonService.getPrisonApiSourceData(prisonerId)
     var validationMessages = validationService.validate(sourceData)
     if (validationMessages.type == ValidationType.VALID) {
       try {
-        val booking = bookingService.getBooking(sourceData)
+        val booking = bookingService.getBooking(sourceData, calculationUserInput)
         calculationService.calculateReleaseDates(booking)
       } catch (validationException: CrdCalculationValidationException) {
         validationMessages = ValidationMessages(
@@ -356,6 +365,33 @@ class CalculationController(
     return returnToCustodyDate!!
   }
 
+  @GetMapping(value = ["/calculation-user-input/{calculationRequestId}"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
+  @ResponseBody
+  @Operation(
+    summary = "Get user input for a calculationRequestId",
+    description = "This endpoint will return the user input based on a calculationRequestId",
+    security = [
+      SecurityRequirement(name = "SYSTEM_USER"),
+      SecurityRequirement(name = "RELEASE_DATES_CALCULATOR")
+    ],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
+      ApiResponse(responseCode = "404", description = "No calculation exists for this calculationRequestId")
+    ]
+  )
+  fun getCalculationInput(
+    @Parameter(required = true, example = "123456", description = "The calculationRequestId of the calculation")
+    @PathVariable("calculationRequestId")
+    calculationRequestId: Long
+  ): CalculationUserInput? {
+    log.info("Request received to get user input from $calculationRequestId calculation")
+    return calculationTransactionalService.findUserInput(calculationRequestId)
+  }
+
   @GetMapping(value = ["/adjustments/{calculationRequestId}"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
   @ResponseBody
@@ -381,6 +417,35 @@ class CalculationController(
   ): BookingAndSentenceAdjustments {
     log.info("Request received to get booking and sentence adjustments from $calculationRequestId calculation")
     return calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(calculationRequestId)
+  }
+
+  @GetMapping(value = ["/{prisonerId}/user-questions"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
+  @ResponseBody
+  @Operation(
+    summary = "Return which sentences and offences may be considered for different calculation rules",
+    description = "This endpoint will return which sentences and offences may be considered for different calculation rules." +
+      "We will have to ask the user for clarification if any of the rules apply beacuse we cannot trust input data from NOMIS",
+    security = [
+      SecurityRequirement(name = "SYSTEM_USER"),
+      SecurityRequirement(name = "RELEASE_DATES_CALCULATOR")
+    ],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role")
+    ]
+  )
+  fun getCalculationUserQuestions(
+    @Parameter(required = true, example = "A1234AB", description = "The prisoners ID (aka nomsId)")
+    @PathVariable("prisonerId")
+    prisonerId: String,
+  ): CalculationUserQuestions {
+    log.info("Request received to get sentences which require user input $prisonerId")
+    val prisonerDetails = prisonService.getOffenderDetail(prisonerId)
+    val sentenceAndOffences = prisonService.getSentencesAndOffences(prisonerDetails.bookingId)
+    return calculationUserQuestionService.getQuestionsForSentences(prisonerDetails, sentenceAndOffences)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CrdCalcu
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
@@ -75,15 +75,15 @@ class CalculationController(
     @PathVariable("prisonerId")
     prisonerId: String,
     @RequestBody
-    calculationUserInput: CalculationUserInput?
+    calculationUserInputs: CalculationUserInputs?
   ): CalculatedReleaseDates {
     log.info("Request received to calculate release dates for $prisonerId")
     val sourceData = prisonService.getPrisonApiSourceData(prisonerId)
-    val booking = bookingService.getBooking(sourceData, calculationUserInput)
+    val booking = bookingService.getBooking(sourceData, calculationUserInputs)
     try {
-      return calculationTransactionalService.calculate(booking, PRELIMINARY, sourceData, calculationUserInput)
+      return calculationTransactionalService.calculate(booking, PRELIMINARY, sourceData, calculationUserInputs)
     } catch (error: Exception) {
-      calculationTransactionalService.recordError(booking, sourceData, calculationUserInput, error)
+      calculationTransactionalService.recordError(booking, sourceData, calculationUserInputs, error)
       throw error
     }
   }
@@ -258,14 +258,14 @@ class CalculationController(
     @PathVariable("prisonerId")
     prisonerId: String,
     @RequestBody
-    calculationUserInput: CalculationUserInput?
+    calculationUserInputs: CalculationUserInputs?
   ): ResponseEntity<ValidationMessages?> {
     log.info("Request received to validate $prisonerId")
     val sourceData = prisonService.getPrisonApiSourceData(prisonerId)
     var validationMessages = validationService.validate(sourceData)
     if (validationMessages.type == ValidationType.VALID) {
       try {
-        val booking = bookingService.getBooking(sourceData, calculationUserInput)
+        val booking = bookingService.getBooking(sourceData, calculationUserInputs)
         calculationService.calculateReleaseDates(booking)
       } catch (validationException: CrdCalculationValidationException) {
         validationMessages = ValidationMessages(
@@ -387,7 +387,7 @@ class CalculationController(
     @Parameter(required = true, example = "123456", description = "The calculationRequestId of the calculation")
     @PathVariable("calculationRequestId")
     calculationRequestId: Long
-  ): CalculationUserInput? {
+  ): CalculationUserInputs? {
     log.info("Request received to get user input from $calculationRequestId calculation")
     return calculationTransactionalService.findUserInput(calculationRequestId)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/TestController.kt
@@ -58,7 +58,7 @@ class TestController(
       ),
       null
     )
-    return calculationTransactionalService.calculate(booking, PRELIMINARY, fakeSourceData)
+    return calculationTransactionalService.calculate(booking, PRELIMINARY, fakeSourceData, null)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.ValidationException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationType
@@ -13,7 +13,7 @@ class BookingService(
   private val validationService: ValidationService
 ) {
 
-  fun getBooking(prisonApiSourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?): Booking {
+  fun getBooking(prisonApiSourceData: PrisonApiSourceData, calculationUserInputs: CalculationUserInputs?): Booking {
     val prisonerDetails = prisonApiSourceData.prisonerDetails
     val sentenceAndOffences = prisonApiSourceData.sentenceAndOffences
     val bookingAndSentenceAdjustments = prisonApiSourceData.bookingAndSentenceAdjustments
@@ -23,7 +23,7 @@ class BookingService(
     }
     val offender = transform(prisonerDetails)
     val adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences)
-    val sentences = sentenceAndOffences.map { transform(it, calculationUserInput) }.flatten()
+    val sentences = sentenceAndOffences.map { transform(it, calculationUserInputs) }.flatten()
 
     return Booking(
       offender = offender,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.ValidationException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationType
@@ -12,7 +13,7 @@ class BookingService(
   private val validationService: ValidationService
 ) {
 
-  fun getBooking(prisonApiSourceData: PrisonApiSourceData): Booking {
+  fun getBooking(prisonApiSourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?): Booking {
     val prisonerDetails = prisonApiSourceData.prisonerDetails
     val sentenceAndOffences = prisonApiSourceData.sentenceAndOffences
     val bookingAndSentenceAdjustments = prisonApiSourceData.bookingAndSentenceAdjustments
@@ -22,7 +23,7 @@ class BookingService(
     }
     val offender = transform(prisonerDetails)
     val adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences)
-    val sentences = sentenceAndOffences.map { transform(it) }.flatten()
+    val sentences = sentenceAndOffences.map { transform(it, calculationUserInput) }.flatten()
 
     return Booking(
       offender = offender,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -46,10 +46,10 @@ class CalculationTransactionalService(
       ?: throw IllegalStateException("User is not authenticated")
 
   @Transactional
-  fun calculate(booking: Booking, calculationStatus: CalculationStatus, sourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?, calculationFragments: CalculationFragments? = null): CalculatedReleaseDates {
+  fun calculate(booking: Booking, calculationStatus: CalculationStatus, sourceData: PrisonApiSourceData, calculationUserInputs: CalculationUserInputs?, calculationFragments: CalculationFragments? = null): CalculatedReleaseDates {
     val calculationRequest =
       calculationRequestRepository.save(
-        transform(booking, getCurrentAuthentication().principal, calculationStatus, sourceData, objectMapper, calculationUserInput, calculationFragments)
+        transform(booking, getCurrentAuthentication().principal, calculationStatus, sourceData, objectMapper, calculationUserInputs, calculationFragments)
       )
 
     val (workingBooking, calculationResult) = calculationService.calculateReleaseDates(booking)
@@ -99,7 +99,7 @@ class CalculationTransactionalService(
   }
 
   @Transactional(readOnly = true)
-  fun findUserInput(calculationRequestId: Long): CalculationUserInput? {
+  fun findUserInput(calculationRequestId: Long): CalculationUserInputs? {
     val calculationRequest = getCalculationRequest(calculationRequestId)
     return transform(calculationRequest.calculationRequestUserInputs)
   }
@@ -203,9 +203,9 @@ class CalculationTransactionalService(
   }
 
   @Transactional
-  fun recordError(booking: Booking, sourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?, error: Exception) {
+  fun recordError(booking: Booking, sourceData: PrisonApiSourceData, calculationUserInputs: CalculationUserInputs?, error: Exception) {
     calculationRequestRepository.save(
-      transform(booking, getCurrentAuthentication().principal, ERROR, sourceData, objectMapper, calculationUserInput)
+      transform(booking, getCurrentAuthentication().principal, ERROR, sourceData, objectMapper, calculationUserInputs)
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -45,10 +46,10 @@ class CalculationTransactionalService(
       ?: throw IllegalStateException("User is not authenticated")
 
   @Transactional
-  fun calculate(booking: Booking, calculationStatus: CalculationStatus, sourceData: PrisonApiSourceData, calculationFragments: CalculationFragments? = null): CalculatedReleaseDates {
+  fun calculate(booking: Booking, calculationStatus: CalculationStatus, sourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?, calculationFragments: CalculationFragments? = null): CalculatedReleaseDates {
     val calculationRequest =
       calculationRequestRepository.save(
-        transform(booking, getCurrentAuthentication().principal, calculationStatus, sourceData, objectMapper, calculationFragments)
+        transform(booking, getCurrentAuthentication().principal, calculationStatus, sourceData, objectMapper, calculationUserInput, calculationFragments)
       )
 
     val (workingBooking, calculationResult) = calculationService.calculateReleaseDates(booking)
@@ -95,6 +96,12 @@ class CalculationTransactionalService(
   @Transactional(readOnly = true)
   fun findCalculationResults(calculationRequestId: Long): CalculatedReleaseDates {
     return transform(getCalculationRequest(calculationRequestId))
+  }
+
+  @Transactional(readOnly = true)
+  fun findUserInput(calculationRequestId: Long): CalculationUserInput? {
+    val calculationRequest = getCalculationRequest(calculationRequestId)
+    return transform(calculationRequest.calculationRequestUserInputs)
   }
 
   @Transactional(readOnly = true)
@@ -196,9 +203,9 @@ class CalculationTransactionalService(
   }
 
   @Transactional
-  fun recordError(booking: Booking, sourceData: PrisonApiSourceData, error: Exception) {
+  fun recordError(booking: Booking, sourceData: PrisonApiSourceData, calculationUserInput: CalculationUserInput?, error: Exception) {
     calculationRequestRepository.save(
-      transform(booking, getCurrentAuthentication().principal, ERROR, sourceData, objectMapper)
+      transform(booking, getCurrentAuthentication().principal, ERROR, sourceData, objectMapper, calculationUserInput)
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationUserQuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationUserQuestionService.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceQuestion
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType.ADIMP
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType.SEC250
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType.SEC91_03
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType.YOI
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isBeforeOrEqualTo
+import java.time.Period
+import java.util.EnumSet
+
+@Service
+class CalculationUserQuestionService(
+  val featureToggles: FeatureToggles
+) {
+  val sentenceCalcTypes = EnumSet.of(ADIMP, YOI, SEC250, SEC91_03)
+
+  fun getQuestionsForSentences(prisonerDetails: PrisonerDetails, sentencesAndOffences: List<SentenceAndOffences>): CalculationUserQuestions {
+
+    return CalculationUserQuestions(
+      sentenceQuestions = sentencesAndOffences.mapNotNull {
+        if (!sentenceCalcTypes.contains(SentenceCalculationType.from(it.sentenceCalculationType))) {
+          null
+        } else {
+          val duration = Period.of(it.terms[0].years, it.terms[0].months, it.terms[0].weeks * 7 + it.terms[0].days)
+          val ageDuration = Period.between(prisonerDetails.dateOfBirth, it.sentenceDate)
+
+          val sevenYearsOrMore = duration.years >= 7
+          val overEighteen = ageDuration.years >= 18
+          val withinSdsPlusWindow =
+            it.sentenceDate.isAfterOrEqualTo(ImportantDates.SDS_PLUS_COMMENCEMENT_DATE) && it.sentenceDate.isBeforeOrEqualTo(
+              featureToggles.pcscStartDate
+            )
+
+          if (sevenYearsOrMore && overEighteen && withinSdsPlusWindow) {
+            CalculationSentenceQuestion(it.sentenceSequence, UserInputType.SCHEDULE_15_ATTRACTING_LIFE)
+          } else {
+            null
+          }
+        }
+      }
+
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ImportantDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ImportantDates.kt
@@ -6,4 +6,5 @@ object ImportantDates {
   val ORA_DATE: LocalDate = LocalDate.of(2015, 2, 1)
   val CJA_DATE: LocalDate = LocalDate.of(2005, 4, 4)
   val LASPO_DATE: LocalDate = LocalDate.of(2012, 12, 3)
+  val SDS_PLUS_COMMENCEMENT_DATE = LocalDate.of(2020, 4, 1)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
@@ -28,8 +28,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeter
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.CJA_DATE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.LASPO_DATE
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.SDS_PLUS_COMMENCEMENT_DATE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
-import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 @Service
@@ -256,6 +256,5 @@ class SentenceIdentificationService {
     private const val FOUR = 4L
     private const val SEVEN = 7L
     private const val TWELVE = 12L
-    private val SDS_PLUS_COMMENCEMENT_DATE = LocalDate.of(2020, 4, 1)
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,3 +128,4 @@ domain-events-sns:
 
 feature-toggles:
   eds: ${EDS_FEATURE_TOGGLE}
+  pcscStartDateString: ${PCSC_START_DATE}

--- a/src/main/resources/migration/common/V15__calcluation_user_input.sql
+++ b/src/main/resources/migration/common/V15__calcluation_user_input.sql
@@ -1,0 +1,10 @@
+CREATE TABLE calculation_request_user_input
+(
+    id                     serial      constraint calculation_request_user_input_pk PRIMARY KEY,
+    calculation_request_id integer NOT NULL references calculation_request (id),
+    offence_code varchar(20),
+    nomis_matches boolean,
+    sentence_sequence integer,
+    type varchar(50),
+    user_choice boolean
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationIntTest.kt
@@ -245,7 +245,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation where remand periods overlap with a sentence periods`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/$REMAND_OVERLAPS_WITH_SENTENCE_PRISONER_ID/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -278,7 +278,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on invalid data`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/$VALIDATION_PRISONER_ID/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -303,7 +303,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on unsupported data`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/$UNSUPPORTED_PRISONER_ID/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -320,7 +320,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on valid data`() {
-    webTestClient.get()
+    webTestClient.post()
       .uri("/calculation/$PRISONER_ID/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -523,7 +523,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on extinguished crd booking`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/EXTINGUISH/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -580,7 +580,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on argument after release date 1`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/CRS-796-1/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -598,7 +598,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on argument after release date 2`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/CRS-796-2/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
@@ -659,7 +659,7 @@ class CalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Run validation on a mixture of SDS and EDS sentences`() {
-    val validationMessages: ValidationMessages = webTestClient.get()
+    val validationMessages: ValidationMessages = webTestClient.post()
       .uri("/calculation/EDS-SDS/validate")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationUserInputIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationUserInputIntTest.kt
@@ -9,9 +9,9 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType.CRD
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 import java.time.LocalDate
@@ -27,9 +27,9 @@ class CalculationUserInputIntTest : IntegrationTestBase() {
   @Test
   @Transactional(readOnly = true)
   fun `Use a user input that differs from NOMIS and check its persisted through prelim, confirmed and view`() {
-    val userInput = CalculationUserInput(
+    val userInput = CalculationUserInputs(
       listOf(
-        SentenceCalculationUserInput(
+        CalculationSentenceUserInput(
           sentenceSequence = 1,
           offenceCode = "SX03014",
           isScheduleFifteenMaximumLife = false // Different to NOMIS.
@@ -72,7 +72,7 @@ class CalculationUserInputIntTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(CalculationUserInput::class.java)
+      .expectBody(CalculationUserInputs::class.java)
       .returnResult().responseBody!!
 
     assertThat(userInputResponse).isEqualTo(userInput)
@@ -86,9 +86,9 @@ class CalculationUserInputIntTest : IntegrationTestBase() {
   @Test
   @Transactional(readOnly = true)
   fun `Use a user input that is the same as NOMIS`() {
-    val userInput = CalculationUserInput(
+    val userInput = CalculationUserInputs(
       listOf(
-        SentenceCalculationUserInput(
+        CalculationSentenceUserInput(
           sentenceSequence = 1,
           offenceCode = "SX03014",
           isScheduleFifteenMaximumLife = true // same as NOMIS.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationUserInputIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/CalculationUserInputIntTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType.CRD
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
+import java.time.LocalDate
+
+@Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+class CalculationUserInputIntTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var calculationRequestRepository: CalculationRequestRepository
+
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
+
+  @Test
+  @Transactional(readOnly = true)
+  fun `Use a user input that differs from NOMIS and check its persisted through prelim, confirmed and view`() {
+    val userInput = CalculationUserInput(
+      listOf(
+        SentenceCalculationUserInput(
+          sentenceSequence = 1,
+          offenceCode = "SX03014",
+          isScheduleFifteenMaximumLife = false // Different to NOMIS.
+        )
+      )
+    )
+    val prelimResponse = webTestClient.post()
+      .uri("/calculation/USERINPUT")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .bodyValue(objectMapper.writeValueAsString(userInput))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculatedReleaseDates::class.java)
+      .returnResult().responseBody
+
+    // Halfway
+    assertThat(prelimResponse.dates[CRD]).isEqualTo(LocalDate.of(2028, 1, 10))
+
+    val confirmResponse = webTestClient.post()
+      .uri("/calculation/USERINPUT/confirm/${prelimResponse.calculationRequestId}")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .bodyValue(objectMapper.writeValueAsString(CalculationFragments("<p>BREAKDOWN</p>")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculatedReleaseDates::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(confirmResponse.dates[CRD]).isEqualTo(LocalDate.of(2028, 1, 10))
+
+    val userInputResponse = webTestClient.get()
+      .uri("/calculation/calculation-user-input/${confirmResponse.calculationRequestId}")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculationUserInput::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(userInputResponse).isEqualTo(userInput)
+
+    val dbRequest = calculationRequestRepository.findById(confirmResponse.calculationRequestId).get()
+    assertThat(dbRequest.calculationRequestUserInputs).isNotEmpty
+    assertThat(dbRequest.calculationRequestUserInputs[0].nomisMatches).isFalse
+    assertThat(dbRequest.calculationRequestUserInputs[0].userChoice).isFalse
+  }
+
+  @Test
+  @Transactional(readOnly = true)
+  fun `Use a user input that is the same as NOMIS`() {
+    val userInput = CalculationUserInput(
+      listOf(
+        SentenceCalculationUserInput(
+          sentenceSequence = 1,
+          offenceCode = "SX03014",
+          isScheduleFifteenMaximumLife = true // same as NOMIS.
+        )
+      )
+    )
+    val prelimResponse = webTestClient.post()
+      .uri("/calculation/USERINPUT")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .bodyValue(objectMapper.writeValueAsString(userInput))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculatedReleaseDates::class.java)
+      .returnResult().responseBody
+
+    // Halfway
+    assertThat(prelimResponse.dates[CRD]).isEqualTo(LocalDate.of(2030, 1, 9))
+
+    val dbRequest = calculationRequestRepository.findById(prelimResponse.calculationRequestId).get()
+    assertThat(dbRequest.calculationRequestUserInputs).isNotEmpty
+    assertThat(dbRequest.calculationRequestUserInputs[0].nomisMatches).isTrue
+    assertThat(dbRequest.calculationRequestUserInputs[0].userChoice).isTrue
+  }
+
+  @Test
+  fun `Service will return which sentences may fall under SDS+ and need user input`() {
+    val response = webTestClient.get()
+      .uri("/calculation/USERINPUT/user-questions")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculationUserQuestions::class.java)
+      .returnResult().responseBody
+
+    // Halfway
+    assertThat(response.sentenceQuestions.size).isEqualTo(1)
+    assertThat(response.sentenceQuestions[0].userInputType).isEqualTo(UserInputType.SCHEDULE_15_ATTRACTING_LIFE)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -34,9 +34,9 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -130,7 +130,7 @@ class CalculationControllerTest {
     val offender = Offender(prisonerId, LocalDate.of(1980, 1, 1))
 
     val booking = Booking(offender, mutableListOf(), Adjustments(), null, bookingId)
-    val userInput = CalculationUserInput(listOf(SentenceCalculationUserInput(1, "ABC", true)))
+    val userInput = CalculationUserInputs(listOf(CalculationSentenceUserInput(1, "ABC", true)))
     val calculatedReleaseDates = CalculatedReleaseDates(
       calculationRequestId = 9991L, dates = mapOf(), calculationStatus = PRELIMINARY,
       bookingId = bookingId, prisonerId = prisonerId
@@ -254,7 +254,7 @@ class CalculationControllerTest {
       calculationRequestId = 9991L, dates = mapOf(), calculationStatus = PRELIMINARY,
       bookingId = bookingId, prisonerId = prisonerId
     )
-    val userInput = CalculationUserInput(listOf(SentenceCalculationUserInput(1, "ABC", true)))
+    val userInput = CalculationUserInputs(listOf(CalculationSentenceUserInput(1, "ABC", true)))
 
     whenever(calculationTransactionalService.findCalculationResults(calculationRequestId)).thenReturn(calculation)
     whenever(calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId)).thenReturn(sentences)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
@@ -11,12 +11,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Adjust
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceUserInput
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecallType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAdjustments
@@ -175,7 +175,7 @@ class BookingServiceTest {
   fun `A booking object is generated correctly when requesting a booking for a prisonerId with user input`() {
     whenever(validationService.validate(sourceData)).thenReturn(ValidationMessages(ValidationType.VALID))
 
-    val result = bookingService.getBooking(sourceData, CalculationUserInput(listOf(SentenceCalculationUserInput(sequence, offenceCode, false))))
+    val result = bookingService.getBooking(sourceData, CalculationUserInputs(listOf(CalculationSentenceUserInput(sequence, offenceCode, false))))
 
     assertThat(result).isEqualTo(
       Booking(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
@@ -11,10 +11,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Adjust
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecallType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculationUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAdjustments
@@ -42,6 +44,76 @@ class BookingServiceTest {
   private val validationService = mock<ValidationService>()
   private val bookingService = BookingService(validationService)
 
+  val prisonerId = "A123456A"
+  val sequence = 153
+  val lineSequence = 154
+  val caseSequence = 155
+  val bookingId = 123456L
+  val consecutiveTo = 99
+  val offenceCode = "RR1"
+  val offences = listOf(
+    OffenderOffence(
+      offenderChargeId = 1L,
+      offenceStartDate = FIRST_JAN_2015,
+      offenceCode = offenceCode,
+      offenceDescription = "Littering",
+      indicators = listOf(OffenderOffence.SCHEDULE_15_LIFE_INDICATOR)
+    ),
+  )
+  val sentenceAndOffences = SentenceAndOffences(
+    bookingId = bookingId,
+    sentenceSequence = sequence,
+    lineSequence = lineSequence,
+    caseSequence = caseSequence,
+    consecutiveToSequence = consecutiveTo,
+    sentenceDate = FIRST_JAN_2015,
+    terms = listOf(
+      SentenceTerms(years = 5)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.FTRSCH18.name,
+    sentenceTypeDescription = "28 day fixed term recall",
+    offences = offences,
+  )
+  val bookingAndSentenceAdjustments = BookingAndSentenceAdjustments(
+    bookingAdjustments = listOf(
+      BookingAdjustments(
+        active = true,
+        numberOfDays = 5,
+        type = BookingAdjustmentType.UNLAWFULLY_AT_LARGE,
+        fromDate = FIRST_JAN_2015.minusDays(6),
+        toDate = FIRST_JAN_2015.minusDays(1)
+      )
+    ),
+    sentenceAdjustments = listOf(
+      SentenceAdjustments(
+        active = true,
+        sentenceSequence = sequence,
+        numberOfDays = 6,
+        type = SentenceAdjustmentType.REMAND,
+        fromDate = FIRST_JAN_2015.minusDays(7),
+        toDate = FIRST_JAN_2015.minusDays(1)
+
+      ),
+      SentenceAdjustments(
+        active = true,
+        sentenceSequence = sequence,
+        numberOfDays = 22,
+        type = SentenceAdjustmentType.UNUSED_REMAND
+      )
+    )
+  )
+  val prisonerDetails = PrisonerDetails(
+    bookingId,
+    prisonerId,
+    dateOfBirth = DOB,
+    firstName = "Harry",
+    lastName = "Houdini"
+  )
+  val returnToCustodyDate = ReturnToCustodyDate(bookingId, LocalDate.of(2022, 3, 15))
+  val sourceData = PrisonApiSourceData(listOf(sentenceAndOffences), prisonerDetails, bookingAndSentenceAdjustments, returnToCustodyDate)
+
   @BeforeEach
   fun reset() {
     reset(validationService)
@@ -50,77 +122,9 @@ class BookingServiceTest {
   @Test
   @Suppress("LongMethod")
   fun `A booking object is generated correctly when requesting a booking for a prisonerId`() {
-    val prisonerId = "A123456A"
-    val sequence = 153
-    val lineSequence = 154
-    val caseSequence = 155
-    val bookingId = 123456L
-    val consecutiveTo = 99
-    val offences = listOf(
-      OffenderOffence(
-        offenderChargeId = 1L,
-        offenceStartDate = FIRST_JAN_2015,
-        offenceCode = "RR1",
-        offenceDescription = "Littering"
-      ),
-    )
-    val sentenceAndOffences = SentenceAndOffences(
-      bookingId = bookingId,
-      sentenceSequence = sequence,
-      lineSequence = lineSequence,
-      caseSequence = caseSequence,
-      consecutiveToSequence = consecutiveTo,
-      sentenceDate = FIRST_JAN_2015,
-      terms = listOf(
-        SentenceTerms(years = 5)
-      ),
-      sentenceStatus = "IMP",
-      sentenceCategory = "CAT",
-      sentenceCalculationType = SentenceCalculationType.FTRSCH18.name,
-      sentenceTypeDescription = "28 day fixed term recall",
-      offences = offences,
-    )
-    val bookingAndSentenceAdjustments = BookingAndSentenceAdjustments(
-      bookingAdjustments = listOf(
-        BookingAdjustments(
-          active = true,
-          numberOfDays = 5,
-          type = BookingAdjustmentType.UNLAWFULLY_AT_LARGE,
-          fromDate = FIRST_JAN_2015.minusDays(6),
-          toDate = FIRST_JAN_2015.minusDays(1)
-        )
-      ),
-      sentenceAdjustments = listOf(
-        SentenceAdjustments(
-          active = true,
-          sentenceSequence = sequence,
-          numberOfDays = 6,
-          type = SentenceAdjustmentType.REMAND,
-          fromDate = FIRST_JAN_2015.minusDays(7),
-          toDate = FIRST_JAN_2015.minusDays(1)
-
-        ),
-        SentenceAdjustments(
-          active = true,
-          sentenceSequence = sequence,
-          numberOfDays = 22,
-          type = SentenceAdjustmentType.UNUSED_REMAND
-        )
-      )
-    )
-    val prisonerDetails = PrisonerDetails(
-      bookingId,
-      prisonerId,
-      dateOfBirth = DOB,
-      firstName = "Harry",
-      lastName = "Houdini"
-    )
-
-    val returnToCustodyDate = ReturnToCustodyDate(bookingId, LocalDate.of(2022, 3, 15))
-    val sourceData = PrisonApiSourceData(listOf(sentenceAndOffences), prisonerDetails, bookingAndSentenceAdjustments, returnToCustodyDate)
     whenever(validationService.validate(sourceData)).thenReturn(ValidationMessages(ValidationType.VALID))
 
-    val result = bookingService.getBooking(sourceData)
+    val result = bookingService.getBooking(sourceData, null)
 
     assertThat(result).isEqualTo(
       Booking(
@@ -134,7 +138,7 @@ class BookingServiceTest {
           StandardDeterminateSentence(
             sentencedAt = FIRST_JAN_2015,
             duration = FIVE_YEAR_DURATION,
-            offence = Offence(committedAt = FIRST_JAN_2015),
+            offence = Offence(committedAt = FIRST_JAN_2015, isScheduleFifteenMaximumLife = true),
             identifier = UUID.nameUUIDFromBytes(("$bookingId-$sequence").toByteArray()),
             consecutiveSentenceUUIDs = mutableListOf(
               UUID.nameUUIDFromBytes(("$bookingId-$consecutiveTo").toByteArray())
@@ -166,6 +170,56 @@ class BookingServiceTest {
     )
   }
 
+  @Test
+  @Suppress("LongMethod")
+  fun `A booking object is generated correctly when requesting a booking for a prisonerId with user input`() {
+    whenever(validationService.validate(sourceData)).thenReturn(ValidationMessages(ValidationType.VALID))
+
+    val result = bookingService.getBooking(sourceData, CalculationUserInput(listOf(SentenceCalculationUserInput(sequence, offenceCode, false))))
+
+    assertThat(result).isEqualTo(
+      Booking(
+        bookingId = 123456,
+        returnToCustodyDate = returnToCustodyDate.returnToCustodyDate,
+        offender = Offender(
+          dateOfBirth = DOB,
+          reference = prisonerId,
+        ),
+        sentences = mutableListOf(
+          StandardDeterminateSentence(
+            sentencedAt = FIRST_JAN_2015,
+            duration = FIVE_YEAR_DURATION,
+            offence = Offence(committedAt = FIRST_JAN_2015, isScheduleFifteenMaximumLife = false),
+            identifier = UUID.nameUUIDFromBytes(("$bookingId-$sequence").toByteArray()),
+            consecutiveSentenceUUIDs = mutableListOf(
+              UUID.nameUUIDFromBytes(("$bookingId-$consecutiveTo").toByteArray())
+            ),
+            lineSequence = lineSequence,
+            caseSequence = caseSequence,
+            recallType = RecallType.FIXED_TERM_RECALL_28
+          )
+        ),
+        adjustments = Adjustments(
+          mutableMapOf(
+            UNLAWFULLY_AT_LARGE to mutableListOf(
+              Adjustment(
+                appliesToSentencesFrom = FIRST_JAN_2015.minusDays(6),
+                numberOfDays = 5, fromDate = FIRST_JAN_2015.minusDays(6),
+                toDate = FIRST_JAN_2015.minusDays(1)
+              )
+            ),
+            REMAND to mutableListOf(
+              Adjustment(
+                appliesToSentencesFrom = FIRST_JAN_2015, numberOfDays = 6,
+                fromDate = FIRST_JAN_2015.minusDays(7),
+                toDate = FIRST_JAN_2015.minusDays(1)
+              )
+            )
+          )
+        )
+      )
+    )
+  }
   private companion object {
     val FIVE_YEAR_DURATION = Duration(mutableMapOf(DAYS to 0L, WEEKS to 0L, MONTHS to 0L, YEARS to 5L))
     val FIRST_JAN_2015: LocalDate = LocalDate.of(2015, 1, 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -151,7 +151,7 @@ class CalculationTransactionalServiceTest {
     val booking = jsonTransformation.loadBooking("$exampleType/$exampleNumber")
     val calculatedReleaseDates: CalculatedReleaseDates
     try {
-      calculatedReleaseDates = calculationTransactionalService.calculate(booking, PRELIMINARY, fakeSourceData)
+      calculatedReleaseDates = calculationTransactionalService.calculate(booking, PRELIMINARY, fakeSourceData, null)
     } catch (e: Exception) {
       if (!error.isNullOrEmpty()) {
         assertEquals(error, e.javaClass.simpleName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationUserQuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationUserQuestionServiceTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
+import java.time.LocalDate
+
+class CalculationUserQuestionServiceTest {
+  private val featureToggles = FeatureToggles()
+  private val calculationUserQuestionService = CalculationUserQuestionService(featureToggles)
+
+  val offences = listOf(
+    OffenderOffence(
+      offenderChargeId = 1L,
+      offenceStartDate = FIRST_MAY_2020,
+      offenceCode = "ABC",
+      offenceDescription = "Littering",
+      indicators = listOf(OffenderOffence.SCHEDULE_15_LIFE_INDICATOR)
+    ),
+  )
+
+  private val under7YearSentence = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 1,
+    lineSequence = 1,
+    caseSequence = 1,
+    sentenceDate = FIRST_MAY_2020,
+    terms = listOf(
+      SentenceTerms(years = 6, months = 11)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+    sentenceTypeDescription = "ADMIP",
+    offences = offences,
+  )
+
+  private val sdsPlusSentence = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 2,
+    lineSequence = 2,
+    caseSequence = 1,
+    sentenceDate = FIRST_MAY_2020,
+    terms = listOf(
+      SentenceTerms(years = 8)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+    sentenceTypeDescription = "ADMIP",
+    offences = offences,
+  )
+
+  private val beforeSdsWindow = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 3,
+    lineSequence = 3,
+    caseSequence = 1,
+    sentenceDate = FIRST_MAY_2018,
+    terms = listOf(
+      SentenceTerms(years = 8)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+    sentenceTypeDescription = "ADMIP",
+    offences = offences,
+  )
+
+  private val afterSdsWindow = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 4,
+    lineSequence = 4,
+    caseSequence = 1,
+    sentenceDate = FIRST_MAY_2023,
+    terms = listOf(
+      SentenceTerms(years = 8)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+    sentenceTypeDescription = "ADMIP",
+    offences = offences,
+  )
+
+  val ftrSentence = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 5,
+    lineSequence = 5,
+    caseSequence = 1,
+    sentenceDate = FIRST_MAY_2020,
+    terms = listOf(
+      SentenceTerms(years = 8)
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = SentenceCalculationType.FTR.name,
+    sentenceTypeDescription = "Fixed Term Recall",
+    offences = offences,
+  )
+
+  val over18PrisonerDetails = PrisonerDetails(
+    1,
+    "asd",
+    dateOfBirth = LocalDate.of(1980, 1, 1),
+    firstName = "Harry",
+    lastName = "Houdini"
+  )
+
+  val under18PrisonerDetails = PrisonerDetails(
+    1,
+    "asd",
+    dateOfBirth = LocalDate.of(2015, 1, 1),
+    firstName = "Harry",
+    lastName = "Houdini"
+  )
+
+  @Test
+  fun `The sentences which may fall under SDS+ are returned`() {
+    val under18Result = calculationUserQuestionService.getQuestionsForSentences(under18PrisonerDetails, listOf(sdsPlusSentence, beforeSdsWindow, afterSdsWindow, under7YearSentence, ftrSentence))
+    assertThat(under18Result.sentenceQuestions).isEmpty()
+
+    val over18Result = calculationUserQuestionService.getQuestionsForSentences(over18PrisonerDetails, listOf(sdsPlusSentence, beforeSdsWindow, afterSdsWindow, under7YearSentence, ftrSentence))
+    assertThat(over18Result.sentenceQuestions.size).isEqualTo(1)
+    assertThat(over18Result.sentenceQuestions[0].sentenceSequence).isEqualTo(sdsPlusSentence.sentenceSequence)
+    assertThat(over18Result.sentenceQuestions[0].userInputType).isEqualTo(UserInputType.SCHEDULE_15_ATTRACTING_LIFE)
+  }
+
+  private companion object {
+    val FIRST_MAY_2018: LocalDate = LocalDate.of(2018, 5, 1)
+    val FIRST_MAY_2020: LocalDate = LocalDate.of(2020, 5, 1)
+    val FIRST_MAY_2023: LocalDate = LocalDate.of(2023, 5, 1)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctionsTest.kt
@@ -76,7 +76,7 @@ class TransformFunctionsTest {
       caseSequence = caseSequence
     )
 
-    assertThat(transform(request)).isEqualTo(
+    assertThat(transform(request, null)).isEqualTo(
       listOf(
         StandardDeterminateSentence(
           sentencedAt = FIRST_JAN_2015,
@@ -133,7 +133,7 @@ class TransformFunctionsTest {
       caseSequence = caseSequence
     )
 
-    assertThat(transform(request)).isEqualTo(
+    assertThat(transform(request, null)).isEqualTo(
       listOf(
         StandardDeterminateSentence(
           sentencedAt = FIRST_JAN_2015,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -64,3 +64,4 @@ domain-events-sns:
 
 feature-toggles:
   eds: true
+  pcscStartDateString: 2022-06-27

--- a/src/test/resources/test_data/api_integration/adjustments/USERINPUT.json
+++ b/src/test/resources/test_data/api_integration/adjustments/USERINPUT.json
@@ -1,0 +1,4 @@
+{
+  "bookingAdjustments": [],
+  "sentenceAdjustments": []
+}

--- a/src/test/resources/test_data/api_integration/sentences/USERINPUT.json
+++ b/src/test/resources/test_data/api_integration/sentences/USERINPUT.json
@@ -1,0 +1,38 @@
+[
+  {
+    "bookingId": 1,
+    "sentenceSequence": 1,
+    "lineSequence": 1,
+    "caseSequence": 1,
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-01-10",
+    "terms": [{
+      "years": 12,
+      "months": 0,
+      "weeks": 0,
+      "days": 0
+    }],
+    "offences": [
+      {
+        "offenderChargeId": 3932624,
+        "offenceStartDate": "2021-06-20",
+        "offenceCode": "SX03014",
+        "offenceDescription": "Rape of a boy under 13 - SOA 2003",
+        "indicators": [
+          "S",
+          "M",
+          "23",
+          "ERS",
+          "PIMMS1",
+          "S1",
+          "SOR",
+          "SCH15/CJIB/L",
+          "V"
+        ]
+      }
+    ]
+  }
+]

--- a/src/test/resources/test_data/reset-base-data.sql
+++ b/src/test/resources/test_data/reset-base-data.sql
@@ -1,2 +1,3 @@
 DELETE FROM calculation_outcome;
+DELETE FROM calculation_request_user_input;
 DELETE FROM calculation_request;


### PR DESCRIPTION
This PR builds all the functionality required to get user input into our calculations.

As a first step we will be asking users about SDS+ sentences (schedule 15 attracting life). This however will be extended for the PCSC bill.

There are two parts.
1. Workout which sentences could fall under one of these rules, and return the "Questions" to the front end. 
2. Take the users response and feed it into the calc engine, if not supplied (1000 calcs) then go with NOMIS inputs

