### PR TITLE
CRS-1849: Latest calc model changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/LatestCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/LatestCalculation.kt
@@ -1,13 +1,12 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import java.time.LocalDateTime
 
 data class LatestCalculation(
   val prisonerId: String,
-  val calculatedAt: LocalDateTime?,
+  val calculatedAt: LocalDateTime,
   val location: String?,
   val reason: String,
   val source: CalculationSource,
-  val dates: Map<ReleaseDateType, DetailedDate>,
+  val dates: List<DetailedDate>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/OffenderKeyDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/OffenderKeyDates.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class OffenderKeyDates(
   val reasonCode: String,
+  val calculatedAt: LocalDateTime,
   val comment: String? = null,
   val homeDetentionCurfewEligibilityDate: LocalDate? = null,
   val earlyTermDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDa
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
-import java.time.LocalDateTime
 
 @Component
 class LatestCalculationService(
@@ -43,7 +42,6 @@ class LatestCalculationService(
             null,
             null,
             null,
-            null,
           )
         } else {
           val calculationRequest = latestCrdsCalc.get()
@@ -58,7 +56,6 @@ class LatestCalculationService(
             prisonerId,
             prisonerCalculation,
             calculationRequest.reasonForCalculation?.displayName ?: prisonerCalculation.reasonCode,
-            calculationRequest.calculatedAt,
             location,
             sentenceAndOffences,
             breakdown,
@@ -92,7 +89,6 @@ class LatestCalculationService(
     prisonerId: String,
     prisonerCalculation: OffenderKeyDates,
     reason: String,
-    calculatedAt: LocalDateTime?,
     location: String?,
     sentenceAndOffences: List<SentenceAndOffences>?,
     breakdown: CalculationBreakdown?,
@@ -121,11 +117,11 @@ class LatestCalculationService(
     )
     return LatestCalculation(
       prisonerId,
-      calculatedAt,
+      prisonerCalculation.calculatedAt,
       location,
       reason,
       calculationSource,
-      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown),
+      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown).values.toList(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -367,7 +367,7 @@ class CalculationControllerTest {
       "HMP Belfast",
       "Other",
       CalculationSource.CRDS,
-      mapOf(ReleaseDateType.CRD to DetailedDate(ReleaseDateType.CRD, ReleaseDateType.CRD.description, LocalDate.of(2024, 1, 1), emptyList())),
+      listOf(DetailedDate(ReleaseDateType.CRD, ReleaseDateType.CRD.description, LocalDate.of(2024, 1, 1), emptyList())),
     )
 
     whenever(latestCalculationService.latestCalculationForPrisoner(prisonerId)).thenReturn(expected.right())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
@@ -21,6 +21,8 @@ import java.time.LocalDateTime
 
 class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService) : IntegrationTestBase() {
 
+  private val now = LocalDateTime.now()
+
   @BeforeEach
   fun setUp() {
     mockPrisonService.withInstAgencies(
@@ -36,7 +38,7 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
     val bookingId = 123456L
     val prisonerId = "ABC123"
     val prisonerDetails = PrisonerDetails(bookingId, prisonerId, "Joe", "Bloggs", LocalDate.of(1970, 1, 1))
-    val offenderKeyDates = OffenderKeyDates("NEW", "From NOMIS", conditionalReleaseDate = LocalDate.of(2030, 1, 6), sentenceExpiryDate = LocalDate.of(2025, 2, 14))
+    val offenderKeyDates = OffenderKeyDates("NEW", now, "From NOMIS", conditionalReleaseDate = LocalDate.of(2030, 1, 6), sentenceExpiryDate = LocalDate.of(2025, 2, 14))
     stubPrisoner(prisonerDetails)
     stubKeyDates(bookingId, offenderKeyDates)
 
@@ -53,13 +55,13 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
     assertThat(latestCalculation).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
-        mapOf(
-          ReleaseDateType.SED to DetailedDate(ReleaseDateType.SED, ReleaseDateType.SED.description, LocalDate.of(2025, 2, 14), emptyList()),
-          ReleaseDateType.CRD to DetailedDate(
+        listOf(
+          DetailedDate(ReleaseDateType.SED, ReleaseDateType.SED.description, LocalDate.of(2025, 2, 14), emptyList()),
+          DetailedDate(
             ReleaseDateType.CRD,
             ReleaseDateType.CRD.description,
             LocalDate.of(2030, 1, 6),
@@ -84,6 +86,7 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
 
     val offenderKeyDates = OffenderKeyDates(
       "NEW",
+      now,
       "From CRDS: ${confirmed.calculationReference}",
       conditionalReleaseDate = LocalDate.of(2016, 1, 6),
       topupSupervisionExpiryDate = LocalDate.of(2017, 1, 6),
@@ -113,13 +116,13 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
         "",
         "Initial calculation",
         CalculationSource.CRDS,
-        mapOf(
-          ReleaseDateType.SLED to DetailedDate(ReleaseDateType.SLED, ReleaseDateType.SLED.description, LocalDate.of(2016, 11, 6), emptyList()),
-          ReleaseDateType.SED to DetailedDate(ReleaseDateType.SED, ReleaseDateType.SED.description, LocalDate.of(2016, 11, 6), emptyList()),
-          ReleaseDateType.LED to DetailedDate(ReleaseDateType.LED, ReleaseDateType.LED.description, LocalDate.of(2016, 11, 6), emptyList()),
-          ReleaseDateType.HDCED to DetailedDate(ReleaseDateType.HDCED, ReleaseDateType.HDCED.description, LocalDate.of(2015, 8, 7), emptyList()),
-          ReleaseDateType.CRD to DetailedDate(ReleaseDateType.CRD, ReleaseDateType.CRD.description, LocalDate.of(2016, 1, 6), emptyList()),
-          ReleaseDateType.TUSED to DetailedDate(ReleaseDateType.TUSED, ReleaseDateType.TUSED.description, LocalDate.of(2017, 1, 6), emptyList()),
+        listOf(
+          DetailedDate(ReleaseDateType.SLED, ReleaseDateType.SLED.description, LocalDate.of(2016, 11, 6), emptyList()),
+          DetailedDate(ReleaseDateType.SED, ReleaseDateType.SED.description, LocalDate.of(2016, 11, 6), emptyList()),
+          DetailedDate(ReleaseDateType.LED, ReleaseDateType.LED.description, LocalDate.of(2016, 11, 6), emptyList()),
+          DetailedDate(ReleaseDateType.CRD, ReleaseDateType.CRD.description, LocalDate.of(2016, 1, 6), emptyList()),
+          DetailedDate(ReleaseDateType.HDCED, ReleaseDateType.HDCED.description, LocalDate.of(2015, 8, 7), emptyList()),
+          DetailedDate(ReleaseDateType.TUSED, ReleaseDateType.TUSED.description, LocalDate.of(2017, 1, 6), emptyList()),
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
@@ -51,6 +51,7 @@ class LatestCalculationServiceTest {
     "Smith",
     LocalDate.of(1970, 1, 1),
   )
+  private val now = LocalDateTime.now()
 
   @Test
   fun `should return a problem if could not load prisoner details`() {
@@ -90,17 +91,17 @@ class LatestCalculationServiceTest {
   @Test
   fun `if there are no CRDS calcs then return as NOMIS`() {
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW").right())
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW", calculatedAt = now).right())
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
-        emptyMap(),
+        emptyList(),
       ).right(),
     )
   }
@@ -108,17 +109,17 @@ class LatestCalculationServiceTest {
   @Test
   fun `Should use the NOMIS calculation if the comment doesn't contain the CRDS calc reference`() {
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW", comment = "Not this one").right())
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW", calculatedAt = now, comment = "Not this one").right())
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(CalculationRequest(calculationReference = UUID.randomUUID())))
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
-        emptyMap(),
+        emptyList(),
       ).right(),
     )
   }
@@ -126,17 +127,17 @@ class LatestCalculationServiceTest {
   @Test
   fun `Should use the NOMIS calculation if the comment is null`() {
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW").right())
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW", calculatedAt = now).right())
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(CalculationRequest(calculationReference = UUID.randomUUID())))
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
-        emptyMap(),
+        emptyList(),
       ).right(),
     )
   }
@@ -144,17 +145,17 @@ class LatestCalculationServiceTest {
   @Test
   fun `Should use the NOMIS reason code for reason if it's set`() {
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW").right())
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(OffenderKeyDates(reasonCode = "NEW", calculatedAt = now).right())
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(CalculationRequest(calculationReference = UUID.randomUUID())))
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
-        emptyMap(),
+        emptyList(),
       ).right(),
     )
   }
@@ -184,6 +185,7 @@ class LatestCalculationServiceTest {
         tariffExpiredRemovalSchemeEligibilityDate = LocalDate.of(2025, 1, 18),
         dtoPostRecallReleaseDate = LocalDate.of(2025, 1, 19),
         reasonCode = "NEW",
+        calculatedAt = now,
       ).right(),
     )
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
@@ -210,12 +212,12 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 18), ReleaseDateType.TERSED),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
@@ -232,6 +234,7 @@ class LatestCalculationServiceTest {
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
         licenceExpiryDate = LocalDate.of(2025, 1, 1),
         reasonCode = "NEW",
+        calculatedAt = now,
       ).right(),
     )
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
@@ -242,12 +245,12 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.LED),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
-        null,
+        now,
         null,
         "NEW",
         CalculationSource.NOMIS,
@@ -268,6 +271,7 @@ class LatestCalculationServiceTest {
         licenceExpiryDate = LocalDate.of(2025, 1, 2),
         conditionalReleaseDate = LocalDate.of(2025, 1, 7),
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
       ).right(),
     )
@@ -287,7 +291,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 7), ReleaseDateType.CRD),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
@@ -312,6 +316,7 @@ class LatestCalculationServiceTest {
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
         licenceExpiryDate = LocalDate.of(2025, 1, 1),
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
       ).right(),
     )
@@ -331,7 +336,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.LED),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
 
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
@@ -356,6 +361,7 @@ class LatestCalculationServiceTest {
     whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
       OffenderKeyDates(
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
       ).right(),
@@ -368,7 +374,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
@@ -392,6 +398,7 @@ class LatestCalculationServiceTest {
     whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
       OffenderKeyDates(
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
       ).right(),
@@ -404,7 +411,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
     )
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
@@ -428,6 +435,7 @@ class LatestCalculationServiceTest {
     whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
       OffenderKeyDates(
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
       ).right(),
@@ -440,7 +448,7 @@ class LatestCalculationServiceTest {
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), expectedBreakdown)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), expectedBreakdown)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
@@ -463,6 +471,7 @@ class LatestCalculationServiceTest {
     whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
       OffenderKeyDates(
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
       ).right(),
@@ -474,7 +483,7 @@ class LatestCalculationServiceTest {
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), null)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), null)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
@@ -497,6 +506,7 @@ class LatestCalculationServiceTest {
     whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
       OffenderKeyDates(
         reasonCode = "NEW",
+        calculatedAt = calculatedAt,
         comment = "Some stuff and then the ref: $calculationReference",
         sentenceExpiryDate = LocalDate.of(2025, 1, 1),
       ).right(),
@@ -508,7 +518,7 @@ class LatestCalculationServiceTest {
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
     val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, expectedBreakdown)).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, expectedBreakdown)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
@@ -538,5 +548,5 @@ class LatestCalculationServiceTest {
     offences = listOf(OffenderOffence(1L, LocalDate.of(2015, 1, 1), null, "ADIMP_ORA", "description", listOf("A"))),
   )
 
-  private fun toDetailedDates(dates: List<ReleaseDate>): Map<ReleaseDateType, DetailedDate> = dates.map { DetailedDate(it.type, it.type.description, it.date, emptyList()) }.associateBy { it.type }
+  private fun toDetailedDates(dates: List<ReleaseDate>): List<DetailedDate> = dates.map { DetailedDate(it.type, it.type.description, it.date, emptyList()) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.UserContext
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.MockPrisonService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
+import java.time.LocalDateTime
 
 class PrisonApiClientIntTest(private val mockPrisonService: MockPrisonService) : IntegrationTestBase() {
 
@@ -36,11 +37,11 @@ class PrisonApiClientIntTest(private val mockPrisonService: MockPrisonService) :
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withBody("""{ "reasonCode": "NEW" }""")
+            .withBody("""{ "reasonCode": "NEW", "calculatedAt": "2025-01-02T10:30:00" }""")
             .withStatus(200),
         ),
     )
-    assertThat(prisonApiClient.getOffenderKeyDates(bookingId)).isEqualTo(OffenderKeyDates("NEW").right())
+    assertThat(prisonApiClient.getOffenderKeyDates(bookingId)).isEqualTo(OffenderKeyDates("NEW", LocalDateTime.of(2025, 1, 2, 10, 30, 0)).right())
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
@@ -58,7 +58,7 @@ class PrisonServiceTest {
   @Test
   fun `should get offender key dates`() {
     val bookingId = 123456L
-    val expected = OffenderKeyDates(reasonCode = "NEW")
+    val expected = OffenderKeyDates(reasonCode = "NEW", calculatedAt = LocalDateTime.now())
     whenever(prisonApiClient.getOffenderKeyDates(bookingId)).thenReturn(expected.right())
     val keyDates = prisonService.getOffenderKeyDates(bookingId)
     assertThat(keyDates).isEqualTo(expected.right())


### PR DESCRIPTION
Remove use of map and just use a list as this is to present all dates rather than pick specific dates. This preserves the order of dates as well. Make calculatedAt mandatory in line with latest prison API.