### PR TITLE
CRS-1849: hide SED and LED if we can create a SLED

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
@@ -99,10 +99,11 @@ class LatestCalculationService(
     sentenceAndOffences: List<SentenceAndOffences>?,
     breakdown: CalculationBreakdown?,
   ): LatestCalculation {
+    val sled = createASLEDIfWeCan(prisonerCalculation)
     val dates = listOfNotNull(
-      createASLEDIfWeCan(prisonerCalculation),
-      prisonerCalculation.sentenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.SED) },
-      prisonerCalculation.licenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.LED) },
+      sled,
+      if (sled != null) null else prisonerCalculation.sentenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.SED) },
+      if (sled != null) null else prisonerCalculation.licenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.LED) },
       prisonerCalculation.conditionalReleaseDate?.let { ReleaseDate(it, ReleaseDateType.CRD) },
       prisonerCalculation.automaticReleaseDate?.let { ReleaseDate(it, ReleaseDateType.ARD) },
       prisonerCalculation.homeDetentionCurfewEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.HDCED) },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationIntTest.kt
@@ -122,8 +122,6 @@ class LatestCalculationIntTest(private val mockPrisonService: MockPrisonService)
         CalculationSource.CRDS,
         listOf(
           DetailedDate(ReleaseDateType.SLED, ReleaseDateType.SLED.description, LocalDate.of(2016, 11, 6), emptyList()),
-          DetailedDate(ReleaseDateType.SED, ReleaseDateType.SED.description, LocalDate.of(2016, 11, 6), emptyList()),
-          DetailedDate(ReleaseDateType.LED, ReleaseDateType.LED.description, LocalDate.of(2016, 11, 6), emptyList()),
           DetailedDate(ReleaseDateType.CRD, ReleaseDateType.CRD.description, LocalDate.of(2016, 1, 6), emptyList()),
           DetailedDate(ReleaseDateType.HDCED, ReleaseDateType.HDCED.description, LocalDate.of(2015, 8, 7), emptyList()),
           DetailedDate(ReleaseDateType.TUSED, ReleaseDateType.TUSED.description, LocalDate.of(2017, 1, 6), emptyList()),


### PR DESCRIPTION
Was showing SLED, LED and SED all at once. Only show the SED and LED if they are not the same or are missing. If they are the same only show SLED.