### PR TITLE
CRS-1811: match up valuation outcomes with people on HDC4+ mismatches

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
@@ -201,7 +201,9 @@ class ComparisonService(
   }
 
   private fun transformToHdcFourPlusComparisonMismatch(hdc4PlusResults: List<ComparisonPerson>, hdc4PlusCalculationOutcomes: List<CalculationOutcome>): List<HdcFourPlusComparisonMismatch> = hdc4PlusResults.map { comparisonPerson ->
-    val releaseDate = hdc4PlusCalculationOutcomes.filter { outcome -> outcome.outcomeDate != null }.maxByOrNull { outcome -> outcome.outcomeDate!! }
+    val releaseDate = hdc4PlusCalculationOutcomes
+      .filter { outcome -> comparisonPerson.calculationRequestId?.let { id -> id == outcome.calculationRequestId } ?: false }
+      .filter { outcome -> outcome.outcomeDate != null }.maxByOrNull { outcome -> outcome.outcomeDate!! }
       ?.let { nonNullOutcome -> ReleaseDate(nonNullOutcome.outcomeDate!!, ReleaseDateType.valueOf(nonNullOutcome.calculationDateType)) }
     HdcFourPlusComparisonMismatch(comparisonPerson.person, comparisonPerson.lastName, comparisonPerson.mismatchType, comparisonPerson.hdcedFourPlusDate!!, comparisonPerson.establishment, releaseDate)
   }


### PR DESCRIPTION
Was taking the latest across any person instead of valuation outcomes per person.