### PR TITLE
CRS-1101 Remove validation call from the get-calc-breakdown endpoint, this is unnecessary and causes problems for the view journey

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -240,8 +240,7 @@ class CalculationController(
     calculationRequestId: Long,
   ): CalculationBreakdown {
     log.info("Request received return calculation breakdown for calculationRequestId {}", calculationRequestId)
-    val a = bookingService.getCalculationBreakdown(calculationRequestId)
-    return a
+    return bookingService.getCalculationBreakdown(calculationRequestId)
   }
 
   @GetMapping(value = ["/diagram/{calculationRequestId}"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -240,16 +240,8 @@ class CalculationController(
     calculationRequestId: Long,
   ): CalculationBreakdown {
     log.info("Request received return calculation breakdown for calculationRequestId {}", calculationRequestId)
-    val sentencesAndOffences = calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId)
-    val prisonerDetails = calculationTransactionalService.findPrisonerDetailsFromCalculation(calculationRequestId)
-    val adjustments = calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(calculationRequestId)
-    val returnToCustodyDate = calculationTransactionalService.findReturnToCustodyDateFromCalculation(calculationRequestId)
-    val offenderFinePayments = calculationTransactionalService.findOffenderFinePaymentsFromCalculation(calculationRequestId)
-    val calculation = calculationTransactionalService.findCalculationResults(calculationRequestId)
-    val userInput = calculationTransactionalService.findUserInput(calculationRequestId)
-    val sourceData = PrisonApiSourceData(sentencesAndOffences, prisonerDetails, adjustments, offenderFinePayments, returnToCustodyDate)
-
-    return calculationTransactionalService.calculateWithBreakdown(bookingService.getBooking(sourceData, userInput), calculation)
+    val a = bookingService.getCalculationBreakdown(calculationRequestId)
+    return a
   }
 
   @GetMapping(value = ["/diagram/{calculationRequestId}"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
@@ -3,25 +3,22 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.ValidationException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
 
 @Service
 class BookingService(
-  private val validationService: ValidationService
+  private val validationService: ValidationService,
+  private val calculationTransactionalService: CalculationTransactionalService,
 ) {
 
   fun getBooking(prisonApiSourceData: PrisonApiSourceData, calculationUserInputs: CalculationUserInputs?): Booking {
     val prisonerDetails = prisonApiSourceData.prisonerDetails
     val sentenceAndOffences = prisonApiSourceData.sentenceAndOffences
     val bookingAndSentenceAdjustments = prisonApiSourceData.bookingAndSentenceAdjustments
-    val validationMessages = validationService.validate(prisonApiSourceData)
-    if (validationMessages.isNotEmpty()) {
-      var message = "The validation has failed with errors:"
-      validationMessages.forEach { message += "\n    " + it.message }
-      throw ValidationException(message)
-    }
+    validate(prisonApiSourceData)
     val offender = transform(prisonerDetails)
     val adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences)
     val sentences = sentenceAndOffences.map { transform(it, calculationUserInputs) }.flatten()
@@ -33,5 +30,49 @@ class BookingService(
       bookingId = prisonerDetails.bookingId,
       returnToCustodyDate = prisonApiSourceData.returnToCustodyDate?.returnToCustodyDate
     )
+  }
+
+  fun getCalculationBreakdown(
+    calculationRequestId: Long
+  ): CalculationBreakdown {
+    val sourceData = getSourceData(calculationRequestId)
+    val booking = getBookingForBreakdown(
+      sourceData,
+      calculationRequestId,
+      calculationTransactionalService.findUserInput(calculationRequestId)
+    )
+    val calculation = calculationTransactionalService.findCalculationResults(calculationRequestId)
+    return calculationTransactionalService.calculateWithBreakdown(booking, calculation)
+  }
+
+  private fun getBookingForBreakdown(
+    sourceData: PrisonApiSourceData,
+    calculationRequestId: Long,
+    calculationUserInputs: CalculationUserInputs?,
+  ): Booking = Booking(
+      offender = transform(sourceData.prisonerDetails),
+      sentences = sourceData.sentenceAndOffences.map { transform(it, calculationUserInputs) }.flatten(),
+      adjustments = transform(sourceData.bookingAndSentenceAdjustments, sourceData.sentenceAndOffences),
+      bookingId = sourceData.prisonerDetails.bookingId,
+      returnToCustodyDate = calculationTransactionalService.findReturnToCustodyDateFromCalculation(calculationRequestId)?.returnToCustodyDate
+    )
+
+  private fun getSourceData(calculationRequestId: Long): PrisonApiSourceData =
+    PrisonApiSourceData(
+      sentenceAndOffences = calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId),
+      prisonerDetails = calculationTransactionalService.findPrisonerDetailsFromCalculation(calculationRequestId),
+      bookingAndSentenceAdjustments = calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(
+        calculationRequestId
+      ),
+      returnToCustodyDate = calculationTransactionalService.findReturnToCustodyDateFromCalculation(calculationRequestId),
+    )
+
+  private fun validate(prisonApiSourceData: PrisonApiSourceData) {
+    val validationMessages = validationService.validate(prisonApiSourceData)
+    if (validationMessages.isNotEmpty()) {
+      var message = "The validation has failed with errors:"
+      validationMessages.forEach { message += "\n    " + it.message }
+      throw ValidationException(message)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -248,26 +248,10 @@ class CalculationControllerTest {
 
   @Test
   fun `Test GET of calculation breakdown by calculationRequestId`() {
-    val prisonerId = "A1234AB"
     val calculationRequestId = 9995L
-    val bookingId = 9995L
-    val offender = Offender(prisonerId, LocalDate.of(1980, 1, 1))
-    val booking = Booking(offender, mutableListOf(), Adjustments(), null, bookingId)
     val breakdown = CalculationBreakdown(listOf(), null)
-    val calculation = CalculatedReleaseDates(
-      calculationRequestId = 9991L, dates = mapOf(), calculationStatus = PRELIMINARY,
-      bookingId = bookingId, prisonerId = prisonerId
-    )
-    val userInput = CalculationUserInputs(listOf(CalculationSentenceUserInput(1, "ABC", UserInputType.ORIGINAL, true)))
-
-    whenever(calculationTransactionalService.findCalculationResults(calculationRequestId)).thenReturn(calculation)
-    whenever(calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId)).thenReturn(sentences)
-    whenever(calculationTransactionalService.findPrisonerDetailsFromCalculation(calculationRequestId)).thenReturn(prisonerDetails)
-    whenever(calculationTransactionalService.findOffenderFinePaymentsFromCalculation(calculationRequestId)).thenReturn(offenderFineFinePayment)
-    whenever(calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(calculationRequestId)).thenReturn(adjustments)
-    whenever(calculationTransactionalService.findUserInput(calculationRequestId)).thenReturn(userInput)
-    whenever(bookingService.getBooking(sourceData, userInput)).thenReturn(booking)
-    whenever(calculationTransactionalService.calculateWithBreakdown(booking, calculation)).thenReturn(breakdown)
+0
+    whenever(bookingService.getCalculationBreakdown(calculationRequestId)).thenReturn(breakdown)
 
     val result = mvc.perform(get("/calculation/breakdown/$calculationRequestId").accept(APPLICATION_JSON))
       .andExpect(status().isOk)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -250,7 +250,6 @@ class CalculationControllerTest {
   fun `Test GET of calculation breakdown by calculationRequestId`() {
     val calculationRequestId = 9995L
     val breakdown = CalculationBreakdown(listOf(), null)
-0
     whenever(bookingService.getCalculationBreakdown(calculationRequestId)).thenReturn(breakdown)
 
     val result = mvc.perform(get("/calculation/breakdown/$calculationRequestId").accept(APPLICATION_JSON))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
@@ -43,7 +43,8 @@ import java.util.UUID
 
 class BookingServiceTest {
   private val validationService = mock<ValidationService>()
-  private val bookingService = BookingService(validationService)
+  private val calculationTransactionalService = mock<CalculationTransactionalService>()
+  private val bookingService = BookingService(validationService, calculationTransactionalService)
 
   val prisonerId = "A123456A"
   val sequence = 153

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingServiceTest.kt
@@ -6,9 +6,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
-import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.REMAND
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.UNLAWFULLY_AT_LARGE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus.PRELIMINARY
@@ -415,7 +412,6 @@ class BookingServiceTest {
     whenever(calculationTransactionalService.findCalculationResults(calculationRequestId)).thenReturn(calculation)
     whenever(calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId)).thenReturn(sentences)
     whenever(calculationTransactionalService.findPrisonerDetailsFromCalculation(calculationRequestId)).thenReturn(prisonerDetails)
-    whenever(calculationTransactionalService.findOffenderFinePaymentsFromCalculation(calculationRequestId)).thenReturn(offenderFineFinePayment) // TODO
     whenever(calculationTransactionalService.findBookingAndSentenceAdjustmentsFromCalculation(calculationRequestId)).thenReturn(adjustments)
     whenever(calculationTransactionalService.findUserInput(calculationRequestId)).thenReturn(userInput)
     whenever(calculationTransactionalService.calculateWithBreakdown(booking, calculation)).thenReturn(breakdown)


### PR DESCRIPTION
Validation is not required by the view journey as we are just displaying a previous calc. This change also removes the validation call from the get-breakdown call.

Additionally, if we add new validation rules there is a potential for the view journey to break, because it calls validation using old input data (potentially).. and the old input data could break the validation if there are new rules.

