### PR TITLE
CRS-1849: Add booking id to latest calc API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/LatestCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/LatestCalculation.kt
@@ -4,8 +4,9 @@ import java.time.LocalDateTime
 
 data class LatestCalculation(
   val prisonerId: String,
+  val bookingId: Long,
   val calculatedAt: LocalDateTime,
-  val location: String?,
+  val establishment: String?,
   val reason: String,
   val source: CalculationSource,
   val dates: List<DetailedDate>,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationControllerTest.kt
@@ -363,6 +363,7 @@ class CalculationControllerTest {
     val prisonerId = "ABC123"
     val expected = LatestCalculation(
       prisonerId,
+      123456,
       LocalDateTime.now(),
       "HMP Belfast",
       "Other",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
@@ -55,6 +55,7 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
     assertThat(latestCalculation).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -112,6 +113,7 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
     assertThat(latestCalculation.copy(calculatedAt = calculatedAtOverrideForComparison)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAtOverrideForComparison,
         "",
         "Initial calculation",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
@@ -97,6 +97,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -115,6 +116,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -133,6 +135,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -151,6 +154,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -217,6 +221,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -250,6 +255,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         now,
         null,
         "NEW",
@@ -296,6 +302,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         null,
         "Some reason",
@@ -342,6 +349,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         null,
         "Some reason",
@@ -379,6 +387,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         "HMP ABC",
         "NEW",
@@ -416,6 +425,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         "XYZ",
         "NEW",
@@ -452,6 +462,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         "HMP ABC",
         "NEW",
@@ -487,6 +498,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         "HMP ABC",
         "NEW",
@@ -522,6 +534,7 @@ class LatestCalculationServiceTest {
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
       LatestCalculation(
         prisonerId,
+        bookingId,
         calculatedAt,
         "HMP ABC",
         "NEW",


### PR DESCRIPTION
This is required to be able to link into the view journey which requires prisoner id and booking id.