### PR TITLE
CRS-1796: Add agencyId to person returned in calculable sentence enve…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/Person.kt
@@ -14,6 +14,8 @@ data class Person(
 
   var lastName: String,
 
+  var agencyId: String,
+
   val alerts: List<Alert>,
 ) {
   fun isActiveSexOffender(): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonService.kt
@@ -267,6 +267,7 @@ class BulkComparisonService(
       bookingId = source.bookingId,
       offenderNo = source.person.prisonerNumber,
       dateOfBirth = source.person.dateOfBirth,
+      agencyId = source.person.agencyId,
       alerts = source.person.alerts,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/PersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/PersonTest.kt
@@ -11,7 +11,7 @@ internal class PersonTest {
   @Test
   fun `test has active sex offender alert`() {
     val sexOffenderAlert = Alert(LocalDate.now(), alertType = "S", alertCode = "SOR")
-    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Davis", listOf(sexOffenderAlert))
+    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Davis", "BMI", listOf(sexOffenderAlert))
 
     assertTrue(person.isActiveSexOffender())
   }
@@ -19,7 +19,7 @@ internal class PersonTest {
   @Test
   fun `test has expired sex offender alert`() {
     val expiredSexOffenderAlert = Alert(LocalDate.now(), dateExpires = LocalDate.now().minusDays(1), alertType = "S", alertCode = "SOR")
-    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Collins", listOf(expiredSexOffenderAlert))
+    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Collins", "BMI", listOf(expiredSexOffenderAlert))
 
     assertFalse(person.isActiveSexOffender())
   }
@@ -27,7 +27,7 @@ internal class PersonTest {
   @Test
   fun `test does not have sex offender alert`() {
     val alert = Alert(LocalDate.now(), dateExpires = LocalDate.now().minusDays(1), alertType = "A", alertCode = "DEF")
-    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Zinis", listOf(alert))
+    val person = Person("ABC1234", LocalDate.now().minusYears(23), "Zinis", "BMI", listOf(alert))
 
     assertFalse(person.isActiveSexOffender())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonServiceTest.kt
@@ -123,7 +123,7 @@ class BulkComparisonServiceTest {
   )
 
   private val calculableSentenceEnvelope = CalculableSentenceEnvelope(
-    person = Person("A", LocalDate.of(1990, 5, 1), "Morris", emptyList()),
+    person = Person("A", LocalDate.of(1990, 5, 1), "Morris", "HDR", emptyList()),
     bookingId = 12345,
     sentenceAndOffences = listOf(sentenceAndOffence),
     sentenceAdjustments = emptyList(),
@@ -138,6 +138,7 @@ class BulkComparisonServiceTest {
       "A",
       LocalDate.of(1990, 5, 1),
       "Rickman",
+      "KQR",
       alerts = listOf(Alert(LocalDate.now(), alertType = "S", alertCode = "SR")),
     ),
   )

--- a/src/test/resources/test_data/api_integration/prisonCalculableSentenceEnvelope/ABC.json
+++ b/src/test/resources/test_data/api_integration/prisonCalculableSentenceEnvelope/ABC.json
@@ -5,6 +5,7 @@
         "prisonerNumber": "Z0020ZZ",
         "dateOfBirth": "1966-01-01",
         "lastName": "Smith",
+        "agencyId": "BMI",
         "alerts": [
           {
             "alertId": 1,

--- a/src/test/resources/test_data/api_integration/prisonCalculableSentenceEnvelope/default.json
+++ b/src/test/resources/test_data/api_integration/prisonCalculableSentenceEnvelope/default.json
@@ -4,7 +4,8 @@
       "person": {
         "prisonerNumber": "Z0020ZZ",
         "dateOfBirth": "1966-01-01",
-        "lastName": "Jones"
+        "lastName": "Jones",
+        "agencyId": "BMI"
       },
       "bookingId": -20,
       "sentenceAndOffences": [

--- a/src/test/resources/test_data/api_integration/prisonerCalculableSentenceEnvelope/CRS-1704.json
+++ b/src/test/resources/test_data/api_integration/prisonerCalculableSentenceEnvelope/CRS-1704.json
@@ -4,6 +4,7 @@
       "prisonerNumber": "Z0030ZZ",
       "dateOfBirth": "1972-11-14",
       "lastName": "Smith",
+      "agencyId": "BMI",
       "alerts": []
     },
     "bookingId": 1205535,

--- a/src/test/resources/test_data/api_integration/prisonerCalculableSentenceEnvelope/Z0020ZZ.json
+++ b/src/test/resources/test_data/api_integration/prisonerCalculableSentenceEnvelope/Z0020ZZ.json
@@ -4,6 +4,7 @@
       "prisonerNumber": "Z0020ZZ",
       "dateOfBirth": "1966-01-01",
       "lastName": "Jones",
+      "agencyId": "BMI",
       "alerts": [
         {
           "alertId": 1,


### PR DESCRIPTION
…lope from prison api. This is used to populate prisoner location in calculation request.