### PR TITLE
CRS-1794: make all username fields 240 chars

### DIFF
--- a/src/main/resources/migration/common/V50__extend_length_of_user_fields.sql
+++ b/src/main/resources/migration/common/V50__extend_length_of_user_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE comparison_person_discrepancy ALTER COLUMN created_by TYPE VARCHAR(240);
+ALTER TABLE calculation_request ALTER COLUMN calculated_by_username TYPE VARCHAR(240);
+ALTER TABLE comparison ALTER COLUMN calculated_by_username TYPE VARCHAR(240);
+ALTER TABLE comparison_person ALTER COLUMN calculated_by_username TYPE VARCHAR(240);
+ALTER TABLE approved_dates_submission ALTER COLUMN submitted_by_username TYPE VARCHAR(240);


### PR DESCRIPTION
Username can by up to 240 according to hmpss-auth schema. In reality, it will probably not be this big as it should only be a staff id for NOMIS users or a UUID for systems however custom users can be created such as CRD_TEST_USER which breaks the usual pattern.