### PR TITLE
CRS-1814: Replace calculation outcome repository method findByCalcula…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/CalculationOutcomeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/CalculationOutcomeRepository.kt
@@ -1,10 +1,15 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationOutcome
 
 @Repository
 interface CalculationOutcomeRepository : JpaRepository<CalculationOutcome, Long> {
-  fun findByCalculationRequestIdIn(calculationRequestIds: List<Long>): List<CalculationOutcome>
+  @Query(nativeQuery = true, value = "select * from calculation_outcome where calculation_outcome.calculation_request_id in (select calculation_request_id from comparison_person where comparison_id = ? and mismatch_type='RELEASE_DATES_MISMATCH')")
+  fun findForComparisonAndReleaseDatesMismatch(comparisonId: Long): List<CalculationOutcome>
+
+  @Query(nativeQuery = true, value = "select * from calculation_outcome where calculation_outcome.calculation_request_id in (select calculation_request_id from comparison_person where comparison_id = ? and calculation_request_id is not null and hdced_four_plus_date is not null)")
+  fun findForComparisonAndHdcedFourPlusDateIsNotNull(comparisonId: Long): List<CalculationOutcome>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
@@ -87,7 +87,7 @@ class ComparisonService(
         .mapNotNull { it.calculationRequestId }
 
       val calculationOutcomes = if (releaseMismatchCalculationRequests.isNotEmpty()) {
-        calculationOutcomeRepository.findByCalculationRequestIdIn(releaseMismatchCalculationRequests)
+        calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(comparison.id)
       } else {
         emptyList()
       }
@@ -103,7 +103,7 @@ class ComparisonService(
 
       val hdc4PlusResults = comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)
       val hdc4PlusCalculationOutcomes = calculationOutcomeRepository
-        .findByCalculationRequestIdIn(hdc4PlusResults.mapNotNull { it.calculationRequestId })
+        .findForComparisonAndHdcedFourPlusDateIsNotNull(comparison.id)
         .filter { it.calculationDateType in listOf(ReleaseDateType.CRD.name, ReleaseDateType.ARD.name) }
 
       val mismatchesSortedByReleaseDate = mismatchesAndCrdsDates.sortedWith(::establishmentAndReleaseDateComparator)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonServiceTest.kt
@@ -305,7 +305,7 @@ class ComparisonServiceTest : IntegrationTestBase() {
     ).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(comparisonPersons)
 
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -432,7 +432,7 @@ class ComparisonServiceTest : IntegrationTestBase() {
     ).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(comparisonPersons)
 
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -469,7 +469,8 @@ class ComparisonServiceTest : IntegrationTestBase() {
     whenever(comparisonRepository.findByComparisonShortReference("ABCD1234")).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(emptyList())
     whenever(comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)).thenReturn(comparisonPersons)
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndHdcedFourPlusDateIsNotNull(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -499,7 +500,8 @@ class ComparisonServiceTest : IntegrationTestBase() {
     whenever(comparisonRepository.findByComparisonShortReference("ABCD1234")).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(emptyList())
     whenever(comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)).thenReturn(comparisonPersons)
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndHdcedFourPlusDateIsNotNull(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -534,7 +536,8 @@ class ComparisonServiceTest : IntegrationTestBase() {
     whenever(comparisonRepository.findByComparisonShortReference("ABCD1234")).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(emptyList())
     whenever(comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)).thenReturn(comparisonPersons)
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndHdcedFourPlusDateIsNotNull(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -558,7 +561,7 @@ class ComparisonServiceTest : IntegrationTestBase() {
     whenever(comparisonRepository.findByComparisonShortReference("ABCD1234")).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(emptyList())
     whenever(comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)).thenReturn(comparisonPersons)
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(emptyList())
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(emptyList())
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 
@@ -600,7 +603,8 @@ class ComparisonServiceTest : IntegrationTestBase() {
     whenever(comparisonRepository.findByComparisonShortReference("ABCD1234")).thenReturn(comparison)
     whenever(comparisonPersonRepository.findByComparisonIdIsAndIsMatchFalse(comparison.id)).thenReturn(emptyList())
     whenever(comparisonPersonRepository.findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(comparison.id)).thenReturn(comparisonPersons)
-    whenever(calculationOutcomeRepository.findByCalculationRequestIdIn(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndReleaseDatesMismatch(any())).thenReturn(calculationOutcomes)
+    whenever(calculationOutcomeRepository.findForComparisonAndHdcedFourPlusDateIsNotNull(any())).thenReturn(calculationOutcomes)
 
     val result = comparisonService.getComparisonByComparisonReference("ABCD1234")
 


### PR DESCRIPTION
…tionRequestIdIn. When running large comparisons this was being passed a list of thousands of id's and was getting very slow.