### PR TITLE
CP-1670 Add Service to lookup PCSC Markers from MO API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ that is seeded with data specific to each test suite.
 `$ ./gradlew dependencyCheckAnalyze`
 
 # Running the service locally using run-local.sh
+**_N.B. This currently still requires Adjustments and Manage Offences to be configured to look at dev environment_** 
+
 This will run the service locally. It starts the database runs manage-offences-api via a bash script. It connects to the dev versions of prison-api and hmpps-auth
 Run the following commands from the root directory of the project:
 1. docker-compose -f docker-compose-test.yml pull

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,7 +18,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     ADJUSTMENTS_API_URL: https://adjustments-api-dev.hmpps.service.justice.gov.uk
-
+    MANAGE-OFFENCES_API_URL: https://manage-offences-api-dev.hmpps.service.justice.gov.uk
   # Switches off the allow list in the DEV env only.
   allowlist: null
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://api-preprod.prison.service.justice.gov.uk
     ADJUSTMENTS_API_URL: https://adjustments-api-preprod.hmpps.service.justice.gov.uk
+    MANAGE-OFFENCES_API_URL: https://manage-offences-api-preprod.hmpps.service.justice.gov.uk
 
   serviceAccountName: calculate-release-dates-api-preprod
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://api.prison.service.justice.gov.uk
     ADJUSTMENTS_API_URL: https://adjustments-api.hmpps.service.justice.gov.uk
+    MANAGE-OFFENCES_API_URL: https://manage-offences-api.hmpps.service.justice.gov.uk
 
   serviceAccountName: calculate-release-dates-api-prod
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
@@ -59,7 +59,7 @@ class WebClientConfiguration(
   }
 
   @Bean
-  fun manageOffencesApiClient(webClientBuilder: WebClient.Builder): WebClient {
+  fun manageOffencesApiWebClient(webClientBuilder: WebClient.Builder): WebClient {
     return webClientBuilder
       .baseUrl(manageOffencesApiUrl)
       .filter(addAuthHeaderFilterFunction())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
@@ -15,6 +15,7 @@ class WebClientConfiguration(
   @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
   @Value("\${bank-holiday.api.url:https://www.gov.uk}") private val bankHolidayApiUrl: String,
   @Value("\${adjustments.api.url}") private val adjustmentsApiUrl: String,
+  @Value("\${manage-offences.api.url}") private val manageOffencesApiUrl: String
 ) {
 
   @Bean
@@ -53,6 +54,14 @@ class WebClientConfiguration(
   fun adjustmentsApiWebClient(webClientBuilder: WebClient.Builder): WebClient {
     return webClientBuilder
       .baseUrl(adjustmentsApiUrl)
+      .filter(addAuthHeaderFilterFunction())
+      .build()
+  }
+
+  @Bean
+  fun manageOffencesApiClient(webClientBuilder: WebClient.Builder): WebClient {
+    return webClientBuilder
+      .baseUrl(manageOffencesApiUrl)
       .filter(addAuthHeaderFilterFunction())
       .build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/WebClientConfiguration.kt
@@ -15,7 +15,7 @@ class WebClientConfiguration(
   @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
   @Value("\${bank-holiday.api.url:https://www.gov.uk}") private val bankHolidayApiUrl: String,
   @Value("\${adjustments.api.url}") private val adjustmentsApiUrl: String,
-  @Value("\${manage-offences.api.url}") private val manageOffencesApiUrl: String
+  @Value("\${manage-offences.api.url}") private val manageOffencesApiUrl: String,
 ) {
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
+
+data class PcscMarkers(
+  val inListA: Boolean,
+  val inListB: Boolean,
+  val inListC: Boolean,
+  val inListD: Boolean,
+)
+
+data class OffencePcscMarkers(
+  val offenceCode: String,
+  val pcscMarkers: PcscMarkers,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
@@ -1,14 +1,13 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
 
 data class PcscMarkers(
-        val inListA: Boolean,
-        val inListB: Boolean,
-        val inListC: Boolean,
-        val inListD: Boolean,
+  val inListA: Boolean,
+  val inListB: Boolean,
+  val inListC: Boolean,
+  val inListD: Boolean,
 )
 
 data class OffencePcscMarkers(
-        val offenceCode: String,
-        val pcscMarkers: PcscMarkers,
+  val offenceCode: String,
+  val pcscMarkers: PcscMarkers,
 )
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PcscMarkers.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
 
 data class PcscMarkers(
-  val inListA: Boolean,
-  val inListB: Boolean,
-  val inListC: Boolean,
-  val inListD: Boolean,
+        val inListA: Boolean,
+        val inListB: Boolean,
+        val inListC: Boolean,
+        val inListD: Boolean,
 )
 
 data class OffencePcscMarkers(
-  val offenceCode: String,
-  val pcscMarkers: PcscMarkers,
+        val offenceCode: String,
+        val pcscMarkers: PcscMarkers,
 )
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
@@ -5,10 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CaseLoad
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.*
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.CalculableSentenceEnvelope
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffencePcscMarkers
 
 @Service
 class ManageOffencesApiClient(@Qualifier("manageOffencesApiWebClient") private val webClient: WebClient) {
@@ -16,8 +13,7 @@ class ManageOffencesApiClient(@Qualifier("manageOffencesApiWebClient") private v
   private val log = LoggerFactory.getLogger(this::class.java)
 
   fun getPCSCMarkersForOffences(offenceCodes: List<String>): List<OffencePcscMarkers> {
-
-    val offencesList = if (offenceCodes.size > 1) offenceCodes.joinToString(",") else offenceCodes[0];
+    val offencesList = if (offenceCodes.size > 1) offenceCodes.joinToString(",") else offenceCodes[0]
     log.info("/schedule/pcsc-indicators?$offencesList")
 
     return webClient.get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CaseLoad
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.*
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.CalculableSentenceEnvelope
+
+@Service
+class ManageOffencesApiClient(@Qualifier("manageOffencesApiClient") private val webClient: WebClient) {
+  private inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getPCSCMarkersForOffences(offenceCodes: List<String>): List<OffencePcscMarkers> {
+
+    val offencesList = offenceCodes.joinToString { "," }
+
+    return webClient.get()
+      .uri("/schedule/pcsc-indicators?$offencesList")
+      .retrieve()
+      .bodyToMono(typeReference<List<OffencePcscMarkers>>())
+      .block()!!
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClient.kt
@@ -11,13 +11,14 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.*
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.CalculableSentenceEnvelope
 
 @Service
-class ManageOffencesApiClient(@Qualifier("manageOffencesApiClient") private val webClient: WebClient) {
+class ManageOffencesApiClient(@Qualifier("manageOffencesApiWebClient") private val webClient: WebClient) {
   private inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
   private val log = LoggerFactory.getLogger(this::class.java)
 
   fun getPCSCMarkersForOffences(offenceCodes: List<String>): List<OffencePcscMarkers> {
 
-    val offencesList = offenceCodes.joinToString { "," }
+    val offencesList = if (offenceCodes.size > 1) offenceCodes.joinToString(",") else offenceCodes[0];
+    log.info("/schedule/pcsc-indicators?$offencesList")
 
     return webClient.get()
       .uri("/schedule/pcsc-indicators?$offencesList")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
@@ -12,9 +12,4 @@ class ManageOffencesService(
   fun getPcscMarkersForOffenceCodes(vararg offenceCodes: String): List<OffencePcscMarkers> {
     return manageOffencesApiClient.getPCSCMarkersForOffences(offenceCodes.toList())
   }
-
-  fun doesOffenceCodeHavePcscMarkers(offenceCode: String): Boolean {
-    val returnedPcscMarkers = getPcscMarkersForOffenceCodes(offenceCode).firstOrNull();
-    return returnedPcscMarkers!!.pcscMarkers.inListA || returnedPcscMarkers.pcscMarkers.inListB || returnedPcscMarkers.pcscMarkers.inListC || returnedPcscMarkers.pcscMarkers.inListD
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffencePcscMarkers
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PcscMarkers
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
+
+@Service
+class ManageOffencesService(
+  private val manageOffencesApiClient: ManageOffencesApiClient,
+) {
+  fun getPcscMarkersForOffenceCodes(vararg offenceCodes: String): List<OffencePcscMarkers> {
+    return manageOffencesApiClient.getPCSCMarkersForOffences(offenceCodes.toList())
+  }
+
+  fun doesOffenceCodeHavePcscMarkers(offenceCode: String): Boolean {
+    val returnedPcscMarkers = getPcscMarkersForOffenceCodes(offenceCode).firstOrNull();
+    return returnedPcscMarkers!!.pcscMarkers.inListA || returnedPcscMarkers.pcscMarkers.inListB || returnedPcscMarkers.pcscMarkers.inListC || returnedPcscMarkers.pcscMarkers.inListD
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffencePcscMarkers
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PcscMarkers
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 
 @Service
 class ManageOffencesService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
+import java.time.LocalDate
+import java.time.Period
+import java.util.*
+
+@Service
+class OffenceSdsPlusLookupService(
+        private val manageOffencesService: ManageOffencesService, private val prisonService: PrisonService
+) {
+    val postPcscCalcTypes: Map<String, EnumSet<SentenceCalculationType>> = mapOf(
+            "SDS+" to EnumSet.of(
+                    SentenceCalculationType.ADIMP,
+                    SentenceCalculationType.ADIMP_ORA,
+                    SentenceCalculationType.SEC250,
+                    SentenceCalculationType.SEC250_ORA,
+                    SentenceCalculationType.SEC91_03,
+                    SentenceCalculationType.SEC91_03_ORA,
+                    SentenceCalculationType.YOI,
+                    SentenceCalculationType.YOI_ORA,
+            ),
+    )
+
+    fun setSdsPlusMarkerForOffences(prisonerId: String): List<String> {
+        val prisonerDetails = prisonService.getOffenderDetail(prisonerId)
+        val sentencesAndOffences = prisonService.getSentencesAndOffences(prisonerDetails.bookingId)
+
+        val bookingIdToSentences = getMatchingSentencesToBookingId(sentencesAndOffences)
+        val offencesToCheck = getOffenceCodesToCheckWithMO(bookingIdToSentences)
+
+        return offencesToCheck;
+    }
+
+    fun getOffenceCodesToCheckWithMO(bookingIdToSentences: Map<Long, List<SentenceAndOffences>>): List<String> {
+        val offencesToCheck = bookingIdToSentences.map {
+            it.value.flatMap { offenceList -> offenceList.offences.map { offence -> offence.offenceCode } }
+        }.flatten().distinct();
+        return offencesToCheck
+    }
+
+    fun getMatchingSentencesToBookingId(sentencesAndOffences: List<SentenceAndOffences>): Map<Long, List<SentenceAndOffences>> {
+        val bookingIdToSentences = sentencesAndOffences
+                .filter { SentenceCalculationType.isSupported(it.sentenceCalculationType) }
+                .filter { sentenceAndOffences ->
+                    val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffences.sentenceCalculationType)
+                    val sentencedAfterPcsc = sentencedAfterPcsc(sentenceAndOffences)
+
+                    if (sentencedAfterPcsc) {
+                        val matchingSentenceType = postPcscCalcTypes["SDS+"]!!.contains(sentenceCalculationType)
+                        if (matchingSentenceType && overFourYearsSentenceLength(sentenceAndOffences)) {
+                            return@filter true;
+                        }
+                    }
+                    return@filter false;
+                }
+                .groupBy { it.bookingId }
+        return bookingIdToSentences
+    }
+
+    private fun sentencedAfterPcsc(sentence: SentenceAndOffences): Boolean {
+        return sentence.sentenceDate.isAfterOrEqualTo(
+                ImportantDates.SDS_PLUS_COMMENCEMENT_DATE,
+        )
+    }
+    private fun overFourYearsSentenceLength(sentence: SentenceAndOffences): Boolean {
+        val endOfSentence = endOfSentence(sentence)
+        val endOfFourYears = sentence.sentenceDate.plusYears(4)
+        return endOfSentence.isAfterOrEqualTo(endOfFourYears)
+    }
+
+    private fun endOfSentence(sentence: SentenceAndOffences): LocalDate {
+        val duration =
+                Period.of(sentence.terms[0].years, sentence.terms[0].months, sentence.terms[0].weeks * 7 + sentence.terms[0].days)
+        return sentence.sentenceDate.plus(duration)
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
@@ -29,7 +29,6 @@ class OffenceSdsPlusLookupService(
   )
 
   fun setSdsPlusMarkerForOffences(sentencesAndOffences: List<SentenceAndOffences>) {
-
     val bookingIdToSentences = getMatchingSentencesToBookingId(sentencesAndOffences)
     val offencesToCheck = getOffenceCodesToCheckWithMO(bookingIdToSentences)
 
@@ -42,12 +41,13 @@ class OffenceSdsPlusLookupService(
             .forEach { offence ->
               val moResponseForOffence = moCheckResponses[offence.offenceCode]
               val sentenceIsAfterPcsc = sentencedAfterPcsc(sentenceAndOffence)
-              var sdsPlusIdentified = false;
+              var sdsPlusIdentified = false
               val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffence.sentenceCalculationType)
-              var sevenYearsOrMore = sevenYearsOrMore(sentenceAndOffence)
+              val sevenYearsOrMore = sevenYearsOrMore(sentenceAndOffence)
 
-              if (postPcscCalcTypes["SDS"]!!.contains(sentenceCalculationType)
-                || postPcscCalcTypes["DYOI"]!!.contains(sentenceCalculationType)) {
+              if (postPcscCalcTypes["SDS"]!!.contains(sentenceCalculationType) ||
+                postPcscCalcTypes["DYOI"]!!.contains(sentenceCalculationType)
+              ) {
                 if (sentencedWithinOriginalSdsPlusWindow(sentenceAndOffence) && sevenYearsOrMore && moResponseForOffence?.pcscMarkers?.inListA == true) {
                   sdsPlusIdentified = true
                 } else if (sentenceIsAfterPcsc && sevenYearsOrMore && moResponseForOffence?.pcscMarkers?.inListD == true) {
@@ -73,7 +73,7 @@ class OffenceSdsPlusLookupService(
   fun getOffenceCodesToCheckWithMO(bookingIdToSentences: Map<Long, List<SentenceAndOffences>>): List<String> {
     val offencesToCheck = bookingIdToSentences.map {
       it.value.flatMap { offenceList -> offenceList.offences.map { offence -> offence.offenceCode } }
-    }.flatten().distinct();
+    }.flatten().distinct()
     return offencesToCheck
   }
 
@@ -86,19 +86,19 @@ class OffenceSdsPlusLookupService(
         val sevenYearsOrMore = sevenYearsOrMore(sentenceAndOffences)
         val sentencedWithinOriginalSdsWindow = sentencedWithinOriginalSdsPlusWindow(sentenceAndOffences)
 
-        var matchFilter = false;
+        var matchFilter = false
 
         if (postPcscCalcTypes["SDS"]!!.contains(sentenceCalculationType) || postPcscCalcTypes["DYOI"]!!.contains(sentenceCalculationType)) {
           if (sentencedWithinOriginalSdsWindow && sevenYearsOrMore) {
-            matchFilter = true;
+            matchFilter = true
           } else if (sentenceIsAfterPcsc && overFourYearsSentenceLength(sentenceAndOffences)) {
-            matchFilter = true;
+            matchFilter = true
           }
         } else if (postPcscCalcTypes["S250"]!!.contains(sentenceCalculationType) && sentenceIsAfterPcsc && sevenYearsOrMore) {
-          matchFilter = true;
+          matchFilter = true
         }
 
-        return@filter matchFilter;
+        return@filter matchFilter
       }
       .groupBy { it.bookingId }
     return bookingIdToSentences

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
@@ -12,71 +11,129 @@ import java.util.*
 
 @Service
 class OffenceSdsPlusLookupService(
-        private val manageOffencesService: ManageOffencesService, private val prisonService: PrisonService
+  private val manageOffencesService: ManageOffencesService,
 ) {
-    val postPcscCalcTypes: Map<String, EnumSet<SentenceCalculationType>> = mapOf(
-            "SDS+" to EnumSet.of(
-                    SentenceCalculationType.ADIMP,
-                    SentenceCalculationType.ADIMP_ORA,
-                    SentenceCalculationType.SEC250,
-                    SentenceCalculationType.SEC250_ORA,
-                    SentenceCalculationType.SEC91_03,
-                    SentenceCalculationType.SEC91_03_ORA,
-                    SentenceCalculationType.YOI,
-                    SentenceCalculationType.YOI_ORA,
-            ),
+  val postPcscCalcTypes: Map<String, EnumSet<SentenceCalculationType>> = mapOf(
+    "SDS" to EnumSet.of(
+      SentenceCalculationType.ADIMP,
+      SentenceCalculationType.ADIMP_ORA,
+    ),
+    "DYOI" to EnumSet.of(
+      SentenceCalculationType.YOI,
+      SentenceCalculationType.YOI_ORA,
+    ),
+    "S250" to EnumSet.of(
+      SentenceCalculationType.SEC250,
+      SentenceCalculationType.SEC250_ORA,
+    ),
+  )
+
+  fun setSdsPlusMarkerForOffences(sentencesAndOffences: List<SentenceAndOffences>) {
+
+    val bookingIdToSentences = getMatchingSentencesToBookingId(sentencesAndOffences)
+    val offencesToCheck = getOffenceCodesToCheckWithMO(bookingIdToSentences)
+    val moCheckResponses = manageOffencesService.getPcscMarkersForOffenceCodes(*offencesToCheck.toTypedArray()).associateBy { it.offenceCode }
+
+    bookingIdToSentences.forEach {
+      it.value.forEach { sentenceAndOffence ->
+        sentenceAndOffence.offences.filter { offenderOffence -> offencesToCheck.contains(offenderOffence.offenceCode) }
+          .forEach { offence ->
+            val moResponseForOffence = moCheckResponses[offence.offenceCode]
+            val sentenceIsAfterPcsc = sentencedAfterPcsc(sentenceAndOffence)
+            var sdsPlusIdentified = false;
+            val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffence.sentenceCalculationType)
+            var sevenYearsOrMore = sevenYearsOrMore(sentenceAndOffence)
+
+            if (postPcscCalcTypes["SDS"]!!.contains(sentenceCalculationType)
+              || postPcscCalcTypes["DYOI"]!!.contains(sentenceCalculationType)) {
+              if (sentencedWithinOriginalSdsPlusWindow(sentenceAndOffence) && sevenYearsOrMore && moResponseForOffence?.pcscMarkers?.inListA == true) {
+                sdsPlusIdentified = true
+              } else if (sentenceIsAfterPcsc && sevenYearsOrMore && moResponseForOffence?.pcscMarkers?.inListD == true) {
+                sdsPlusIdentified = true
+              } else if (sentenceIsAfterPcsc && fourToUnderSeven(sentenceAndOffence) && moResponseForOffence?.pcscMarkers?.inListB == true) {
+                sdsPlusIdentified = true
+              }
+            } else if (postPcscCalcTypes["S250"]!!.contains(sentenceCalculationType)) {
+              if (sentenceIsAfterPcsc && sevenYearsOrMore && moResponseForOffence?.pcscMarkers?.inListC == true) {
+                sdsPlusIdentified = true
+              }
+            }
+
+            if (sdsPlusIdentified) {
+              offence.indicators = offence.indicators.plus(listOf(OffenderOffence.PCSC_SDS_PLUS))
+            }
+          }
+      }
+    }
+  }
+
+  fun getOffenceCodesToCheckWithMO(bookingIdToSentences: Map<Long, List<SentenceAndOffences>>): List<String> {
+    val offencesToCheck = bookingIdToSentences.map {
+      it.value.flatMap { offenceList -> offenceList.offences.map { offence -> offence.offenceCode } }
+    }.flatten().distinct();
+    return offencesToCheck
+  }
+
+  fun getMatchingSentencesToBookingId(sentencesAndOffences: List<SentenceAndOffences>): Map<Long, List<SentenceAndOffences>> {
+    val bookingIdToSentences = sentencesAndOffences
+      .filter { SentenceCalculationType.isSupported(it.sentenceCalculationType) }
+      .filter { sentenceAndOffences ->
+        val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffences.sentenceCalculationType)
+        val sentenceIsAfterPcsc = sentencedAfterPcsc(sentenceAndOffences)
+        val sevenYearsOrMore = sevenYearsOrMore(sentenceAndOffences)
+        val sentencedWithinOriginalSdsWindow = sentencedWithinOriginalSdsPlusWindow(sentenceAndOffences)
+
+        var matchFilter = false;
+
+        if (postPcscCalcTypes["SDS"]!!.contains(sentenceCalculationType) || postPcscCalcTypes["DYOI"]!!.contains(sentenceCalculationType) ){
+          if (sentencedWithinOriginalSdsWindow && sevenYearsOrMore){
+            matchFilter = true;
+          }
+          else if(sentenceIsAfterPcsc && overFourYearsSentenceLength(sentenceAndOffences)){
+            matchFilter = true;
+          }
+        } else if(postPcscCalcTypes["S250"]!!.contains(sentenceCalculationType) && sentenceIsAfterPcsc && sevenYearsOrMore){
+          matchFilter = true;
+        }
+
+        return@filter matchFilter;
+      }
+      .groupBy { it.bookingId }
+    return bookingIdToSentences
+  }
+
+  private fun sentencedAfterPcsc(sentence: SentenceAndOffences): Boolean {
+    return sentence.sentenceDate.isAfterOrEqualTo(
+      ImportantDates.PCSC_COMMENCEMENT_DATE,
     )
+  }
 
-    fun setSdsPlusMarkerForOffences(prisonerId: String): List<String> {
-        val prisonerDetails = prisonService.getOffenderDetail(prisonerId)
-        val sentencesAndOffences = prisonService.getSentencesAndOffences(prisonerDetails.bookingId)
+  private fun sentencedWithinOriginalSdsPlusWindow(sentence: SentenceAndOffences): Boolean {
+    return sentence.sentenceDate.isAfterOrEqualTo(ImportantDates.SDS_PLUS_COMMENCEMENT_DATE) && !sentencedAfterPcsc(sentence)
+  }
 
-        val bookingIdToSentences = getMatchingSentencesToBookingId(sentencesAndOffences)
-        val offencesToCheck = getOffenceCodesToCheckWithMO(bookingIdToSentences)
+  private fun overFourYearsSentenceLength(sentence: SentenceAndOffences): Boolean {
+    val endOfSentence = endOfSentence(sentence)
+    val endOfFourYears = sentence.sentenceDate.plusYears(4)
+    return endOfSentence.isAfterOrEqualTo(endOfFourYears)
+  }
 
-        return offencesToCheck;
-    }
+  private fun endOfSentence(sentence: SentenceAndOffences): LocalDate {
+    val duration =
+      Period.of(sentence.terms[0].years, sentence.terms[0].months, sentence.terms[0].weeks * 7 + sentence.terms[0].days)
+    return sentence.sentenceDate.plus(duration)
+  }
 
-    fun getOffenceCodesToCheckWithMO(bookingIdToSentences: Map<Long, List<SentenceAndOffences>>): List<String> {
-        val offencesToCheck = bookingIdToSentences.map {
-            it.value.flatMap { offenceList -> offenceList.offences.map { offence -> offence.offenceCode } }
-        }.flatten().distinct();
-        return offencesToCheck
-    }
+  private fun sevenYearsOrMore(sentence: SentenceAndOffences): Boolean {
+    val endOfSentence = endOfSentence(sentence)
+    val endOfSevenYears = sentence.sentenceDate.plusYears(7)
+    return endOfSentence.isAfterOrEqualTo(endOfSevenYears)
+  }
 
-    fun getMatchingSentencesToBookingId(sentencesAndOffences: List<SentenceAndOffences>): Map<Long, List<SentenceAndOffences>> {
-        val bookingIdToSentences = sentencesAndOffences
-                .filter { SentenceCalculationType.isSupported(it.sentenceCalculationType) }
-                .filter { sentenceAndOffences ->
-                    val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffences.sentenceCalculationType)
-                    val sentencedAfterPcsc = sentencedAfterPcsc(sentenceAndOffences)
-
-                    if (sentencedAfterPcsc) {
-                        val matchingSentenceType = postPcscCalcTypes["SDS+"]!!.contains(sentenceCalculationType)
-                        if (matchingSentenceType && overFourYearsSentenceLength(sentenceAndOffences)) {
-                            return@filter true;
-                        }
-                    }
-                    return@filter false;
-                }
-                .groupBy { it.bookingId }
-        return bookingIdToSentences
-    }
-
-    private fun sentencedAfterPcsc(sentence: SentenceAndOffences): Boolean {
-        return sentence.sentenceDate.isAfterOrEqualTo(
-                ImportantDates.SDS_PLUS_COMMENCEMENT_DATE,
-        )
-    }
-    private fun overFourYearsSentenceLength(sentence: SentenceAndOffences): Boolean {
-        val endOfSentence = endOfSentence(sentence)
-        val endOfFourYears = sentence.sentenceDate.plusYears(4)
-        return endOfSentence.isAfterOrEqualTo(endOfFourYears)
-    }
-
-    private fun endOfSentence(sentence: SentenceAndOffences): LocalDate {
-        val duration =
-                Period.of(sentence.terms[0].years, sentence.terms[0].months, sentence.terms[0].weeks * 7 + sentence.terms[0].days)
-        return sentence.sentenceDate.plus(duration)
-    }
+  private fun fourToUnderSeven(sentence: SentenceAndOffences): Boolean {
+    val endOfSentence = endOfSentence(sentence)
+    val endOfFourYears = sentence.sentenceDate.plusYears(4)
+    val endOfSevenYears = sentence.sentenceDate.plusYears(7)
+    return endOfSentence.isAfterOrEqualTo(endOfFourYears) && endOfSentence.isBefore(endOfSevenYears)
+  }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -30,6 +30,10 @@ adjustments:
   api:
     url: http://localhost:8081
 
+manage-offences:
+  api:
+    url: http://localhost:8335
+
 system:
   client:
     id: calculate-release-dates-admin

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -26,13 +26,15 @@ prison:
   api:
     url: http://localhost:8080
 
+#TODO: Add local docker compose support for Adjustments container
 adjustments:
   api:
     url: http://localhost:8081
 
+#TODO: Add local docker compose support for Manage Offences container
 manage-offences:
   api:
-    url: http://localhost:8335
+    url: https://manage-offences-api-dev.hmpps.service.justice.gov.uk
 
 system:
   client:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
@@ -11,6 +11,7 @@ import org.springframework.test.context.jdbc.SqlMergeMode
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.BankHolidayApiExtension
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.ManageOffensesApiExtension
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.OAuthExtension
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.PrisonApiExtension
 /*
@@ -32,7 +33,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremoc
   "classpath:test_data/reset-base-data.sql",
   "classpath:test_data/load-base-data.sql",
 )
-@ExtendWith(OAuthExtension::class, PrisonApiExtension::class, BankHolidayApiExtension::class)
+@ExtendWith(OAuthExtension::class, PrisonApiExtension::class, BankHolidayApiExtension::class, ManageOffensesApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 class IntegrationTestBase internal constructor() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.TestUtil
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
+
+/*
+    This class mocks the manage offences api.
+    JSON files exist in 'src/test/resources/test_data/api_integration
+    Add files to any sub-directory to automatically stub rest calls. The file name will act as the prisoner id.
+    The hashcode of the prisoner id string, will be the booking id.
+    Once a file is added to any of the directories, all calls will be stubbed, if not all directories have an
+    entry for the given prisoner id, the mock will fallback to a default json file.
+ */
+class ManageOffensesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val manageOffensesApi = ManageOffensesMockServer();
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+  override fun beforeAll(context: ExtensionContext) {
+    manageOffensesApi.start()
+    manageOffensesApi.stubMOResponse()
+  }
+
+  override fun afterAll(context: ExtensionContext?) {
+    manageOffensesApi.stop()
+  }
+
+  override fun beforeEach(context: ExtensionContext?) {
+    manageOffensesApi.resetRequests()
+  }
+}
+
+
+class ManageOffensesMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8334
+  }
+
+  fun stubMOResponse(): StubMapping =
+    stubFor(
+      get("/api/manage")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """""".trimIndent(),
+            )
+            .withStatus(200),
+        ),
+    )
+}
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -1,11 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.equalTo
-import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.post
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -13,26 +9,18 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.TestUtil
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
 
-/*
-    This class mocks the manage offences api.
-    JSON files exist in 'src/test/resources/test_data/api_integration
-    Add files to any sub-directory to automatically stub rest calls. The file name will act as the prisoner id.
-    The hashcode of the prisoner id string, will be the booking id.
-    Once a file is added to any of the directories, all calls will be stubbed, if not all directories have an
-    entry for the given prisoner id, the mock will fallback to a default json file.
- */
 class ManageOffensesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
   companion object {
     @JvmField
     val manageOffensesApi = ManageOffensesMockServer();
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
+
   override fun beforeAll(context: ExtensionContext) {
     manageOffensesApi.start()
     manageOffensesApi.stubMOResponse()
+    manageOffensesApi.stubMOMultipleResults()
   }
 
   override fun afterAll(context: ExtensionContext?) {
@@ -47,17 +35,59 @@ class ManageOffensesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEa
 
 class ManageOffensesMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
-    private const val WIREMOCK_PORT = 8334
+    private const val WIREMOCK_PORT = 8335
   }
 
   fun stubMOResponse(): StubMapping =
     stubFor(
-      get("/api/manage")
+      get(urlMatching("/schedule/pcsc-indicators\\?COML025A"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody(
-              """""".trimIndent(),
+              """[
+                {
+                    "offenceCode": "COML025A",
+                    "pcscMarkers": {
+                        "inListA": false,
+                        "inListB": true,
+                        "inListC": true,
+                        "inListD": false
+                    }
+                }
+            ]""".trimIndent(),
+            )
+            .withStatus(200),
+        ),
+    )
+
+  fun stubMOMultipleResults(): StubMapping =
+    stubFor(
+      get(urlMatching("/schedule/pcsc-indicators\\?COML025A,COML022"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """[
+                {
+                    "offenceCode": "COML025A",
+                    "pcscMarkers": {
+                        "inListA": false,
+                        "inListB": true,
+                        "inListC": true,
+                        "inListD": false
+                    }
+                },
+                {
+                    "offenceCode": "COML022",
+                    "pcscMarkers": {
+                        "inListA": false,
+                        "inListB": true,
+                        "inListC": true,
+                        "inListD": false
+                    }
+                }
+            ]""".trimIndent(),
             )
             .withStatus(200),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -13,7 +15,7 @@ import org.slf4j.LoggerFactory
 class ManageOffensesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
   companion object {
     @JvmField
-    val manageOffensesApi = ManageOffensesMockServer();
+    val manageOffensesApi = ManageOffensesMockServer()
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
@@ -31,7 +33,6 @@ class ManageOffensesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEa
     manageOffensesApi.resetRequests()
   }
 }
-
 
 class ManageOffensesMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -55,7 +56,8 @@ class ManageOffensesMockServer : WireMockServer(WIREMOCK_PORT) {
                         "inListD": false
                     }
                 }
-            ]""".trimIndent(),
+            ]
+              """.trimIndent(),
             )
             .withStatus(200),
         ),
@@ -87,10 +89,10 @@ class ManageOffensesMockServer : WireMockServer(WIREMOCK_PORT) {
                         "inListD": false
                     }
                 }
-            ]""".trimIndent(),
+            ]
+              """.trimIndent(),
             )
             .withStatus(200),
         ),
     )
 }
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
@@ -28,7 +28,7 @@ class ManualCalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Storing a no dates manual entry is successful`() {
-    val response = webTestClient.post()
+      val response = webTestClient.post()
       .uri("/manual-calculation/$PRISONER_ID")
       .bodyValue(ManualEntryRequest(listOf(ManualEntrySelectedDate(ReleaseDateType.None, "None", null))))
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
@@ -28,7 +28,7 @@ class ManualCalculationIntTest : IntegrationTestBase() {
 
   @Test
   fun `Storing a no dates manual entry is successful`() {
-      val response = webTestClient.post()
+    val response = webTestClient.post()
       .uri("/manual-calculation/$PRISONER_ID")
       .bodyValue(ManualEntryRequest(listOf(ManualEntrySelectedDate(ReleaseDateType.None, "None", null))))
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/MoPCSCIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/MoPCSCIntTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.UserContext
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.OffenceSdsPlusLookupService
+import java.time.LocalDate
+
+class MoPCSCIntTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var offenceSdsPlusLookupService: OffenceSdsPlusLookupService
+
+  @Test
+  fun `Test Call to MO Service Matching S250 Offence marked as SDS+`() {
+    //S250 over 7 years and sentenced after PCSC date
+    val inputOffenceList = listOf(
+      SentenceAndOffences(
+        1,
+        1,
+        1,
+        1,
+        null,
+        "TEST",
+        "TEST",
+        SentenceCalculationType.SEC250.toString(),
+        "TEST",
+        LocalDate.of(2022, 8, 29),
+        listOf(SentenceTerms(8, 4, 1, 1)),
+        listOf(
+          OffenderOffence(
+            1,
+            LocalDate.of(2022, 1, 1),
+            null,
+            "COML025A",
+            "TEST OFFENSE",
+          ),
+        ),
+      ),
+    )
+
+    UserContext.setAuthToken("123456")
+    offenceSdsPlusLookupService.setSdsPlusMarkerForOffences(inputOffenceList)
+    assertTrue(inputOffenceList[0].offences[0].isPcscSdsPlus)
+  }
+
+  @Test
+  fun `Test Call to MO Service Matching S250 Offence marked as SDS+ `() {
+    //S250 over 7 years and sentenced after PCSC date
+    val inputOffenceList = listOf(
+      SentenceAndOffences(
+        1,
+        1,
+        1,
+        1,
+        null,
+        "TEST",
+        "TEST",
+        SentenceCalculationType.SEC250.toString(),
+        "TEST",
+        LocalDate.of(2022, 8, 29),
+        listOf(SentenceTerms(8, 4, 1, 1)),
+        listOf(
+          OffenderOffence(
+            1,
+            LocalDate.of(2022, 1, 1),
+            null,
+            "COML025A",
+            "TEST OFFENSE",
+          ),
+          OffenderOffence(
+            1,
+            LocalDate.of(2022, 1, 1),
+            null,
+            "COML022",
+            "TEST OFFENSE",
+          ),
+        ),
+      ),
+    )
+
+    UserContext.setAuthToken("123456")
+    offenceSdsPlusLookupService.setSdsPlusMarkerForOffences(inputOffenceList)
+    assertTrue(inputOffenceList[0].offences[0].isPcscSdsPlus)
+    assertTrue(inputOffenceList[0].offences[0].isPcscSdsPlus)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/MoPCSCIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/MoPCSCIntTest.kt
@@ -18,8 +18,8 @@ class MoPCSCIntTest : IntegrationTestBase() {
   lateinit var offenceSdsPlusLookupService: OffenceSdsPlusLookupService
 
   @Test
-  fun `Test Call to MO Service Matching S250 Offence marked as SDS+`() {
-    //S250 over 7 years and sentenced after PCSC date
+  fun `Test Call to MO Service Matching SEC_250 Offence marked as SDS+`() {
+    // S250 over 7 years and sentenced after PCSC date
     val inputOffenceList = listOf(
       SentenceAndOffences(
         1,
@@ -51,8 +51,8 @@ class MoPCSCIntTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Test Call to MO Service Matching S250 Offence marked as SDS+ `() {
-    //S250 over 7 years and sentenced after PCSC date
+  fun `Test Call to MO Service Matching SEC_250 multiple offences marked as SDS+ `() {
+    // S250 over 7 years and sentenced after PCSC date
     val inputOffenceList = listOf(
       SentenceAndOffences(
         1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
@@ -22,28 +22,6 @@ class ManageOffencesServiceTest {
       assertThat(listOf(dummyOffencePcscSomeMarkers)).isEqualTo(testResult);
     }
 
-    @Test
-    fun doesSingleOffenceCodeHaveAllPcscMarkers() {
-      whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
-      val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_SOME_PCSC_MARKERS)
-      assertTrue(testResult);
-    }
-
-  @Test
-  fun doesSingleOffenceCodeHaveSomePcscMarkers() {
-    whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
-    val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_SOME_PCSC_MARKERS)
-    assertTrue(testResult);
-  }
-
-  @Test
-  fun doesSingleOffenceCodeHaveNoPcscMarkers() {
-    whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_NO_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscNoMarkers))
-    val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_NO_PCSC_MARKERS)
-    assertFalse(testResult);
-  }
-
-
   companion object {
     private const val OFFENCE_CODE_SOME_PCSC_MARKERS = "AV82002"
     private const val OFFENCE_CODE_NO_PCSC_MARKERS = ""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+import org.mockito.kotlin.*
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffencePcscMarkers
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PcscMarkers
+
+class ManageOffencesServiceTest {
+
+    private val mockManageOffencesApiClient = mock<ManageOffencesApiClient>();
+    private val underTest = ManageOffencesService(mockManageOffencesApiClient);
+
+    @Test
+    fun getPcscMarkersForOffenceCodes() {
+      whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
+      val testResult = underTest.getPcscMarkersForOffenceCodes(OFFENCE_CODE_SOME_PCSC_MARKERS);
+      verify(mockManageOffencesApiClient, times(1)).getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS));
+      assertThat(listOf(dummyOffencePcscSomeMarkers)).isEqualTo(testResult);
+    }
+
+    @Test
+    fun doesSingleOffenceCodeHaveAllPcscMarkers() {
+      whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
+      val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_SOME_PCSC_MARKERS)
+      assertTrue(testResult);
+    }
+
+  @Test
+  fun doesSingleOffenceCodeHaveSomePcscMarkers() {
+    whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
+    val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_SOME_PCSC_MARKERS)
+    assertTrue(testResult);
+  }
+
+  @Test
+  fun doesSingleOffenceCodeHaveNoPcscMarkers() {
+    whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_NO_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscNoMarkers))
+    val testResult = underTest.doesOffenceCodeHavePcscMarkers(OFFENCE_CODE_NO_PCSC_MARKERS)
+    assertFalse(testResult);
+  }
+
+
+  companion object {
+    private const val OFFENCE_CODE_SOME_PCSC_MARKERS = "AV82002"
+    private const val OFFENCE_CODE_NO_PCSC_MARKERS = ""
+    private val dummyOffencePcscSomeMarkers = OffencePcscMarkers(
+      offenceCode = OFFENCE_CODE_SOME_PCSC_MARKERS,
+      pcscMarkers = PcscMarkers(
+        inListA = true, inListB = false, inListC = false, inListD = true
+      )
+    )
+    private val dummyOffencePcscNoMarkers = OffencePcscMarkers(
+      offenceCode = OFFENCE_CODE_SOME_PCSC_MARKERS,
+      pcscMarkers = PcscMarkers(
+        inListA = false, inListB = false, inListC = false, inListD = false
+      )
+    )
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
@@ -1,26 +1,26 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-
-import org.mockito.kotlin.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PcscMarkers
 
 class ManageOffencesServiceTest {
 
-    private val mockManageOffencesApiClient = mock<ManageOffencesApiClient>();
-    private val underTest = ManageOffencesService(mockManageOffencesApiClient);
+  private val mockManageOffencesApiClient = mock<ManageOffencesApiClient>()
+  private val underTest = ManageOffencesService(mockManageOffencesApiClient)
 
-    @Test
-    fun getPcscMarkersForOffenceCodes() {
-      whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
-      val testResult = underTest.getPcscMarkersForOffenceCodes(OFFENCE_CODE_SOME_PCSC_MARKERS);
-      verify(mockManageOffencesApiClient, times(1)).getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS));
-      assertThat(listOf(dummyOffencePcscSomeMarkers)).isEqualTo(testResult);
-    }
+  @Test
+  fun getPcscMarkersForOffenceCodes() {
+    whenever(mockManageOffencesApiClient.getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))).thenReturn(listOf(dummyOffencePcscSomeMarkers))
+    val testResult = underTest.getPcscMarkersForOffenceCodes(OFFENCE_CODE_SOME_PCSC_MARKERS)
+    verify(mockManageOffencesApiClient, times(1)).getPCSCMarkersForOffences(listOf(OFFENCE_CODE_SOME_PCSC_MARKERS))
+    assertThat(listOf(dummyOffencePcscSomeMarkers)).isEqualTo(testResult)
+  }
 
   companion object {
     private const val OFFENCE_CODE_SOME_PCSC_MARKERS = "AV82002"
@@ -28,15 +28,20 @@ class ManageOffencesServiceTest {
     private val dummyOffencePcscSomeMarkers = OffencePcscMarkers(
       offenceCode = OFFENCE_CODE_SOME_PCSC_MARKERS,
       pcscMarkers = PcscMarkers(
-        inListA = true, inListB = false, inListC = false, inListD = true
-      )
+        inListA = true,
+        inListB = false,
+        inListC = false,
+        inListD = true,
+      ),
     )
     private val dummyOffencePcscNoMarkers = OffencePcscMarkers(
       offenceCode = OFFENCE_CODE_SOME_PCSC_MARKERS,
       pcscMarkers = PcscMarkers(
-        inListA = false, inListB = false, inListC = false, inListD = false
-      )
+        inListA = false,
+        inListB = false,
+        inListC = false,
+        inListD = false,
+      ),
     )
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupServiceTest.kt
@@ -1,0 +1,208 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.*
+import java.time.LocalDate
+
+class OffenceSdsPlusLookupServiceTest {
+
+    private val mockManageOffencesService = mock<ManageOffencesService>();
+    private val mockPrisonService = mock<PrisonService>();
+
+    private val underTest = OffenceSdsPlusLookupService(mockManageOffencesService, mockPrisonService);
+
+    @Test
+    fun testSetSdsPlusMarkerForMatchingSingularSentenceAndSingularOffence() {
+        whenever(mockPrisonService.getOffenderDetail(any())).thenReturn(PrisonerDetails(bookingId = 1, offenderNo = "123", dateOfBirth = LocalDate.of(1971, 1, 1)))
+        whenever(mockPrisonService.getSentencesAndOffences(1)).thenReturn(sentenceMatchesSDSCriteriaOneOffence)
+        assertEquals(listOf("A123456"), underTest.setSdsPlusMarkerForOffences("123"))
+    }
+
+    @Test
+    fun testSetSdsPlusMarkerForMatchingSingularSentenceAndTwoOffences() {
+        whenever(mockPrisonService.getOffenderDetail(any())).thenReturn(PrisonerDetails(bookingId = 1, offenderNo = "123", dateOfBirth = LocalDate.of(1971, 1, 1)))
+        whenever(mockPrisonService.getSentencesAndOffences(1)).thenReturn(sentenceMatchesSDSCriteriaTwoOffences)
+        assertEquals(listOf("A123456", "A000000"), underTest.setSdsPlusMarkerForOffences("123"))
+    }
+
+    @Test
+    fun testSetSdsPlusMarkerForMatchingMultipleMatchingSentencesAndTwoOffences() {
+        whenever(mockPrisonService.getOffenderDetail(any())).thenReturn(PrisonerDetails(bookingId = 1, offenderNo = "123", dateOfBirth = LocalDate.of(1971, 1, 1)))
+        whenever(mockPrisonService.getSentencesAndOffences(1)).thenReturn(multipleSentencesMatchesSDSCriteriaMultipleOffences)
+        assertEquals(listOf("A123456", "A000000","A111111", "A22222"), underTest.setSdsPlusMarkerForOffences("123"))
+    }
+
+    @Test
+    fun testSetSdsPlusMarkerForMatchingOneMatchingSentencesOneNotMatchingSentenceOnDate() {
+        whenever(mockPrisonService.getOffenderDetail(any())).thenReturn(PrisonerDetails(bookingId = 1, offenderNo = "123", dateOfBirth = LocalDate.of(1971, 1, 1)))
+        whenever(mockPrisonService.getSentencesAndOffences(1)).thenReturn(oneSentencesMatchesSDSCriteriaOneDoesNotMatchOnDateMultipleOffences)
+        assertEquals(listOf("A111111", "A22222"), underTest.setSdsPlusMarkerForOffences("123"))
+    }
+
+    companion object {
+        private val sentenceMatchesSDSCriteriaOneOffence = listOf(SentenceAndOffences(1,
+                1,
+                1,
+                1,
+                null,
+                "TEST",
+                "TEST",
+                SentenceCalculationType.ADIMP.toString(),
+                "TEST",
+                LocalDate.of(2020, 4, 2),
+                listOf(SentenceTerms(4, 1, 1, 1)),
+                listOf(OffenderOffence(
+                        1,
+                        LocalDate.of(2020, 4, 1),
+                        null,
+                        "A123456",
+                        "TEST OFFENSE")
+                )))
+
+        private val sentenceMatchesSDSCriteriaTwoOffences = listOf(SentenceAndOffences(1,
+                1,
+                1,
+                1,
+                null,
+                "TEST",
+                "TEST",
+                SentenceCalculationType.ADIMP.toString(),
+                "TEST",
+                LocalDate.of(2020, 4, 2),
+                listOf(SentenceTerms(4, 1, 1, 1)),
+                listOf(OffenderOffence(
+                        1,
+                        LocalDate.of(2020, 4, 1),
+                        null,
+                        "A123456",
+                        "TEST OFFENCE 1"),
+                        OffenderOffence(
+                                1,
+                                LocalDate.of(2020, 4, 1),
+                                null,
+                                "A000000",
+                                "TEST OFFENCE 2")
+                )))
+
+        private val multipleSentencesMatchesSDSCriteriaMultipleOffences = listOf(SentenceAndOffences(1,
+                1,
+                1,
+                1,
+                null,
+                "TEST",
+                "TEST",
+                SentenceCalculationType.ADIMP.toString(),
+                "TEST",
+                LocalDate.of(2020, 4, 2),
+                listOf(SentenceTerms(4, 1, 1, 1)),
+                listOf(OffenderOffence(
+                        1,
+                        LocalDate.of(2020, 4, 1),
+                        null,
+                        "A123456",
+                        "TEST OFFENCE 1"),
+                        OffenderOffence(
+                                1,
+                                LocalDate.of(2020, 4, 1),
+                                null,
+                                "A000000",
+                                "TEST OFFENCE 2")
+                )),
+                SentenceAndOffences(
+                        1,
+                        1,
+                        1,
+                        1,
+                        null,
+                        "TEST",
+                        "TEST",
+                        SentenceCalculationType.SEC250.toString(),
+                        "TEST",
+                        LocalDate.of(2020, 4, 2),
+                        listOf(SentenceTerms(4, 1, 1, 1)),
+                        listOf(OffenderOffence(
+                                1,
+                                LocalDate.of(2020, 4, 1),
+                                null,
+                                "A111111",
+                                "TEST OFFENCE 1"),
+                                OffenderOffence(
+                                        1,
+                                        LocalDate.of(2020, 4, 1),
+                                        null,
+                                        "A22222",
+                                        "TEST OFFENCE 2")
+                        )))
+
+        private val oneSentencesMatchesSDSCriteriaOneDoesNotMatchOnDateMultipleOffences = listOf(SentenceAndOffences(1,
+                1,
+                1,
+                1,
+                null,
+                "TEST",
+                "TEST",
+                SentenceCalculationType.ADIMP.toString(),
+                "TEST",
+                LocalDate.of(2020, 3, 31),
+                listOf(SentenceTerms(4, 1, 1, 1)),
+                listOf(OffenderOffence(
+                        1,
+                        LocalDate.of(2020, 4, 1),
+                        null,
+                        "A123456",
+                        "TEST OFFENCE 1"),
+                        OffenderOffence(
+                                1,
+                                LocalDate.of(2020, 4, 1),
+                                null,
+                                "A000000",
+                                "TEST OFFENCE 2")
+                )),
+                SentenceAndOffences(
+                        1,
+                        1,
+                        1,
+                        1,
+                        null,
+                        "TEST",
+                        "TEST",
+                        SentenceCalculationType.SEC250.toString(),
+                        "TEST",
+                        LocalDate.of(2020, 4, 2),
+                        listOf(SentenceTerms(4, 1, 1, 1)),
+                        listOf(OffenderOffence(
+                                1,
+                                LocalDate.of(2020, 4, 1),
+                                null,
+                                "A111111",
+                                "TEST OFFENCE 1"),
+                                OffenderOffence(
+                                        1,
+                                        LocalDate.of(2020, 4, 1),
+                                        null,
+                                        "A22222",
+                                        "TEST OFFENCE 2")
+                        )))
+    }
+
+//    val bookingId: Long,
+//    val sentenceSequence: Int,
+//    val lineSequence: Int,
+//    val caseSequence: Int,
+//    val consecutiveToSequence: Int? = null,
+//    val sentenceStatus: String,
+//    val sentenceCategory: String,
+//    val sentenceCalculationType: String,
+//    val sentenceTypeDescription: String,
+//    val sentenceDate: LocalDate,
+//    val terms: List<SentenceTerms> = emptyList(),
+//    val offences: List<OffenderOffence> = emptyList(),
+//    val caseReference: String? = null,
+//    val courtDescription: String? = null,
+//    val fineAmount: BigDecimal? = null,
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -61,6 +61,10 @@ adjustments:
   api:
     url: http://localhost:8334
 
+manage-offences:
+  api:
+    url: http://localhost:8335
+
 
 domain-events-sns:
   provider: localstack


### PR DESCRIPTION
* Adds new service that sets Offence markers based on response from Manage Offences `schedule/pcsc-indicators?<offence-codes>` endpoint