### PR TITLE
Bump Prod pod mem limits

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,6 +16,12 @@ generic-service:
 
   serviceAccountName: calculate-release-dates-api-prod
 
+  resources:
+  requests:
+    memory: 2G
+  limits:
+    memory: 4G
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,10 +17,10 @@ generic-service:
   serviceAccountName: calculate-release-dates-api-prod
 
   resources:
-  requests:
-    memory: 2G
-  limits:
-    memory: 4G
+    requests:
+      memory: 2G
+    limits:
+      memory: 4G
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
* Apply pod memory limit bump that was made on preprod to prevent bulk calc pods from being culled when they reached the 1GB limit.
