### PR TITLE
CRS-1848: Show that prisoner detail and offences are historic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationOriginalData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationOriginalData.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+
+data class CalculationOriginalData(
+  val prisonerDetails: PrisonerDetails?,
+  val sentencesAndOffences: List<SentenceAndOffences>?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DetailedCalculationResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DetailedCalculationResults.kt
@@ -1,15 +1,12 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 
 data class DetailedCalculationResults(
   val context: CalculationContext,
   val dates: Map<ReleaseDateType, DetailedDate>,
   val approvedDates: Map<ReleaseDateType, DetailedDate>?,
-  val prisonerDetails: PrisonerDetails?,
-  val sentencesAndOffences: List<SentenceAndOffences>?,
+  val calculationOriginalData: CalculationOriginalData,
   val calculationBreakdown: CalculationBreakdown?,
   val breakdownMissingReason: BreakdownMissingReason? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsService.kt
@@ -12,12 +12,14 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.Unsuppor
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BreakdownMissingReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationContext
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOriginalData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedCalculationResults
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 
 @Service
 @Transactional(readOnly = true)
+@Suppress("RedundantModalityModifier") // required for spring @Transactional
 open class DetailedCalculationResultsService(
   private val calculationTransactionalService: CalculationTransactionalService,
   private val prisonApiDataMapper: PrisonApiDataMapper,
@@ -61,8 +63,10 @@ open class DetailedCalculationResultsService(
       calculationContext(calculationRequestId, calculationRequest),
       calculationResultEnrichmentService.addDetailToCalculationDates(calculationRequest, calculationBreakdown),
       approvedDates(calculationRequest.approvedDatesSubmissions.firstOrNull()),
-      prisonerDetails,
-      sentenceAndOffences,
+      CalculationOriginalData(
+        prisonerDetails,
+        sentenceAndOffences,
+      ),
       calculationBreakdown,
       breakdownMissingReason,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedRel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationContext
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOriginalData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRequestModel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
@@ -321,8 +322,10 @@ class CalculationControllerTest {
       CalculationContext(calculationRequestId, 1, "A", CONFIRMED, UUID.randomUUID(), null, null, null, CalculationType.CALCULATED),
       dates = mapOf(),
       null,
-      null,
-      null,
+      CalculationOriginalData(
+        null,
+        null,
+      ),
       null,
     )
     whenever(detailedCalculationResultsService.findDetailedCalculationResults(calculationRequestId)).thenReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.Unsuppor
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BreakdownMissingReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationContext
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOriginalData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedCalculationResults
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
@@ -84,8 +85,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        prisonerDetails,
-        null,
+        CalculationOriginalData(
+          prisonerDetails,
+          null,
+        ),
         null,
         BreakdownMissingReason.PRISON_API_DATA_MISSING,
       ),
@@ -114,8 +117,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        null,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          null,
+          listOf(originalSentence),
+        ),
         null,
         BreakdownMissingReason.PRISON_API_DATA_MISSING,
       ),
@@ -145,8 +150,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        prisonerDetails,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          prisonerDetails,
+          listOf(originalSentence),
+        ),
         null,
         BreakdownMissingReason.PRISON_API_DATA_MISSING,
       ),
@@ -180,8 +187,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        prisonerDetails,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          prisonerDetails,
+          listOf(originalSentence),
+        ),
         null,
         BreakdownMissingReason.BREAKDOWN_CHANGED_SINCE_LAST_CALCULATION,
       ),
@@ -214,8 +223,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        prisonerDetails,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          prisonerDetails,
+          listOf(originalSentence),
+        ),
         null,
         BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN,
       ),
@@ -246,8 +257,10 @@ class DetailedCalculationResultsServiceTest {
         expectedCalcContext,
         enrichedReleaseDates,
         null,
-        prisonerDetails,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          prisonerDetails,
+          listOf(originalSentence),
+        ),
         expectedBreakdown,
         null,
       ),
@@ -309,8 +322,10 @@ class DetailedCalculationResultsServiceTest {
           ReleaseDateType.HDCAD to DetailedDate(ReleaseDateType.HDCAD, ReleaseDateType.HDCAD.description, LocalDate.of(2024, 1, 2), emptyList()),
           ReleaseDateType.ROTL to DetailedDate(ReleaseDateType.ROTL, ReleaseDateType.ROTL.description, LocalDate.of(2024, 1, 2), emptyList()),
         ),
-        prisonerDetails,
-        listOf(originalSentence),
+        CalculationOriginalData(
+          prisonerDetails,
+          listOf(originalSentence),
+        ),
         expectedBreakdown,
         null,
       ),


### PR DESCRIPTION
Minor model change to show that prisoner detail and sentence and offence information is that which was used to make the calculation and is not current.