### PR TITLE
Crs 1052 POC for GDS linting in circle ci pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
           command: ./gradlew -Pdocs generateOpenApiDocs
       - run:
           command: mkdir ~/docs
+      - run:
+          command: cp build/openapi.json ~/docs
       - save_cache:
           paths:
             - ~/.gradle
@@ -59,7 +61,7 @@ jobs:
       - persist_to_workspace:
           root: ~/docs
           paths:
-            - build/openapi.json
+            - openapi.json
 
   lint-api-docs:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
             - gradle-
       - run:
           command: ./gradlew -Pdocs generateOpenApiDocs
+      - run:
+          command: mkdir ~/docs
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew -Pdocs generateOpenApiDocs -PoutputDir=~/docs
+          command: ./gradlew -Pdocs generateOpenApiDocs
       - run:
           command: mv build/docs ~/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
           at: .
       # Create a folder for results to live in
       - run: "[ -d lint-results ] || mkdir lint-results"
+      - run: "cat ./openapi.json"
+      - run: "cat .spectral.yml"
       - run:
           name: Run Spectral Lint
           command: npx @stoplight/spectral-cli lint ./openapi.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run: "cat .spectral.yml"
       - run:
           name: Run Spectral Lint
-          command: npx @stoplight/spectral-cli lint ./openapi.json
+          command: npx @stoplight/spectral-cli lint ~/docs/openapi.json
             -o lint-results/junit.xml
             -f junit
             -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_artifacts:
-          path: build/openapi.yml
+          path: build/openapi.json
 
   integration-test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ parameters:
   releases-slack-channel:
     type: string
     default: farsight-alerts
+  node-version:
+    type: string
+    default: 16.15-browsers
 
 jobs:
   validate:
@@ -51,6 +54,28 @@ jobs:
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_artifacts:
           path: build/openapi.json
+      - persist_to_workspace:
+          root: ~/docs
+          paths:
+            - build/openapi.json
+
+  lint-api-docs:
+    executor:
+      name: hmpps/node
+      tag: << pipeline.parameters.node-version >>
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/docs
+      # Create a folder for results to live in
+      - run: "[ -d lint-results ] || mkdir lint-results"
+      - run:
+          name: Run Spectral Lint
+          command: npx @stoplight/spectral-cli lint /docs/openapi.json
+            -o lint-results/junit.xml
+            -f junit
+      - store_test_results:
+          path: lint-results
 
   integration-test:
     executor:
@@ -85,10 +110,16 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      -  generate-api-docs:
+      - generate-api-docs:
            filters:
              tags:
                ignore: /.*/
+      - lint-api-docs:
+           filters:
+             tags:
+               ignore: /.*/
+           requires:
+             - generate-api-docs
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
             -o lint-results/junit.xml
             -f junit
             -v
+      - store_artifacts:
+          path: lint-results
       - store_test_results:
           path: lint-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: farsight-alertsq
+    default: farsight-alerts
   releases-slack-channel:
     type: string
     default: farsight-alerts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,17 +47,15 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: mkdir ~/docs
-      - run:
           command: ./gradlew -Pdocs generateOpenApiDocs -PoutputDir=~/docs
-#      - run:
-#          command: cp build/openapi.json ~/docs
+      - run:
+          command: mv build/docs ~/
       - save_cache:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_artifacts:
-          path: build/openapi.json
+          path: ~/docs/openapi.json
       - persist_to_workspace:
           root: ~/docs
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew -Pdocs generateOpenApiDocs
-      - run:
           command: mkdir ~/docs
       - run:
-          command: cp build/openapi.json ~/docs
+          command: ./gradlew -Pdocs generateOpenApiDocs -PoutputDir=~/docs
+#      - run:
+#          command: cp build/openapi.json ~/docs
       - save_cache:
           paths:
             - ~/.gradle
@@ -73,16 +73,11 @@ jobs:
           at: ~/docs
       # Create a folder for results to live in
       - run: "[ -d lint-results ] || mkdir lint-results"
-      - run: "cat ~/docs/openapi.json"
-      - run: "cat .spectral.yml"
       - run:
           name: Run Spectral Lint
           command: npx @stoplight/spectral-cli lint ~/docs/openapi.json
             -o lint-results/junit.xml
             -f junit
-            -v
-      - store_artifacts:
-          path: lint-results
       - store_test_results:
           path: lint-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: farsight-alerts
+    default: farsight-alertsq
   releases-slack-channel:
     type: string
     default: farsight-alerts
@@ -33,10 +33,29 @@ jobs:
       - store_artifacts:
           path: build/reports/tests
 
+  generate-api-docs:
+    executor:
+      name: hmpps/java
+      tag: "18.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle.kts" }}
+            - gradle-
+      - run:
+          command: ./gradlew -Pdocs generateOpenApiDocs
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle.kts" }}
+      - store_artifacts:
+          path: build/openapi.yml
+
   integration-test:
     executor:
       name: hmpps/java
-      tag: "17.0"
+      tag: "18.0"
     steps:
       - checkout
       - restore_cache:
@@ -66,6 +85,10 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+      -  generate-api-docs:
+           filters:
+             tags:
+               ignore: /.*/
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - store_artifacts:
           path: build/openapi.json
       - persist_to_workspace:
-          root: ~/docs
+          root: .
           paths:
             - build/openapi.json
 
@@ -66,12 +66,12 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ~/docs
+          at: .
       # Create a folder for results to live in
       - run: "[ -d lint-results ] || mkdir lint-results"
       - run:
           name: Run Spectral Lint
-          command: npx @stoplight/spectral-cli lint /docs/openapi.json
+          command: npx @stoplight/spectral-cli lint openapi.json
             -o lint-results/junit.xml
             -f junit
       - store_test_results:
@@ -102,14 +102,14 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - validate:
-          filters:
-            tags:
-              ignore: /.*/
-      - integration-test:
-          filters:
-            tags:
-              ignore: /.*/
+#      - validate:
+#          filters:
+#            tags:
+#              ignore: /.*/
+#      - integration-test:
+#          filters:
+#            tags:
+#              ignore: /.*/
       - generate-api-docs:
            filters:
              tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,10 @@ jobs:
       - run: "[ -d lint-results ] || mkdir lint-results"
       - run:
           name: Run Spectral Lint
-          command: npx @stoplight/spectral-cli lint openapi.json
+          command: npx @stoplight/spectral-cli lint ./openapi.json
             -o lint-results/junit.xml
             -f junit
+            -v
       - store_test_results:
           path: lint-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,14 +102,14 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-#      - validate:
-#          filters:
-#            tags:
-#              ignore: /.*/
-#      - integration-test:
-#          filters:
-#            tags:
-#              ignore: /.*/
+      - validate:
+          filters:
+            tags:
+              ignore: /.*/
+      - integration-test:
+          filters:
+            tags:
+              ignore: /.*/
       - generate-api-docs:
            filters:
              tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - store_artifacts:
           path: build/openapi.json
       - persist_to_workspace:
-          root: .
+          root: ~/docs
           paths:
             - build/openapi.json
 
@@ -66,10 +66,10 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: .
+          at: ~/docs
       # Create a folder for results to live in
       - run: "[ -d lint-results ] || mkdir lint-results"
-      - run: "cat ./openapi.json"
+      - run: "cat ~/docs/openapi.json"
       - run: "cat .spectral.yml"
       - run:
           name: Run Spectral Lint

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,0 +1,4 @@
+extends:
+  - https://raw.githubusercontent.com/co-cddo/api-standards-linting/spectral-ruleset-govuk-public-v0.1.0/spectral-ruleset-govuk-public/ruleset.yaml
+formats:
+  - "oas3.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,5 +115,7 @@ dependencyCheck {
 }
 
 openApi {
+  outputDir.set(file("$buildDir/docs"))
+  outputFileName.set("openapi.json")
   customBootRun.args.set(listOf("--spring.profiles.active=docs"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.1-beta"
+  id("org.springdoc.openapi-gradle-plugin") version "1.4.0"
   kotlin("plugin.spring") version "1.7.10"
   kotlin("plugin.jpa") version "1.7.10"
   id("jacoco")
@@ -85,6 +86,10 @@ dependencies {
   testImplementation("io.projectreactor:reactor-test")
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   testImplementation("com.h2database:h2")
+
+  if (project.hasProperty("docs")) {
+    implementation("com.h2database:h2")
+  }
 }
 repositories {
   mavenCentral()
@@ -107,4 +112,8 @@ java {
 
 dependencyCheck {
   suppressionFiles.add("$rootDir/dependencyCheck/suppression.xml")
+}
+
+openApi {
+  customBootRun.args.set(listOf("--spring.profiles.active=docs"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,5 +117,5 @@ dependencyCheck {
 openApi {
   outputDir.set(file("$buildDir/docs"))
   outputFileName.set("openapi.json")
-  customBootRun.args.set(listOf("--spring.profiles.active=docs"))
+  customBootRun.args.set(listOf("--spring.profiles.active=dev,localstack,docs"))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AdjustmentDuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AdjustmentDuration.kt
@@ -7,6 +7,6 @@ import java.time.temporal.ChronoUnit.DAYS
 data class AdjustmentDuration(
   @Schema(description = "Amount of adjustment")
   val adjustmentValue: Int = 0,
-  @Schema(description = "Unit of adjustment", example = "DAYS")
+  @Schema(description = "Unit of adjustment")
   val type: ChronoUnit = DAYS,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateCalculationBreakdown.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateCalculationBreakdown.kt
@@ -1,12 +1,17 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule
 import java.time.LocalDate
 
 @Schema(description = "Calculation breakdown details for a release date type")
 data class ReleaseDateCalculationBreakdown(
-  @Schema(description = "Calculation rules used to determine this calculation.", example = "[HDCED_LT_18_MONTHS]")
+  @ArraySchema(
+    arraySchema = Schema(
+      description= "Calculation rules used to determine this calculation.", example = "[\"HDCED_GE_12W_LT_18M\"]"
+    )
+  )
   val rules: Set<CalculationRule> = emptySet(),
   @Schema(description = "Adjustments details associated that are specifically added as part of a rule")
   val rulesWithExtraAdjustments: Map<CalculationRule, AdjustmentDuration> = emptyMap(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateCalculationBreakdown.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateCalculationBreakdown.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 data class ReleaseDateCalculationBreakdown(
   @ArraySchema(
     arraySchema = Schema(
-      description= "Calculation rules used to determine this calculation.", example = "[\"HDCED_GE_12W_LT_18M\"]"
+      description = "Calculation rules used to determine this calculation.", example = "[\"HDCED_GE_12W_LT_18M\"]"
     )
   )
   val rules: Set<CalculationRule> = emptySet(),

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -30,3 +30,6 @@ system:
   client:
     id: calculate-release-dates-admin
     secret: client_secret
+
+feature-toggles:
+  afine: true

--- a/src/main/resources/application-docs.yml
+++ b/src/main/resources/application-docs.yml
@@ -1,0 +1,63 @@
+spring:
+
+  config:
+    use-legacy-processing: true
+
+  profiles:
+    include: stdout
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          public-key-location: classpath:local-public-key.pub
+
+  datasource:
+    url: 'jdbc:h2:mem:release-dates-db;MODE=PostgreSQL;INIT=create domain if not exists jsonb as json'
+    username: create_vary
+    password: dummy
+
+  flyway:
+    locations: classpath:/migration/h2,classpath:/migration/common
+    url: ${spring.datasource.url}
+    user: create_vary
+    password: dummy
+
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  sql:
+    init:
+      continue-on-error: true
+
+
+management.endpoint:
+  health.cache.time-to-live: 0
+  info.cache.time-to-live: 0
+
+# Wiremock auth server
+hmpps:
+  auth:
+    url: http://localhost:8090/auth
+
+# Wiremock prison-api
+prison:
+  api:
+    url: http://localhost:8332
+
+bank-holiday:
+  api:
+    url: http://localhost:8333
+
+domain-events-sns:
+  provider: localstack
+
+feature-toggles:
+  afine: true

--- a/src/main/resources/application-docs.yml
+++ b/src/main/resources/application-docs.yml
@@ -1,63 +1,15 @@
 spring:
 
-  config:
-    use-legacy-processing: true
-
-  profiles:
-    include: stdout
-
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          public-key-location: classpath:local-public-key.pub
-
   datasource:
     url: 'jdbc:h2:mem:release-dates-db;MODE=PostgreSQL;INIT=create domain if not exists jsonb as json'
     username: create_vary
     password: dummy
 
   flyway:
-    locations: classpath:/migration/h2,classpath:/migration/common
-    url: ${spring.datasource.url}
-    user: create_vary
-    password: dummy
-
-  h2:
-    console:
-      enabled: true
+    enabled: false
 
   jpa:
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
-
-  sql:
-    init:
-      continue-on-error: true
-
-
-management.endpoint:
-  health.cache.time-to-live: 0
-  info.cache.time-to-live: 0
-
-# Wiremock auth server
-hmpps:
-  auth:
-    url: http://localhost:8090/auth
-
-# Wiremock prison-api
-prison:
-  api:
-    url: http://localhost:8332
-
-bank-holiday:
-  api:
-    url: http://localhost:8333
-
-domain-events-sns:
-  provider: localstack
-
-feature-toggles:
-  afine: true


### PR DESCRIPTION
This is a proof of concept for adding GDS linting into the pipeline.

Added jobs:

1. generate the api doc. This uses the gradle plugin https://github.com/springdoc/springdoc-openapi-gradle-plugin
The main issue I had here is that in order to generate the openapi file the plugin needs to spin up the spring boot service. So I've copied the configuration for running spring tests by running the service against h2. The ugly part of this is including h2 as a `implementation` rather than `testImplementation`. This is done with a gradle property so that its not included on the main build. I'm open to any other suggestions, I couldn't figure out how to run the app with test dependencies.

2. lint the api doc. This is configured in the `.spectral` file.


As expected the build fails and circle ci displays the rules that are failing.