### PR TITLE
CRS-1087 Replace return-to-custody prison-api endpoint call (deprecated) with  fixed-term-recall call

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/FixedTermRecallDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/FixedTermRecallDetails.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
+
+import java.time.LocalDate
+
+data class FixedTermRecallDetails(
+  val bookingId: Long,
+  val returnToCustodyDate: LocalDate,
+  val recallLength: Int = 0,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
@@ -6,9 +6,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.FixedTermRecallDetails
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderFinePayment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ReturnToCustodyDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.UpdateOffenderDates
 
@@ -44,12 +44,12 @@ class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: We
       .block()!!
   }
 
-  fun getReturnToCustodyDate(bookingId: Long): ReturnToCustodyDate {
-    log.info("Requesting return to custody date for bookingId $bookingId")
+  fun getFixedTermRecallDetails(bookingId: Long): FixedTermRecallDetails {
+    log.info("Requesting return to fixed term recall details for bookingId $bookingId")
     return webClient.get()
-      .uri("/api/bookings/$bookingId/return-to-custody")
+      .uri("/api/bookings/$bookingId/fixed-term-recall")
       .retrieve()
-      .bodyToMono(typeReference<ReturnToCustodyDate>())
+      .bodyToMono(typeReference<FixedTermRecallDetails>())
       .block()!!
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonService.kt
@@ -35,7 +35,8 @@ class PrisonService(
     val bookingHasFixedTermRecall = sentenceAndOffences.any { SentenceCalculationType.from(it.sentenceCalculationType)?.recallType?.isFixedTermRecall == true }
     var returnToCustodyDate: ReturnToCustodyDate? = null
     if (bookingHasFixedTermRecall) {
-      returnToCustodyDate = prisonApiClient.getReturnToCustodyDate(prisonerDetails.bookingId)
+      // TODO look into replacing ReturnToCustodyDate object with FixedTermRecallDetails
+      returnToCustodyDate = transform(prisonApiClient.getFixedTermRecallDetails(prisonerDetails.bookingId))
     }
     val bookingHasAFine = sentenceAndOffences.any { SentenceCalculationType.from(it.sentenceCalculationType)?.sentenceClazz == AFineSentence::class.java }
     var offenderFinePayments: List<OffenderFinePayment> = listOf()
@@ -51,7 +52,8 @@ class PrisonService(
     val bookingHasFixedTermRecall = sentenceAndOffences.any { SentenceCalculationType.from(it.sentenceCalculationType)?.recallType?.isFixedTermRecall == true }
     var returnToCustodyDate: ReturnToCustodyDate? = null
     if (bookingHasFixedTermRecall) {
-      returnToCustodyDate = prisonApiClient.getReturnToCustodyDate(prisonerDetails.bookingId)
+      // TODO look into replacing ReturnToCustodyDate object with FixedTermRecallDetails
+      returnToCustodyDate = transform(prisonApiClient.getFixedTermRecallDetails(prisonerDetails.bookingId))
     }
     val bookingHasAFine = sentenceAndOffences.any { SentenceCalculationType.from(it.sentenceCalculationType)?.sentenceClazz == AFineSentence::class.java }
     var offenderFinePayments: List<OffenderFinePayment> = listOf()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -63,10 +63,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeter
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.FixedTermRecallDetails
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderKeyDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ReturnToCustodyDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAdjustment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
@@ -566,3 +568,9 @@ fun transform(booking: Booking): SentenceDiagram {
     rows = adjustmentRows + sentenceRows
   )
 }
+
+fun transform(fixedTermRecallDetails: FixedTermRecallDetails): ReturnToCustodyDate =
+  ReturnToCustodyDate(
+    bookingId = fixedTermRecallDetails.bookingId,
+    returnToCustodyDate = fixedTermRecallDetails.returnToCustodyDate,
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -138,7 +138,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubGetReturnToCustody(bookingId: Long, json: String): StubMapping =
     stubFor(
-      get("/api/bookings/$bookingId/return-to-custody")
+      get("/api/bookings/$bookingId/fixed-term-recall")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Light touch refactor to replace prison-api call  to return-to-custody-date .

More could be done with this; ideally the ReturnToCustodyDate object should be replaced with FixedTermRecallDetails, however there is quite a lot of change required for this (UI and API). It is being persisted to a database JSON column  and then resurfaced in an endpoint, hence went for the light touch approach for now