### PR TITLE
CRS-1882: HDCED hint should use next working day instead of previous

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
@@ -80,9 +80,12 @@ class CalculationResultEnrichmentService(
     if (type !in typesAllowedWeekendAdjustment || date.isBefore(LocalDate.now(clock))) {
       return null
     }
-    val previousWorkingDay = workingDayService.previousWorkingDay(date)
-    return if (previousWorkingDay.date != date) {
-      ReleaseDateHint("${previousWorkingDay.date.format(longFormat)} when adjusted to a working day")
+    val adjustedToWorkingDay = when (type) {
+      ReleaseDateType.HDCED -> workingDayService.nextWorkingDay(date)
+      else -> workingDayService.previousWorkingDay(date)
+    }
+    return if (adjustedToWorkingDay.date != date) {
+      ReleaseDateHint("${adjustedToWorkingDay.date.format(longFormat)} when adjusted to a working day")
     } else {
       null
     }


### PR DESCRIPTION
When a HDCED falls on a weekend or bank holiday the weekend adjustment hint text should show the date of the next working day. Other date types remain on previous working day.