### PR TITLE
Display Past Nomis Calculations on Calculate release dates app

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/HistoricCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/HistoricCalculation.kt
@@ -15,4 +15,5 @@ data class HistoricCalculation(
   val establishment: String?,
   val calculationRequestId: Long?,
   val calculationReason: String?,
+  val offenderSentCalculationId: Long?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisCalculationSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisCalculationSummary.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import java.time.LocalDateTime
+
+data class NomisCalculationSummary(val reason: String, val calculatedAt: LocalDateTime, val comment: String? = null, val releaseDates: List<DetailedDate>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserQuestions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedCalculationResults
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.LatestCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationSummary
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
@@ -37,10 +38,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Pris
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ReturnToCustodyDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationBreakdownService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationResultEnrichmentService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationTransactionalService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.CalculationUserQuestionService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.DetailedCalculationResultsService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.LatestCalculationService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.RelevantRemandService
 
 @RestController
@@ -53,6 +56,8 @@ class CalculationController(
   private val detailedCalculationResultsService: DetailedCalculationResultsService,
   private val latestCalculationService: LatestCalculationService,
   private val calculationBreakdownService: CalculationBreakdownService,
+  private val prisonService: PrisonService,
+  private val calculationResultEnrichmentService: CalculationResultEnrichmentService,
 ) {
   @PostMapping(value = ["/{prisonerId}"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
@@ -447,6 +452,35 @@ class CalculationController(
     log.info("Request received return latest calculation for prisoner {}", prisonerId)
     val result = latestCalculationService.latestCalculationForPrisoner(prisonerId)
     return result.getOrElse { problemMessage -> throw CrdWebException(problemMessage, HttpStatus.NOT_FOUND) }
+  }
+
+  @GetMapping(value = ["/nomis-calculation-summary/{offenderSentCalculationId}"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
+  @ResponseBody
+  @Operation(
+    summary = "Get Nomis calculation summary with release dates for a offenderSentCalculationId",
+    description = "This endpoint will return the nomis calculation summary with release dates based on a offenderSentCalculationId",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Returns Nomis calculation summary with release dates based on a offenderSentCalculationId"),
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
+      ApiResponse(responseCode = "404", description = "No nomis calculation summary - release dates exists for this offenderSentCalculationId"),
+    ],
+  )
+  fun getNomisCalculationSummary(
+    @Parameter(required = true, example = "123456", description = "The offenderSentCalculationId of the offender booking or a calculation")
+    @PathVariable("offenderSentCalculationId")
+    offenderSentCalculationId: Long,
+  ): NomisCalculationSummary {
+    log.info("Request received to get offender key dates for $offenderSentCalculationId")
+    val nomisOffenderKeyDates = prisonService.getNOMISOffenderKeyDates(offenderSentCalculationId)
+      .getOrElse { problemMessage -> throw CrdWebException(problemMessage, HttpStatus.NOT_FOUND) }
+    val releaseDatesForSentCalculationId = latestCalculationService.releaseDates(nomisOffenderKeyDates)
+    val detailsReleaseDates = calculationResultEnrichmentService.addDetailToCalculationDates(releaseDatesForSentCalculationId, null, null).values.toList()
+    val nomisReason = prisonService.getNOMISCalcReasons().find { it.code == nomisOffenderKeyDates.reasonCode }?.description ?: nomisOffenderKeyDates.reasonCode
+    return NomisCalculationSummary(nomisReason, nomisOffenderKeyDates.calculatedAt, nomisOffenderKeyDates.comment, detailsReleaseDates)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
@@ -33,7 +33,11 @@ class CalculationResultEnrichmentService(
     private val dtoSentenceTypes = listOf(SentenceCalculationType.DTO_ORA.name, SentenceCalculationType.DTO.name)
   }
 
-  fun addDetailToCalculationDates(releaseDates: List<ReleaseDate>, sentenceAndOffences: List<SentenceAndOffences>?, calculationBreakdown: CalculationBreakdown?): Map<ReleaseDateType, DetailedDate> {
+  fun addDetailToCalculationDates(
+    releaseDates: List<ReleaseDate>,
+    sentenceAndOffences: List<SentenceAndOffences>?,
+    calculationBreakdown: CalculationBreakdown?,
+  ): Map<ReleaseDateType, DetailedDate> {
     val releaseDatesMap = releaseDates.associateBy { it.type }
     return releaseDatesMap.mapValues { (_, releaseDate) ->
       DetailedDate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HistoricCalculationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HistoricCalculationsService.kt
@@ -36,7 +36,7 @@ class HistoricCalculationsService(
           calculationReason = calculation.reasonForCalculation?.displayName
         }
       }
-      HistoricCalculation(prisonerId, nomisCalculation.calculationDate, source, calculationViewData, nomisCalculation.commentText, calculationType, establishment, calculationRequestId, calculationReason)
+      HistoricCalculation(prisonerId, nomisCalculation.calculationDate, source, calculationViewData, nomisCalculation.commentText, calculationType, establishment, calculationRequestId, calculationReason, nomisCalculation.offenderSentCalculationId)
     }
     return historicCalculations
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
@@ -100,6 +100,20 @@ class LatestCalculationService(
     sentenceAndOffences: List<SentenceAndOffences>?,
     breakdown: CalculationBreakdown?,
   ): LatestCalculation {
+    val dates = releaseDates(prisonerCalculation)
+    return LatestCalculation(
+      prisonerId,
+      bookingId,
+      prisonerCalculation.calculatedAt,
+      calculationReference,
+      location,
+      reason,
+      calculationSource,
+      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown).values.toList(),
+    )
+  }
+
+  fun releaseDates(prisonerCalculation: OffenderKeyDates): List<ReleaseDate> {
     val sled = createASLEDIfWeCan(prisonerCalculation)
     val dates = listOfNotNull(
       sled,
@@ -123,16 +137,7 @@ class LatestCalculationService(
       prisonerCalculation.tariffDate?.let { ReleaseDate(it, ReleaseDateType.Tariff) },
       prisonerCalculation.tariffExpiredRemovalSchemeEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.TERSED) },
     )
-    return LatestCalculation(
-      prisonerId,
-      bookingId,
-      prisonerCalculation.calculatedAt,
-      calculationReference,
-      location,
-      reason,
-      calculationSource,
-      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown).values.toList(),
-    )
+    return dates
   }
 
   private fun createASLEDIfWeCan(prisonerCalculation: OffenderKeyDates): ReleaseDate? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
@@ -9,18 +9,17 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.LatestCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 
 @Component
 class LatestCalculationService(
   private val prisonService: PrisonService,
+  private val offenderKeyDatesService: OffenderKeyDatesService,
   private val calculationRequestRepository: CalculationRequestRepository,
   private val calculationResultEnrichmentService: CalculationResultEnrichmentService,
   private val calculationBreakdownService: CalculationBreakdownService,
@@ -100,7 +99,7 @@ class LatestCalculationService(
     sentenceAndOffences: List<SentenceAndOffences>?,
     breakdown: CalculationBreakdown?,
   ): LatestCalculation {
-    val dates = releaseDates(prisonerCalculation)
+    val dates = offenderKeyDatesService.releaseDates(prisonerCalculation)
     return LatestCalculation(
       prisonerId,
       bookingId,
@@ -111,40 +110,5 @@ class LatestCalculationService(
       calculationSource,
       calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown).values.toList(),
     )
-  }
-
-  fun releaseDates(prisonerCalculation: OffenderKeyDates): List<ReleaseDate> {
-    val sled = createASLEDIfWeCan(prisonerCalculation)
-    val dates = listOfNotNull(
-      sled,
-      if (sled != null) null else prisonerCalculation.sentenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.SED) },
-      if (sled != null) null else prisonerCalculation.licenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.LED) },
-      prisonerCalculation.conditionalReleaseDate?.let { ReleaseDate(it, ReleaseDateType.CRD) },
-      prisonerCalculation.automaticReleaseDate?.let { ReleaseDate(it, ReleaseDateType.ARD) },
-      prisonerCalculation.homeDetentionCurfewEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.HDCED) },
-      prisonerCalculation.topupSupervisionExpiryDate?.let { ReleaseDate(it, ReleaseDateType.TUSED) },
-      prisonerCalculation.postRecallReleaseDate?.let { ReleaseDate(it, ReleaseDateType.PRRD) },
-      prisonerCalculation.paroleEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.PED) },
-      prisonerCalculation.releaseOnTemporaryLicenceDate?.let { ReleaseDate(it, ReleaseDateType.ROTL) },
-      prisonerCalculation.earlyRemovalSchemeEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.ERSED) },
-      prisonerCalculation.homeDetentionCurfewApprovedDate?.let { ReleaseDate(it, ReleaseDateType.HDCAD) },
-      prisonerCalculation.midTermDate?.let { ReleaseDate(it, ReleaseDateType.MTD) },
-      prisonerCalculation.earlyTermDate?.let { ReleaseDate(it, ReleaseDateType.ETD) },
-      prisonerCalculation.lateTermDate?.let { ReleaseDate(it, ReleaseDateType.LTD) },
-      prisonerCalculation.approvedParoleDate?.let { ReleaseDate(it, ReleaseDateType.APD) },
-      prisonerCalculation.nonParoleDate?.let { ReleaseDate(it, ReleaseDateType.NPD) },
-      prisonerCalculation.dtoPostRecallReleaseDate?.let { ReleaseDate(it, ReleaseDateType.DPRRD) },
-      prisonerCalculation.tariffDate?.let { ReleaseDate(it, ReleaseDateType.Tariff) },
-      prisonerCalculation.tariffExpiredRemovalSchemeEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.TERSED) },
-    )
-    return dates
-  }
-
-  private fun createASLEDIfWeCan(prisonerCalculation: OffenderKeyDates): ReleaseDate? {
-    return if (prisonerCalculation.sentenceExpiryDate != null && prisonerCalculation.licenceExpiryDate != null && prisonerCalculation.sentenceExpiryDate == prisonerCalculation.licenceExpiryDate) {
-      ReleaseDate(prisonerCalculation.sentenceExpiryDate, ReleaseDateType.SLED)
-    } else {
-      null
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesService.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+import arrow.core.getOrElse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CrdWebException
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationSummary
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.CalculationController
+
+@Service
+@Transactional(readOnly = true)
+class OffenderKeyDatesService(
+  private val prisonService: PrisonService,
+  private val calculationResultEnrichmentService: CalculationResultEnrichmentService,
+) {
+
+  fun getNomisCalculationSummary(offenderSentCalculationId: Long): NomisCalculationSummary {
+    CalculationController.log.info("Request received to get offender key dates for $offenderSentCalculationId")
+    val nomisOffenderKeyDates = prisonService.getNOMISOffenderKeyDates(offenderSentCalculationId)
+      .getOrElse { problemMessage -> throw CrdWebException(problemMessage, HttpStatus.NOT_FOUND) }
+    val releaseDatesForSentCalculationId = releaseDates(nomisOffenderKeyDates)
+    val detailsReleaseDates = calculationResultEnrichmentService.addDetailToCalculationDates(releaseDatesForSentCalculationId, null, null).values.toList()
+    val nomisReason = prisonService.getNOMISCalcReasons().find { it.code == nomisOffenderKeyDates.reasonCode }?.description ?: nomisOffenderKeyDates.reasonCode
+    return NomisCalculationSummary(nomisReason, nomisOffenderKeyDates.calculatedAt, nomisOffenderKeyDates.comment, detailsReleaseDates)
+  }
+
+  private fun createASLEDIfWeCan(prisonerCalculation: OffenderKeyDates): ReleaseDate? {
+    return if (prisonerCalculation.sentenceExpiryDate != null && prisonerCalculation.licenceExpiryDate != null && prisonerCalculation.sentenceExpiryDate == prisonerCalculation.licenceExpiryDate) {
+      ReleaseDate(prisonerCalculation.sentenceExpiryDate, ReleaseDateType.SLED)
+    } else {
+      null
+    }
+  }
+
+  fun releaseDates(prisonerCalculation: OffenderKeyDates): List<ReleaseDate> {
+    val sled = createASLEDIfWeCan(prisonerCalculation)
+    val dates = listOfNotNull(
+      sled,
+      if (sled != null) null else prisonerCalculation.sentenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.SED) },
+      if (sled != null) null else prisonerCalculation.licenceExpiryDate?.let { ReleaseDate(it, ReleaseDateType.LED) },
+      prisonerCalculation.conditionalReleaseDate?.let { ReleaseDate(it, ReleaseDateType.CRD) },
+      prisonerCalculation.automaticReleaseDate?.let { ReleaseDate(it, ReleaseDateType.ARD) },
+      prisonerCalculation.homeDetentionCurfewEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.HDCED) },
+      prisonerCalculation.topupSupervisionExpiryDate?.let { ReleaseDate(it, ReleaseDateType.TUSED) },
+      prisonerCalculation.postRecallReleaseDate?.let { ReleaseDate(it, ReleaseDateType.PRRD) },
+      prisonerCalculation.paroleEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.PED) },
+      prisonerCalculation.releaseOnTemporaryLicenceDate?.let { ReleaseDate(it, ReleaseDateType.ROTL) },
+      prisonerCalculation.earlyRemovalSchemeEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.ERSED) },
+      prisonerCalculation.homeDetentionCurfewApprovedDate?.let { ReleaseDate(it, ReleaseDateType.HDCAD) },
+      prisonerCalculation.midTermDate?.let { ReleaseDate(it, ReleaseDateType.MTD) },
+      prisonerCalculation.earlyTermDate?.let { ReleaseDate(it, ReleaseDateType.ETD) },
+      prisonerCalculation.lateTermDate?.let { ReleaseDate(it, ReleaseDateType.LTD) },
+      prisonerCalculation.approvedParoleDate?.let { ReleaseDate(it, ReleaseDateType.APD) },
+      prisonerCalculation.nonParoleDate?.let { ReleaseDate(it, ReleaseDateType.NPD) },
+      prisonerCalculation.dtoPostRecallReleaseDate?.let { ReleaseDate(it, ReleaseDateType.DPRRD) },
+      prisonerCalculation.tariffDate?.let { ReleaseDate(it, ReleaseDateType.Tariff) },
+      prisonerCalculation.tariffExpiredRemovalSchemeEligibilityDate?.let { ReleaseDate(it, ReleaseDateType.TERSED) },
+    )
+    return dates
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
@@ -193,9 +193,9 @@ class PrisonApiClient(
       .exchangeToMono { response ->
         when (response.statusCode()) {
           HttpStatus.OK -> response.bodyToMono(typeReference<OffenderKeyDates>()).map { it.right() }
-          HttpStatus.NOT_FOUND -> Mono.just("Offender Key Dates  ($offenderSentCalcId) not found or has no calculations".left())
-          HttpStatus.FORBIDDEN -> Mono.just("User is not allowed to view the Offender Key Dates ($offenderSentCalcId)".left())
-          else -> Mono.just("Offender Key Dates ($offenderSentCalcId) could not be loaded for an unknown reason. Status ${response.statusCode().value()}".left())
+          HttpStatus.NOT_FOUND -> Mono.just("Offender Key Dates for offenderSentCalcId ($offenderSentCalcId) not found or has no calculations".left())
+          HttpStatus.FORBIDDEN -> Mono.just("User is not allowed to view the Offender Key Dates for offenderSentCalcId ($offenderSentCalcId)".left())
+          else -> Mono.just("Offender Key Dates for offenderSentCalcId ($offenderSentCalcId) could not be loaded for an unknown reason. Status ${response.statusCode().value()}".left())
         }
       }
       .block()!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClient.kt
@@ -183,4 +183,21 @@ class PrisonApiClient(
       .bodyToMono(typeReference<List<NomisCalculationReason>>())
       .block()!!
   }
+
+  fun getNOMISOffenderKeyDates(offenderSentCalcId: Long): Either<String, OffenderKeyDates> {
+    return webClient.get()
+      .uri { uriBuilder ->
+        uriBuilder.path("/api/offender-dates/sentence-calculation/$offenderSentCalcId")
+          .build()
+      }
+      .exchangeToMono { response ->
+        when (response.statusCode()) {
+          HttpStatus.OK -> response.bodyToMono(typeReference<OffenderKeyDates>()).map { it.right() }
+          HttpStatus.NOT_FOUND -> Mono.just("Offender Key Dates  ($offenderSentCalcId) not found or has no calculations".left())
+          HttpStatus.FORBIDDEN -> Mono.just("User is not allowed to view the Offender Key Dates ($offenderSentCalcId)".left())
+          else -> Mono.just("Offender Key Dates ($offenderSentCalcId) could not be loaded for an unknown reason. Status ${response.statusCode().value()}".left())
+        }
+      }
+      .block()!!
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonService.kt
@@ -103,4 +103,6 @@ class PrisonService(
 
   fun getOffenderKeyDates(bookingId: Long): Either<String, OffenderKeyDates> = prisonApiClient.getOffenderKeyDates(bookingId)
   fun getNOMISCalcReasons(): List<NomisCalculationReason> = prisonApiClient.getNOMISCalcReasons()
+
+  fun getNOMISOffenderKeyDates(offenderSentCalcId: Long): Either<String, OffenderKeyDates> = prisonApiClient.getNOMISOffenderKeyDates(offenderSentCalcId)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/HistoricCalculationsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/HistoricCalculationsControllerTest.kt
@@ -71,6 +71,7 @@ class HistoricCalculationsControllerTest {
       "Ranby (HMP)",
       48,
       "Adding more sentences or terms",
+      -1
     )
 
     whenever(historicCalculationsService.getHistoricCalculationsForPrisoner(anyString())).thenReturn(listOf(historicCalculation))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/HistoricCalculationsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/HistoricCalculationsControllerTest.kt
@@ -71,7 +71,7 @@ class HistoricCalculationsControllerTest {
       "Ranby (HMP)",
       48,
       "Adding more sentences or terms",
-      -1
+      -1,
     )
 
     whenever(historicCalculationsService.getHistoricCalculationsForPrisoner(anyString())).thenReturn(listOf(historicCalculation))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
@@ -32,7 +32,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 class LatestCalculationServiceTest {
 
@@ -41,7 +42,7 @@ class LatestCalculationServiceTest {
   private val calculationResultEnrichmentService: CalculationResultEnrichmentService = mock()
   private val calculationBreakdownService: CalculationBreakdownService = mock()
   private val prisonApiDataMapper: PrisonApiDataMapper = mock()
-  private val offenderKeyDatesService: OffenderKeyDatesService = OffenderKeyDatesService(prisonService, calculationResultEnrichmentService)
+  private val offenderKeyDatesService: OffenderKeyDatesService = mock()
   private val service = LatestCalculationService(prisonService, offenderKeyDatesService, calculationRequestRepository, calculationResultEnrichmentService, calculationBreakdownService, prisonApiDataMapper)
   private val objectMapper = TestUtil.objectMapper()
   private val prisonerId = "ABC123"
@@ -174,133 +175,21 @@ class LatestCalculationServiceTest {
   }
 
   @Test
-  fun `Should map all possible NOMIS dates`() {
-    whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getNOMISCalcReasons()).thenReturn(listOf(NomisCalculationReason("NEW", "New Sentence")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-        licenceExpiryDate = LocalDate.of(2025, 1, 2),
-        paroleEligibilityDate = LocalDate.of(2025, 1, 3),
-        homeDetentionCurfewEligibilityDate = LocalDate.of(2025, 1, 4),
-        homeDetentionCurfewApprovedDate = LocalDate.of(2025, 1, 5),
-        automaticReleaseDate = LocalDate.of(2025, 1, 6),
-        conditionalReleaseDate = LocalDate.of(2025, 1, 7),
-        nonParoleDate = LocalDate.of(2025, 1, 8),
-        postRecallReleaseDate = LocalDate.of(2025, 1, 9),
-        approvedParoleDate = LocalDate.of(2025, 1, 10),
-        topupSupervisionExpiryDate = LocalDate.of(2025, 1, 11),
-        earlyTermDate = LocalDate.of(2025, 1, 12),
-        midTermDate = LocalDate.of(2025, 1, 13),
-        lateTermDate = LocalDate.of(2025, 1, 14),
-        tariffDate = LocalDate.of(2025, 1, 15),
-        releaseOnTemporaryLicenceDate = LocalDate.of(2025, 1, 16),
-        earlyRemovalSchemeEligibilityDate = LocalDate.of(2025, 1, 17),
-        tariffExpiredRemovalSchemeEligibilityDate = LocalDate.of(2025, 1, 18),
-        dtoPostRecallReleaseDate = LocalDate.of(2025, 1, 19),
-        reasonCode = "NEW",
-        calculatedAt = now,
-      ).right(),
-    )
-    whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
-
-    val dates = listOf(
-      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
-      ReleaseDate(LocalDate.of(2025, 1, 2), ReleaseDateType.LED),
-      ReleaseDate(LocalDate.of(2025, 1, 7), ReleaseDateType.CRD),
-      ReleaseDate(LocalDate.of(2025, 1, 6), ReleaseDateType.ARD),
-      ReleaseDate(LocalDate.of(2025, 1, 4), ReleaseDateType.HDCED),
-      ReleaseDate(LocalDate.of(2025, 1, 11), ReleaseDateType.TUSED),
-      ReleaseDate(LocalDate.of(2025, 1, 9), ReleaseDateType.PRRD),
-      ReleaseDate(LocalDate.of(2025, 1, 3), ReleaseDateType.PED),
-      ReleaseDate(LocalDate.of(2025, 1, 16), ReleaseDateType.ROTL),
-      ReleaseDate(LocalDate.of(2025, 1, 17), ReleaseDateType.ERSED),
-      ReleaseDate(LocalDate.of(2025, 1, 5), ReleaseDateType.HDCAD),
-      ReleaseDate(LocalDate.of(2025, 1, 13), ReleaseDateType.MTD),
-      ReleaseDate(LocalDate.of(2025, 1, 12), ReleaseDateType.ETD),
-      ReleaseDate(LocalDate.of(2025, 1, 14), ReleaseDateType.LTD),
-      ReleaseDate(LocalDate.of(2025, 1, 10), ReleaseDateType.APD),
-      ReleaseDate(LocalDate.of(2025, 1, 8), ReleaseDateType.NPD),
-      ReleaseDate(LocalDate.of(2025, 1, 19), ReleaseDateType.DPRRD),
-      ReleaseDate(LocalDate.of(2025, 1, 15), ReleaseDateType.Tariff),
-      ReleaseDate(LocalDate.of(2025, 1, 18), ReleaseDateType.TERSED),
-    )
-    val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
-
-    assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
-      LatestCalculation(
-        prisonerId,
-        bookingId,
-        now,
-        null,
-        null,
-        "New Sentence",
-        CalculationSource.NOMIS,
-        detailedDates,
-      ).right(),
-    )
-  }
-
-  @Test
-  fun `Should replace SED and LED with SLED for NOMIS if SED and LED are the same`() {
-    whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-        licenceExpiryDate = LocalDate.of(2025, 1, 1),
-        reasonCode = "NEW",
-        calculatedAt = now,
-      ).right(),
-    )
-    whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
-
-    val dates = listOf(
-      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SLED),
-    )
-    val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
-    val generatedDates = service.latestCalculationForPrisoner(prisonerId).map { it.dates }.getOrNull()
-    assertThat(generatedDates).anyMatch { it.type == ReleaseDateType.SLED && it.date == LocalDate.of(2025, 1, 1) }
-    assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SED || it.type == ReleaseDateType.LED }
-  }
-
-  @Test
-  fun `Should not create SLED for NOMIS if SED and LED are both absent`() {
-    whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = now,
-      ).right(),
-    )
-    whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.empty())
-
-    val dates = listOf(
-      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SLED),
-    )
-    val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
-
-    assertThat(service.latestCalculationForPrisoner(prisonerId).map { it.dates }.getOrNull()).noneMatch { it.type == ReleaseDateType.SLED }
-  }
-
-  @Test
   fun `Should map CRDS additional fields into the results if the CRDS calc ref appears in the commend`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+      licenceExpiryDate = LocalDate.of(2025, 1, 2),
+      conditionalReleaseDate = LocalDate.of(2025, 1, 7),
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-        licenceExpiryDate = LocalDate.of(2025, 1, 2),
-        conditionalReleaseDate = LocalDate.of(2025, 1, 7),
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(
       Optional.of(
         CalculationRequest(
@@ -317,6 +206,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 2), ReleaseDateType.LED),
       ReleaseDate(LocalDate.of(2025, 1, 7), ReleaseDateType.CRD),
     )
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     val detailedDates = toDetailedDates(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
@@ -369,92 +259,20 @@ class LatestCalculationServiceTest {
   }
 
   @Test
-  fun `Should create SLED for CRDS if LED and SED are the same`() {
-    val calculationReference = UUID.randomUUID()
-    val calculatedAt = LocalDateTime.now()
-
-    whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-        licenceExpiryDate = LocalDate.of(2025, 1, 1),
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-      ).right(),
-    )
-    whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(
-      Optional.of(
-        CalculationRequest(
-          id = 654321,
-          calculationReference = calculationReference,
-          calculatedAt = calculatedAt,
-          reasonForCalculation = CalculationReason(0, false, false, "Some reason", false, null, null, null),
-        ),
-      ),
-    )
-
-    val dates = listOf(
-      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SLED),
-    )
-    val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
-    whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
-
-    val generatedDates = service.latestCalculationForPrisoner(prisonerId).map { it.dates }.getOrNull()
-    assertThat(generatedDates).anyMatch { it.type == ReleaseDateType.SLED && it.date == LocalDate.of(2025, 1, 1) }
-    assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SED || it.type == ReleaseDateType.LED }
-  }
-
-  @Test
-  fun `Should not create SLED for CRDS if SED and LED are both absent`() {
-    val calculationReference = UUID.randomUUID()
-    val calculatedAt = LocalDateTime.now()
-    whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
-    whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-      ).right(),
-    )
-    whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(
-      Optional.of(
-        CalculationRequest(
-          id = 654321,
-          calculationReference = calculationReference,
-          calculatedAt = calculatedAt,
-          reasonForCalculation = CalculationReason(0, false, false, "Some reason", false, null, null, null),
-        ),
-      ),
-    )
-    whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
-
-    val dates = listOf(
-      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SLED),
-    )
-    val detailedDates = toDetailedDates(dates)
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
-
-    assertThat(service.latestCalculationForPrisoner(prisonerId).map { it.dates }.getOrNull()).noneMatch { it.type == ReleaseDateType.SLED }
-  }
-
-  @Test
   fun `Should lookup the location if there is one set on CRDS`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
     whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(
       Optional.of(CalculationRequest(id = 654321, calculationReference = calculationReference, calculatedAt = calculatedAt, prisonerLocation = "ABC")),
     )
@@ -462,6 +280,7 @@ class LatestCalculationServiceTest {
     val dates = listOf(
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
     )
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     val detailedDates = toDetailedDates(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
@@ -483,17 +302,17 @@ class LatestCalculationServiceTest {
   fun `Should default to location code if it's not in agency lookup`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
     whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(
       Optional.of(CalculationRequest(id = 654321, calculationReference = calculationReference, calculatedAt = calculatedAt, prisonerLocation = "XYZ")),
     )
@@ -502,6 +321,7 @@ class LatestCalculationServiceTest {
       ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
     )
     val detailedDates = toDetailedDates(dates)
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, null)).thenReturn(detailedDates.associateBy { it.type })
     whenever(calculationBreakdownService.getBreakdownSafely(any())).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
@@ -522,17 +342,17 @@ class LatestCalculationServiceTest {
   fun `Should pass breakdown and sentences and offences for CRDS`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
     whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     val calculationRequest = CalculationRequest(id = 654321, calculationReference = calculationReference, calculatedAt = calculatedAt, prisonerLocation = "ABC", sentenceAndOffences = objectToJson(listOf(someSentence), objectMapper))
     val expectedBreakdown = CalculationBreakdown(emptyList(), null)
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(calculationRequest))
@@ -540,6 +360,7 @@ class LatestCalculationServiceTest {
     whenever(prisonApiDataMapper.mapSentencesAndOffences(calculationRequest)).thenReturn(listOf(someSentence))
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     val detailedDates = toDetailedDates(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), expectedBreakdown)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
@@ -560,23 +381,24 @@ class LatestCalculationServiceTest {
   fun `Should not blow up if breakdown can't be generated for CRDS`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
     whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     val calculationRequest = CalculationRequest(id = 654321, calculationReference = calculationReference, calculatedAt = calculatedAt, prisonerLocation = "ABC", sentenceAndOffences = objectToJson(listOf(someSentence), objectMapper))
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(calculationRequest))
     whenever(calculationBreakdownService.getBreakdownSafely(calculationRequest)).thenReturn(BreakdownMissingReason.UNSUPPORTED_CALCULATION_BREAKDOWN.left())
     whenever(prisonApiDataMapper.mapSentencesAndOffences(calculationRequest)).thenReturn(listOf(someSentence))
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     val detailedDates = toDetailedDates(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, listOf(someSentence), null)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(
@@ -597,23 +419,24 @@ class LatestCalculationServiceTest {
   fun `Should not blow up if sentences and offences are missing for CRDS`() {
     val calculationReference = UUID.randomUUID()
     val calculatedAt = LocalDateTime.now()
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "NEW",
+      calculatedAt = calculatedAt,
+      comment = "Some stuff and then the ref: $calculationReference",
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+    )
 
     whenever(prisonService.getOffenderDetail(prisonerId)).thenReturn(prisonerDetails)
     whenever(prisonService.getAgenciesByType("INST")).thenReturn(listOf(Agency("ABC", "HMP ABC")))
-    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(
-      OffenderKeyDates(
-        reasonCode = "NEW",
-        calculatedAt = calculatedAt,
-        comment = "Some stuff and then the ref: $calculationReference",
-        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
-      ).right(),
-    )
+    whenever(prisonService.getOffenderKeyDates(bookingId)).thenReturn(offenderKeyDates.right())
+
     val calculationRequest = CalculationRequest(id = 654321, calculationReference = calculationReference, calculatedAt = calculatedAt, prisonerLocation = "ABC", sentenceAndOffences = null)
     val expectedBreakdown = CalculationBreakdown(emptyList(), null)
     whenever(calculationRequestRepository.findLatestConfirmedCalculationForPrisoner(prisonerId)).thenReturn(Optional.of(calculationRequest))
     whenever(calculationBreakdownService.getBreakdownSafely(calculationRequest)).thenReturn(expectedBreakdown.right())
 
     val dates = listOf(ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED))
+    whenever(offenderKeyDatesService.releaseDates(offenderKeyDates)).thenReturn(dates)
     val detailedDates = toDetailedDates(dates)
     whenever(calculationResultEnrichmentService.addDetailToCalculationDates(dates, null, expectedBreakdown)).thenReturn(detailedDates.associateBy { it.type })
     assertThat(service.latestCalculationForPrisoner(prisonerId)).isEqualTo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationServiceTest.kt
@@ -41,7 +41,8 @@ class LatestCalculationServiceTest {
   private val calculationResultEnrichmentService: CalculationResultEnrichmentService = mock()
   private val calculationBreakdownService: CalculationBreakdownService = mock()
   private val prisonApiDataMapper: PrisonApiDataMapper = mock()
-  private val service = LatestCalculationService(prisonService, calculationRequestRepository, calculationResultEnrichmentService, calculationBreakdownService, prisonApiDataMapper)
+  private val offenderKeyDatesService: OffenderKeyDatesService = OffenderKeyDatesService(prisonService, calculationResultEnrichmentService)
+  private val service = LatestCalculationService(prisonService, offenderKeyDatesService, calculationRequestRepository, calculationResultEnrichmentService, calculationBreakdownService, prisonApiDataMapper)
   private val objectMapper = TestUtil.objectMapper()
   private val prisonerId = "ABC123"
   private val bookingId = 123456L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import arrow.core.left
+import arrow.core.right
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CrdWebException
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationReason
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationSummary
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+open class OffenderKeyDatesServiceTest {
+
+  @Mock
+  lateinit var calculationResultEnrichmentService: CalculationResultEnrichmentService
+
+  @Mock
+  lateinit var prisonService: PrisonService
+
+  @InjectMocks
+  lateinit var underTest: OffenderKeyDatesService
+
+  @Test
+  fun `Test getting NomisCalculationSummary for offenderSentCalcId successfully`() {
+    val offenderSentCalcId = 5636121L
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "FS",
+      calculatedAt = LocalDateTime.of(2024, 2, 29, 10, 30),
+      comment = null,
+      homeDetentionCurfewEligibilityDate = LocalDate.of(2024, 1, 1),
+    )
+    val expected = NomisCalculationSummary(
+      "Further Sentence",
+      LocalDateTime.of(2024, 2, 29, 10, 30),
+      null,
+      listOf(
+        DetailedDate(
+          ReleaseDateType.HDCED,
+          ReleaseDateType.HDCED.description,
+          LocalDate.of(2024, 1, 1),
+          emptyList(),
+        ),
+      ),
+    )
+
+    val detailedDates = mapOf(ReleaseDateType.HDCED to DetailedDate(ReleaseDateType.HDCED, ReleaseDateType.HDCED.description, LocalDate.of(2024, 1, 1), emptyList()))
+
+    whenever(prisonService.getNOMISOffenderKeyDates(any())).thenReturn(offenderKeyDates.right())
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull())).thenReturn(detailedDates)
+    whenever(prisonService.getNOMISCalcReasons()).thenReturn(listOf(NomisCalculationReason(code = "FS", description = "Further Sentence")))
+
+    val result = underTest.getNomisCalculationSummary(offenderSentCalcId)
+
+    Assertions.assertThat(result.reason).isEqualTo(expected.reason)
+    Assertions.assertThat(result.calculatedAt).isEqualTo(expected.calculatedAt)
+    Assertions.assertThat(result.comment).isEqualTo(expected.comment)
+    Assertions.assertThat(result.releaseDates).isEqualTo(expected.releaseDates)
+  }
+
+  @Test
+  fun `Test NomisCalculationSummary not existing code reason code`() {
+    val offenderSentCalcId = 5636121L
+    val offenderKeyDates = OffenderKeyDates(
+      reasonCode = "FS",
+      calculatedAt = LocalDateTime.of(2024, 2, 29, 10, 30),
+      comment = null,
+    )
+
+    whenever(prisonService.getNOMISOffenderKeyDates(any())).thenReturn(offenderKeyDates.right())
+
+    val result = underTest.getNomisCalculationSummary(offenderSentCalcId)
+
+    Assertions.assertThat(result.reason).isEqualTo("FS")
+  }
+
+  @Test
+  fun `Test NomisCalculationSummary for exception scenario`() {
+    val offenderSentCalcId = 5636121L
+    val errorMessage = "There isn't one"
+
+    whenever(prisonService.getNOMISOffenderKeyDates(any())).thenReturn(errorMessage.left())
+
+    val exception = assertThrows<CrdWebException> {
+      underTest.getNomisCalculationSummary(offenderSentCalcId)
+    }
+
+    Assertions.assertThat(exception.message).isEqualTo(errorMessage)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationSummary
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -33,6 +34,8 @@ open class OffenderKeyDatesServiceTest {
 
   @InjectMocks
   lateinit var underTest: OffenderKeyDatesService
+
+  private val now = LocalDateTime.now()
 
   @Test
   fun `Test getting NomisCalculationSummary for offenderSentCalcId successfully`() {
@@ -99,5 +102,104 @@ open class OffenderKeyDatesServiceTest {
     }
 
     Assertions.assertThat(exception.message).isEqualTo(errorMessage)
+  }
+
+  @Test
+  fun `Should replace SED and LED with SLED if SED and LED are the same`() {
+    val offenderKeyDates = OffenderKeyDates(
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+      licenceExpiryDate = LocalDate.of(2025, 1, 1),
+      reasonCode = "NEW",
+      calculatedAt = now,
+    )
+
+    val generatedDates = underTest.releaseDates(offenderKeyDates)
+
+    Assertions.assertThat(generatedDates).anyMatch { it.type == ReleaseDateType.SLED && it.date == LocalDate.of(2025, 1, 1) }
+    Assertions.assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SED || it.type == ReleaseDateType.LED }
+  }
+
+  @Test
+  fun `Should create SED and LED and not SLED if SED and LED are the different`() {
+    val offenderKeyDates = OffenderKeyDates(
+      sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+      licenceExpiryDate = LocalDate.of(2026, 1, 1),
+      reasonCode = "NEW",
+      calculatedAt = now,
+    )
+
+    val generatedDates = underTest.releaseDates(offenderKeyDates)
+
+    Assertions.assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SLED }
+    Assertions.assertThat(generatedDates).anyMatch { it.type == ReleaseDateType.SED && it.date == LocalDate.of(2025, 1, 1) }
+    Assertions.assertThat(generatedDates).anyMatch { it.type == ReleaseDateType.LED && it.date == LocalDate.of(2026, 1, 1) }
+  }
+
+  @Test
+  fun `Should not create SLED if SED and LED are both absent`() {
+    val offenderKeyDates =
+      OffenderKeyDates(
+        reasonCode = "NEW",
+        calculatedAt = now,
+      )
+
+    val generatedDates = underTest.releaseDates(offenderKeyDates)
+
+    Assertions.assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SLED }
+    Assertions.assertThat(generatedDates).noneMatch { it.type == ReleaseDateType.SED || it.type == ReleaseDateType.LED }
+  }
+
+  @Test
+  fun `Should map all possible NOMIS dates`() {
+    val offenderKeyDates =
+      OffenderKeyDates(
+        sentenceExpiryDate = LocalDate.of(2025, 1, 1),
+        licenceExpiryDate = LocalDate.of(2025, 1, 2),
+        paroleEligibilityDate = LocalDate.of(2025, 1, 3),
+        homeDetentionCurfewEligibilityDate = LocalDate.of(2025, 1, 4),
+        homeDetentionCurfewApprovedDate = LocalDate.of(2025, 1, 5),
+        automaticReleaseDate = LocalDate.of(2025, 1, 6),
+        conditionalReleaseDate = LocalDate.of(2025, 1, 7),
+        nonParoleDate = LocalDate.of(2025, 1, 8),
+        postRecallReleaseDate = LocalDate.of(2025, 1, 9),
+        approvedParoleDate = LocalDate.of(2025, 1, 10),
+        topupSupervisionExpiryDate = LocalDate.of(2025, 1, 11),
+        earlyTermDate = LocalDate.of(2025, 1, 12),
+        midTermDate = LocalDate.of(2025, 1, 13),
+        lateTermDate = LocalDate.of(2025, 1, 14),
+        tariffDate = LocalDate.of(2025, 1, 15),
+        releaseOnTemporaryLicenceDate = LocalDate.of(2025, 1, 16),
+        earlyRemovalSchemeEligibilityDate = LocalDate.of(2025, 1, 17),
+        tariffExpiredRemovalSchemeEligibilityDate = LocalDate.of(2025, 1, 18),
+        dtoPostRecallReleaseDate = LocalDate.of(2025, 1, 19),
+        reasonCode = "NEW",
+        calculatedAt = now,
+      )
+
+    val dates = listOf(
+      ReleaseDate(LocalDate.of(2025, 1, 1), ReleaseDateType.SED),
+      ReleaseDate(LocalDate.of(2025, 1, 2), ReleaseDateType.LED),
+      ReleaseDate(LocalDate.of(2025, 1, 7), ReleaseDateType.CRD),
+      ReleaseDate(LocalDate.of(2025, 1, 6), ReleaseDateType.ARD),
+      ReleaseDate(LocalDate.of(2025, 1, 4), ReleaseDateType.HDCED),
+      ReleaseDate(LocalDate.of(2025, 1, 11), ReleaseDateType.TUSED),
+      ReleaseDate(LocalDate.of(2025, 1, 9), ReleaseDateType.PRRD),
+      ReleaseDate(LocalDate.of(2025, 1, 3), ReleaseDateType.PED),
+      ReleaseDate(LocalDate.of(2025, 1, 16), ReleaseDateType.ROTL),
+      ReleaseDate(LocalDate.of(2025, 1, 17), ReleaseDateType.ERSED),
+      ReleaseDate(LocalDate.of(2025, 1, 5), ReleaseDateType.HDCAD),
+      ReleaseDate(LocalDate.of(2025, 1, 13), ReleaseDateType.MTD),
+      ReleaseDate(LocalDate.of(2025, 1, 12), ReleaseDateType.ETD),
+      ReleaseDate(LocalDate.of(2025, 1, 14), ReleaseDateType.LTD),
+      ReleaseDate(LocalDate.of(2025, 1, 10), ReleaseDateType.APD),
+      ReleaseDate(LocalDate.of(2025, 1, 8), ReleaseDateType.NPD),
+      ReleaseDate(LocalDate.of(2025, 1, 19), ReleaseDateType.DPRRD),
+      ReleaseDate(LocalDate.of(2025, 1, 15), ReleaseDateType.Tariff),
+      ReleaseDate(LocalDate.of(2025, 1, 18), ReleaseDateType.TERSED),
+    )
+
+    val result = underTest.releaseDates(offenderKeyDates)
+
+    Assertions.assertThat(dates).isEqualTo(result)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
+import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
@@ -11,11 +12,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.UserContext
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CrdWebException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.MockPrisonService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculationReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class PrisonApiClientIntTest(private val mockPrisonService: MockPrisonService) : IntegrationTestBase() {
@@ -84,5 +88,42 @@ class PrisonApiClientIntTest(private val mockPrisonService: MockPrisonService) :
         NomisCalculationReason("UPDATE", "Modify Sentence"),
       ),
     )
+  }
+
+  @Test
+  fun `can get offender release dates by offenderSentCalcId`() {
+    mockPrisonService.withStub(
+      get("/api/offender-dates/sentence-calculation/-1")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              """{
+                      "dtoPostRecallReleaseDate": "2020-03-22",
+                      "conditionalReleaseDate": "2019-05-24",
+                      "sentenceExpiryDate": "2020-03-24",
+                      "effectiveSentenceEndDate": "2025-05-05",
+                      "tariffExpiredRemovalSchemeEligibilityDate": "2020-06-25",
+                      "approvedParoleDate": "2018-09-27",
+                      "comment": "Some Comment Text",
+                      "reasonCode": "NEW",
+                      "calculatedAt": "2017-08-28T00:00:00"
+                  }""",
+            ),
+        ),
+    )
+    // when
+    val offenderKeyDates = prisonApiClient.getNOMISOffenderKeyDates(-1)
+      .getOrElse { problemMessage -> throw CrdWebException(problemMessage, HttpStatus.NOT_FOUND) }
+    assertThat(offenderKeyDates.calculatedAt).isEqualTo(LocalDateTime.of(2017, 8, 28, 0, 0))
+    assertThat(offenderKeyDates.reasonCode).isEqualTo("NEW")
+    assertThat(offenderKeyDates.comment).isEqualTo("Some Comment Text")
+    assertThat(offenderKeyDates.approvedParoleDate).isEqualTo(LocalDate.of(2018, 9, 27))
+    assertThat(offenderKeyDates.tariffExpiredRemovalSchemeEligibilityDate).isEqualTo(LocalDate.of(2020, 6, 25))
+    assertThat(offenderKeyDates.effectiveSentenceEndDate).isEqualTo(LocalDate.of(2025, 5, 5))
+    assertThat(offenderKeyDates.sentenceExpiryDate).isEqualTo(LocalDate.of(2020, 3, 24))
+    assertThat(offenderKeyDates.conditionalReleaseDate).isEqualTo(LocalDate.of(2019, 5, 24))
+    assertThat(offenderKeyDates.dtoPostRecallReleaseDate).isEqualTo(LocalDate.of(2020, 3, 22))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
@@ -64,6 +64,15 @@ class PrisonServiceTest {
     assertThat(keyDates).isEqualTo(expected.right())
   }
 
+  @Test
+  fun `should get offender key dates by using offender sent calc id`() {
+    val offenderSentCalcId = 123456L
+    val expected = OffenderKeyDates(reasonCode = "NEW", calculatedAt = LocalDateTime.now())
+    whenever(prisonApiClient.getNOMISOffenderKeyDates(offenderSentCalcId)).thenReturn(expected.right())
+    val keyDates = prisonService.getNOMISOffenderKeyDates(offenderSentCalcId)
+    assertThat(keyDates).isEqualTo(expected.right())
+  }
+
   companion object {
     private val mapper = ObjectMapper()
 


### PR DESCRIPTION
This update is necessary to present historical NOMIS calculations to the front-end application - Calculate Release Dates App. - https://dsdmoj.atlassian.net/browse/CRS-1877

Details of the Changes:  
1. The /historicCalculations endpoint in CRDAPI is utilized to display the history records of NOMIS and CRD Calculations.
    The offenderSentCalculationId is added to the response, enabling the front-end to call the CRD-Api to fetch the corresponding NOMIS record for NOMIS entries.

2. The /calculation/nomis-calculation-summary/{offenderSentCalculationId} endpoint is introduced to fetch the NOMIS Record from the Prison API. 
This endpoint has been added and merged in this PR and is deployed to Dev - https://github.com/ministryofjustice/prison-api/pull/2110

3. A minor refactoring in LatestCalculationService.kt has been done where the offenderKeyDates building function is extracted to a "releaseDates" function. This makes the rules for SED/LED/SLED and other logic reusable.

This change is backwards compatible and can be deployed independently. 
A separate PR will be raised for the Calculate Release Dates App to utilize the new endpoint.