### PR TITLE
ADJUST1-276 Unused deductions infrastructure.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/UnusedDeductionCalculationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/UnusedDeductionCalculationResponse.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
+
+data class UnusedDeductionCalculationResponse(
+  val unusedDeductions: Int?,
+)


### PR DESCRIPTION
This PR adds an endpoint to the unused deductions that will only calculate the unused deductions. The updating of adjustments functionality will be removed from calculate release dates and be handled by the new unused deductions listener where the changes are handled with sqs queues instead.