### PR TITLE
CRS-1634 Add verification for manual entry submission

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ repositories {
 
 jacoco {
   // You may modify the Jacoco version here
-  toolVersion = "0.8.8"
+  toolVersion = "0.8.11"
 }
 
 kotlin {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationController.kt
@@ -76,6 +76,31 @@ class ValidationController(
     return calculationTransactionalService.supportedValidation(prisonerId)
   }
 
+  @GetMapping(value = ["/{prisonerId}/manual-entry-validation"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
+  @ResponseBody
+  @Operation(
+    summary = "Validates that the sentences for the given prisoner in NOMIS are ok adequate to record a manual date against for unsupported types",
+    description = "This endpoint will validate that the data for the given prisoner in NOMIS is of sufficient quality " +
+      "to allow a manual date to be recorded via CRD",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Validation job has run successfully, the response indicates if there are any errors"),
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
+    ],
+  )
+  fun validateForManualEntry(
+    @Parameter(required = true, example = "A1234AB", description = "The prisoners ID (aka nomisId)")
+    @PathVariable("prisonerId")
+    prisonerId: String,
+  ): List<ValidationMessage> {
+    log.info("Request received to validate prisonerId for manual date entry $prisonerId")
+    val errorMessages = calculationTransactionalService.validateForManualBooking(prisonerId)
+    return errorMessages
+  }
+
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.Approved
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationOutcomeRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
@@ -504,6 +505,11 @@ class CalculationTransactionalService(
     } else {
       transform(calculationRequest)
     }
+  }
+
+  fun validateForManualBooking(prisonerId: String): List<ValidationMessage> {
+      val sourceData = prisonService.getPrisonApiSourceData(prisonerId, true)
+      return validationService.validateSentenceForManualEntry(sourceData.sentenceAndOffences)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -38,7 +38,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.Approved
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationOutcomeRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
@@ -508,8 +507,8 @@ class CalculationTransactionalService(
   }
 
   fun validateForManualBooking(prisonerId: String): List<ValidationMessage> {
-      val sourceData = prisonService.getPrisonApiSourceData(prisonerId, true)
-      return validationService.validateSentenceForManualEntry(sourceData.sentenceAndOffences)
+    val sourceData = prisonService.getPrisonApiSourceData(prisonerId, true)
+    return validationService.validateSentenceForManualEntry(sourceData.sentenceAndOffences)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
@@ -619,7 +619,9 @@ class ValidationService(
   }
 
   private fun validateWithoutOffenceDate(sentencesAndOffence: SentenceAndOffences): ValidationMessage? {
-    val invalid = sentencesAndOffence.offences.any { it.offenceEndDate == null || it.offenceStartDate == null }
+    // It's valid to not have an end date for many offence types, but the start date must always be present in
+    // either case. If an end date is null it will be set to the start date in the transformation.
+    val invalid = sentencesAndOffence.offences.any { it.offenceStartDate == null }
     if (invalid) {
       return ValidationMessage(OFFENCE_MISSING_DATE, getCaseSeqAndLineSeq(sentencesAndOffence))
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
@@ -318,7 +318,7 @@ class ValidationService(
     return validationMessages
   }
 
-  fun validateSentenceForManualEntry(sentences: List<SentenceAndOffences>): MutableList<ValidationMessage>{
+  fun validateSentenceForManualEntry(sentences: List<SentenceAndOffences>): MutableList<ValidationMessage> {
     return sentences.map { validateSentenceForManualEntry(it) }.flatten().toMutableList()
   }
 
@@ -406,7 +406,7 @@ class ValidationService(
 
   private fun validateSentenceForManualEntry(it: SentenceAndOffences): List<ValidationMessage> {
     return listOfNotNull(
-      validateWithoutOffenceDate(it)
+      validateWithoutOffenceDate(it),
     )
   }
 
@@ -619,7 +619,7 @@ class ValidationService(
   }
 
   private fun validateWithoutOffenceDate(sentencesAndOffence: SentenceAndOffences): ValidationMessage? {
-    val invalid = sentencesAndOffence.offences.any { it.offenceEndDate == null && it.offenceStartDate == null }
+    val invalid = sentencesAndOffence.offences.any { it.offenceEndDate == null || it.offenceStartDate == null }
     if (invalid) {
       return ValidationMessage(OFFENCE_MISSING_DATE, getCaseSeqAndLineSeq(sentencesAndOffence))
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationService.kt
@@ -318,6 +318,10 @@ class ValidationService(
     return validationMessages
   }
 
+  fun validateSentenceForManualEntry(sentences: List<SentenceAndOffences>): MutableList<ValidationMessage>{
+    return sentences.map { validateSentenceForManualEntry(it) }.flatten().toMutableList()
+  }
+
   private fun validateConsecutiveSentenceUnique(sentences: List<SentenceAndOffences>): List<ValidationMessage> {
     val consecutiveSentences = sentences.filter { it.consecutiveToSequence != null }
     val sentencesGroupedByConsecutiveTo = consecutiveSentences.groupBy { it.consecutiveToSequence }
@@ -397,6 +401,12 @@ class ValidationService(
       validateEdsSentenceTypesCorrectlyApplied(it),
       validateSopcSentenceTypesCorrectlyApplied(it),
       validateFineAmount(it),
+    )
+  }
+
+  private fun validateSentenceForManualEntry(it: SentenceAndOffences): List<ValidationMessage> {
+    return listOfNotNull(
+      validateWithoutOffenceDate(it)
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
@@ -159,14 +159,6 @@ class ValidationIntTest : IntegrationTestBase() {
   fun `Run validate for manual entry missing offence start date`() {
     runValidateForManualEntry(
       MISSING_OFFENCE_START_DATE_SENTENCE,
-       listOf(ValidationMessage(OFFENCE_MISSING_DATE, listOf("1", "1"))),
-    )
-  }
-
-  @Test
-  fun `Run validate for manual entry missing offence end date`() {
-    runValidateForManualEntry(
-      MISSING_OFFENCE_END_DATE_SENTENCE,
       listOf(ValidationMessage(OFFENCE_MISSING_DATE, listOf("1", "1"))),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Book
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.FixedTermRecallDetails
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderFinePayment
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ReturnToCustodyDate
@@ -101,6 +102,30 @@ class ValidationServiceTest {
     sentenceTypeDescription = "This is a sentence type",
     offences = listOf(),
   )
+  private val sentenceWithMissingOffenceDates = SentenceAndOffences(
+    bookingId = 1L,
+    sentenceSequence = 7,
+    lineSequence = LINE_SEQ,
+    caseSequence = CASE_SEQ,
+    sentenceDate = FIRST_MAY_2018,
+    terms = listOf(
+      SentenceTerms(5, 0, 0, 0, SentenceTerms.IMPRISONMENT_TERM_CODE),
+    ),
+    sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+    sentenceCategory = "2003",
+    sentenceStatus = "a",
+    sentenceTypeDescription = "This is a sentence type",
+    offences = listOf(
+      OffenderOffence(
+        offenderChargeId = 1L,
+        offenceStartDate = null,
+        offenceEndDate = null,
+        offenceCode = "Dummy Offence",
+        offenceDescription = "A Dummy description",
+      ),
+    ),
+  )
+
   private val validSopcSentence = validSdsSentence.copy(
     terms = listOf(
       SentenceTerms(5, 0, 0, 0, SentenceTerms.IMPRISONMENT_TERM_CODE),
@@ -1021,7 +1046,10 @@ class ValidationServiceTest {
   @Test
   fun `Test 14 day FTR sentence type and 28 day recall`() {
     val result = validationService.validateBeforeCalculation(
-      VALID_FTR_SOURCE_DATA.copy(sentenceAndOffences = listOf(FTR_14_DAY_SENTENCE), fixedTermRecallDetails = FTR_DETAILS_28),
+      VALID_FTR_SOURCE_DATA.copy(
+        sentenceAndOffences = listOf(FTR_14_DAY_SENTENCE),
+        fixedTermRecallDetails = FTR_DETAILS_28,
+      ),
       USER_INPUTS,
     )
 
@@ -1031,7 +1059,10 @@ class ValidationServiceTest {
   @Test
   fun `Test 28 day FTR sentence type and 14 day recall`() {
     val result = validationService.validateBeforeCalculation(
-      VALID_FTR_SOURCE_DATA.copy(sentenceAndOffences = listOf(FTR_28_DAY_SENTENCE), fixedTermRecallDetails = FTR_DETAILS_14),
+      VALID_FTR_SOURCE_DATA.copy(
+        sentenceAndOffences = listOf(FTR_28_DAY_SENTENCE),
+        fixedTermRecallDetails = FTR_DETAILS_14,
+      ),
       USER_INPUTS,
     )
 
@@ -1070,7 +1101,10 @@ class ValidationServiceTest {
       @Test
       fun `Test 14 day FTR sentence type and 28 day recall`() {
         val result = validationService.validateBeforeCalculation(
-          VALID_FTR_SOURCE_DATA.copy(sentenceAndOffences = listOf(FTR_14_DAY_SENTENCE), fixedTermRecallDetails = FTR_DETAILS_28),
+          VALID_FTR_SOURCE_DATA.copy(
+            sentenceAndOffences = listOf(FTR_14_DAY_SENTENCE),
+            fixedTermRecallDetails = FTR_DETAILS_28,
+          ),
           USER_INPUTS,
         )
 
@@ -1080,7 +1114,10 @@ class ValidationServiceTest {
       @Test
       fun `Test 28 day FTR sentence type and 14 day recall`() {
         val result = validationService.validateBeforeCalculation(
-          VALID_FTR_SOURCE_DATA.copy(sentenceAndOffences = listOf(FTR_28_DAY_SENTENCE), fixedTermRecallDetails = FTR_DETAILS_14),
+          VALID_FTR_SOURCE_DATA.copy(
+            sentenceAndOffences = listOf(FTR_28_DAY_SENTENCE),
+            fixedTermRecallDetails = FTR_DETAILS_14,
+          ),
           USER_INPUTS,
         )
 
@@ -1108,7 +1145,13 @@ class ValidationServiceTest {
         val result = validationService.validateBeforeCalculation(
           BOOKING.copy(
             fixedTermRecallDetails = FTR_DETAILS_28,
-            sentences = listOf(FTR_SDS_SENTENCE.copy(duration = NINE_MONTH_DURATION, identifier = UUID.randomUUID(), consecutiveSentenceUUIDs = emptyList())),
+            sentences = listOf(
+              FTR_SDS_SENTENCE.copy(
+                duration = NINE_MONTH_DURATION,
+                identifier = UUID.randomUUID(),
+                consecutiveSentenceUUIDs = emptyList(),
+              ),
+            ),
           ),
         )
 
@@ -1151,8 +1194,16 @@ class ValidationServiceTest {
 
       @Test
       fun `Test 14 day FTR sentence and aggregate duration greater than 12 months`() {
-        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_14, duration = FIVE_YEAR_DURATION, consecutiveSentenceUUIDs = emptyList())
-        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(identifier = UUID.randomUUID(), recallType = FIXED_TERM_RECALL_14, consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier))
+        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_14,
+          duration = FIVE_YEAR_DURATION,
+          consecutiveSentenceUUIDs = emptyList(),
+        )
+        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(
+          identifier = UUID.randomUUID(),
+          recallType = FIXED_TERM_RECALL_14,
+          consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier),
+        )
         consecutiveSentenceOne.sentenceCalculation = SENTENCE_CALCULATION
         consecutiveSentenceTwo.sentenceCalculation = SENTENCE_CALCULATION
         var workingBooking = BOOKING.copy(
@@ -1167,13 +1218,27 @@ class ValidationServiceTest {
           workingBooking,
         )
 
-        assertThat(result).isEqualTo(listOf(ValidationMessage(FTR_14_DAYS_AGGREGATE_GE_12_MONTHS), ValidationMessage(FTR_TYPE_14_DAYS_AGGREGATE_GE_12_MONTHS)))
+        assertThat(result).isEqualTo(
+          listOf(
+            ValidationMessage(FTR_14_DAYS_AGGREGATE_GE_12_MONTHS),
+            ValidationMessage(FTR_TYPE_14_DAYS_AGGREGATE_GE_12_MONTHS),
+          ),
+        )
       }
 
       @Test
       fun `Test 28 day FTR sentence and aggregate duration less than 12 months`() {
-        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_14, duration = ONE_MONTH_DURATION, consecutiveSentenceUUIDs = emptyList())
-        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_14, identifier = UUID.randomUUID(), duration = ONE_MONTH_DURATION, consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier))
+        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_14,
+          duration = ONE_MONTH_DURATION,
+          consecutiveSentenceUUIDs = emptyList(),
+        )
+        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_14,
+          identifier = UUID.randomUUID(),
+          duration = ONE_MONTH_DURATION,
+          consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier),
+        )
         consecutiveSentenceOne.sentenceCalculation = SENTENCE_CALCULATION
         consecutiveSentenceTwo.sentenceCalculation = SENTENCE_CALCULATION
         var workingBooking = BOOKING.copy(
@@ -1193,8 +1258,17 @@ class ValidationServiceTest {
 
       @Test
       fun `Test 28 day FTR type sentence and aggregate duration less than 12 months`() {
-        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_28, duration = ONE_MONTH_DURATION, consecutiveSentenceUUIDs = emptyList())
-        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_28, duration = ONE_MONTH_DURATION, identifier = UUID.randomUUID(), consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier))
+        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_28,
+          duration = ONE_MONTH_DURATION,
+          consecutiveSentenceUUIDs = emptyList(),
+        )
+        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_28,
+          duration = ONE_MONTH_DURATION,
+          identifier = UUID.randomUUID(),
+          consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier),
+        )
         consecutiveSentenceOne.sentenceCalculation = SENTENCE_CALCULATION
         consecutiveSentenceTwo.sentenceCalculation = SENTENCE_CALCULATION
         var workingBooking = BOOKING.copy(
@@ -1209,13 +1283,27 @@ class ValidationServiceTest {
           workingBooking,
         )
 
-        assertThat(result).isEqualTo(listOf(ValidationMessage(FTR_28_DAYS_AGGREGATE_LT_12_MONTHS), ValidationMessage(FTR_TYPE_28_DAYS_AGGREGATE_LT_12_MONTHS)))
+        assertThat(result).isEqualTo(
+          listOf(
+            ValidationMessage(FTR_28_DAYS_AGGREGATE_LT_12_MONTHS),
+            ValidationMessage(FTR_TYPE_28_DAYS_AGGREGATE_LT_12_MONTHS),
+          ),
+        )
       }
 
       @Test
       fun `Test 14 day aggregate Type sentence and aggregate duration greater than 12 months`() {
-        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_14, duration = ONE_MONTH_DURATION, consecutiveSentenceUUIDs = emptyList())
-        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(recallType = FIXED_TERM_RECALL_14, duration = FIVE_YEAR_DURATION, identifier = UUID.randomUUID(), consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier))
+        val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_14,
+          duration = ONE_MONTH_DURATION,
+          consecutiveSentenceUUIDs = emptyList(),
+        )
+        val consecutiveSentenceTwo = FTR_SDS_SENTENCE.copy(
+          recallType = FIXED_TERM_RECALL_14,
+          duration = FIVE_YEAR_DURATION,
+          identifier = UUID.randomUUID(),
+          consecutiveSentenceUUIDs = listOf(FTR_SDS_SENTENCE.identifier),
+        )
         consecutiveSentenceOne.sentenceCalculation = SENTENCE_CALCULATION
         consecutiveSentenceTwo.sentenceCalculation = SENTENCE_CALCULATION
         var workingBooking = BOOKING.copy(
@@ -1499,6 +1587,16 @@ class ValidationServiceTest {
     }
   }
 
+  //  fun validateSentenceForManualEntry(sentences: List<SentenceAndOffences>): MutableList<ValidationMessage>{
+  //    return sentences.map { validateSentenceForManualEntry(it) }.flatten().toMutableList()
+  //  }
+  @Test
+  fun `Test that a validation error is generated for sentences with missing offence dates when validating for manual entry`() {
+    val sentenceAndOffences = sentenceWithMissingOffenceDates.copy()
+    val result = validationService.validateSentenceForManualEntry(listOf(sentenceWithMissingOffenceDates))
+    assertThat(result).containsExactly(ValidationMessage(ValidationCode.OFFENCE_MISSING_DATE, listOf("1", "2")))
+  }
+
   fun createConsecutiveSentences(booking: Booking): Booking {
     val (baseSentences, consecutiveSentences) = booking.sentences.partition { it.consecutiveSentenceUUIDs.isEmpty() }
     val sentencesByPrevious = consecutiveSentences.groupBy {
@@ -1640,7 +1738,16 @@ class ValidationServiceTest {
       1,
       FIRST_MAY_2018,
       false,
-      Adjustments(mutableMapOf(REMAND to mutableListOf(Adjustment(numberOfDays = 1, appliesToSentencesFrom = FIRST_MAY_2018)))),
+      Adjustments(
+        mutableMapOf(
+          REMAND to mutableListOf(
+            Adjustment(
+              numberOfDays = 1,
+              appliesToSentencesFrom = FIRST_MAY_2018,
+            ),
+          ),
+        ),
+      ),
       FIRST_MAY_2018,
     )
     private val BOOKING = Booking(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
@@ -1587,9 +1587,6 @@ class ValidationServiceTest {
     }
   }
 
-  //  fun validateSentenceForManualEntry(sentences: List<SentenceAndOffences>): MutableList<ValidationMessage>{
-  //    return sentences.map { validateSentenceForManualEntry(it) }.flatten().toMutableList()
-  //  }
   @Test
   fun `Test that a validation error is generated for sentences with missing offence dates when validating for manual entry`() {
     val sentenceAndOffences = sentenceWithMissingOffenceDates.copy()

--- a/src/test/resources/test_data/api_integration/sentences/CRS-1634-no-offence-end-date.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-1634-no-offence-end-date.json
@@ -1,0 +1,35 @@
+[
+  {
+    "bookingId": 8202231,
+    "sentenceSequence": 1,
+    "lineSequence": 1,
+    "caseSequence": 1,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP_ORA",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-05-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 3,
+        "weeks": 0,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3932966,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "TH68007A",
+        "offenceDescription": "Attempt theft from motor vehicle",
+        "indicators": [
+          "D",
+          "50"
+        ]
+      }
+    ]
+  }
+]

--- a/src/test/resources/test_data/api_integration/sentences/CRS-1634-no-offence-start-date.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-1634-no-offence-start-date.json
@@ -1,0 +1,35 @@
+[
+  {
+    "bookingId": 9202231,
+    "sentenceSequence": 1,
+    "lineSequence": 1,
+    "caseSequence": 1,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP_ORA",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-05-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 3,
+        "weeks": 0,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3932966,
+        "offenceEndDate": "2022-05-04",
+        "offenceCode": "TH68007A",
+        "offenceDescription": "Attempt theft from motor vehicle",
+        "indicators": [
+          "D",
+          "50"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
* Add new controller endpoint for manual entry verification (Currently only validates the offence dates so that it can be successfully submitted back to NOMIS)
* Made the validation more understandable
* Bump the Jacoco plugin version to remove the sea of red when running tests