### PR TITLE
CRS-1940: Indicate SDS+ status at sentence level

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AnalyzedSentenceAndOffences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AnalyzedSentenceAndOffences.kt
@@ -22,4 +22,5 @@ data class AnalyzedSentenceAndOffences(
   val courtDescription: String? = null,
   val fineAmount: BigDecimal? = null,
   val sentenceAndOffenceAnalysis: SentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.SAME,
+  val isSDSPlus: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PrisonApiDataVersions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PrisonApiDataVersions.kt
@@ -22,7 +22,7 @@ class PrisonApiDataVersions {
       val days: Int = 0,
       val offences: List<OffenderOffence> = emptyList(),
     ) {
-      fun toLatest() = uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences(
+      fun toLatest() = SentenceAndOffences(
         bookingId,
         sentenceSequence,
         lineSequence,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SentenceAndOffences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SentenceAndOffences.kt
@@ -19,4 +19,5 @@ data class SentenceAndOffences(
   val caseReference: String? = null,
   val courtDescription: String? = null,
   val fineAmount: BigDecimal? = null,
+  var isSdsPlus: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupService.kt
@@ -44,6 +44,7 @@ class OffenceSdsPlusLookupService(
     val offencesToCheck = getOffenceCodesToCheckWithMO(bookingIdToSentences)
     val bookingToSentenceOffenceMap = mutableMapOf<Long, List<SentenceAndOffences>>()
 
+    sentencesAndOffences.forEach { it.isSdsPlus = false }
     if (offencesToCheck.isNotEmpty()) {
       val moCheckResponses = manageOffencesService.getPcscMarkersForOffenceCodes(*offencesToCheck.toTypedArray()).associateBy { it.offenceCode }
 
@@ -69,6 +70,7 @@ class OffenceSdsPlusLookupService(
               }
               .forEach { offence ->
                 offence.indicators = offence.indicators.plus(listOf(OffenderOffence.PCSC_SDS_PLUS))
+                sentenceAndOffence.isSdsPlus = true
 
                 if (bookingToSentenceOffenceMap.contains(sentenceAndOffence.bookingId)) {
                   bookingToSentenceOffenceMap[sentenceAndOffence.bookingId]?.plus(sentenceAndOffence)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceService.kt
@@ -25,11 +25,11 @@ class SentenceAndOffenceService(
       }
       val lastSentenceAndOffences: List<SentenceAndOffences> = objectMapper.readValue(it.sentenceAndOffences.toString())
       if (sentencesAndOffences == lastSentenceAndOffences) {
-        return@map transform(SentenceAndOffenceAnalysis.SAME, sentencesAndOffences)
+        transform(SentenceAndOffenceAnalysis.SAME, sentencesAndOffences)
       } else {
         val sentencesAndOffencesBySequence = sentencesAndOffences.associateBy { sentenceAndOffences -> "${sentenceAndOffences.caseSequence}-${sentenceAndOffences.sentenceSequence}" }
         val lastSentencesAndOffencesBySequence = lastSentenceAndOffences.associateBy { sentenceAndOffences -> "${sentenceAndOffences.caseSequence}-${sentenceAndOffences.sentenceSequence}" }
-        return@map sentencesAndOffencesBySequence.map { (key: String, value: SentenceAndOffences) ->
+        sentencesAndOffencesBySequence.map { (key: String, value: SentenceAndOffences) ->
           if (lastSentencesAndOffencesBySequence.containsKey(key)) {
             if (value.offences == lastSentencesAndOffencesBySequence[key]!!.offences) {
               transform(SentenceAndOffenceAnalysis.SAME, value)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -862,5 +862,6 @@ fun transform(
     sentenceAndOffences.courtDescription,
     sentenceAndOffences.fineAmount,
     sentenceAndOffenceAnalysis,
+    sentenceAndOffences.isSdsPlus!!,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSdsPlusLookupServiceTest.kt
@@ -29,6 +29,7 @@ class OffenceSdsPlusLookupServiceTest {
     assertTrue(returnedResult.size == 1)
     assertTrue(sentencedAfterSDSPlusBeforePCSCLongerThan7Years[0].offences[0].isPcscSdsPlus)
     assertTrue(sentencedAfterSDSPlusBeforePCSCLongerThan7Years[0].offences[0].isScheduleFifteenMaximumLife)
+    assertTrue(sentencedAfterSDSPlusBeforePCSCLongerThan7Years[0].isSdsPlus!!)
   }
 
   @Test
@@ -37,6 +38,7 @@ class OffenceSdsPlusLookupServiceTest {
     underTest.populateSdsPlusMarkerForOffences(sentencedADIMPAfterPCSCLongerThan7Years)
     assertTrue(sentencedADIMPAfterPCSCLongerThan7Years[0].offences[0].isPcscSdsPlus)
     assertTrue(sentencedADIMPAfterPCSCLongerThan7Years[0].offences[0].isPcscSds)
+    assertTrue(sentencedADIMPAfterPCSCLongerThan7Years[0].isSdsPlus!!)
   }
 
   @Test
@@ -44,6 +46,7 @@ class OffenceSdsPlusLookupServiceTest {
     whenever(mockManageOffencesService.getPcscMarkersForOffenceCodes(any())).thenReturn(listOf(pcscListBMarkers))
     underTest.populateSdsPlusMarkerForOffences(sentencedYOIORAAfterPCSCLonger4To7Years)
     assertTrue(sentencedYOIORAAfterPCSCLonger4To7Years[0].offences[0].isPcscSdsPlus)
+    assertTrue(sentencedYOIORAAfterPCSCLonger4To7Years[0].isSdsPlus!!)
   }
 
   @Test
@@ -52,6 +55,7 @@ class OffenceSdsPlusLookupServiceTest {
     underTest.populateSdsPlusMarkerForOffences(section250Over7YearsPostPCSCSentence)
     assertTrue(section250Over7YearsPostPCSCSentence[0].offences[0].isPcscSdsPlus)
     assertTrue(section250Over7YearsPostPCSCSentence[0].offences[0].isPcscSec250)
+    assertTrue(section250Over7YearsPostPCSCSentence[0].isSdsPlus!!)
   }
 
   @Test
@@ -63,6 +67,7 @@ class OffenceSdsPlusLookupServiceTest {
     underTest.populateSdsPlusMarkerForOffences(section250Over7YearsPrePCSCSentence)
     assertFalse(section250Over7YearsPrePCSCSentence[0].offences[0].isPcscSdsPlus)
     assertFalse(section250Over7YearsPrePCSCSentence[0].offences[0].isPcscSec250)
+    assertFalse(section250Over7YearsPrePCSCSentence[0].isSdsPlus!!)
   }
 
   @Test
@@ -72,6 +77,7 @@ class OffenceSdsPlusLookupServiceTest {
     verify(mockManageOffencesService, times(0)).getPcscMarkersForOffenceCodes(any())
     assertFalse(sentenceMatchesNoMatchingOffencesDueToSentenceDate[0].offences[0].isPcscSdsPlus)
     assertFalse(sentenceMatchesNoMatchingOffencesDueToSentenceDate[0].offences[0].isPcscSec250)
+    assertFalse(sentenceMatchesNoMatchingOffencesDueToSentenceDate[0].isSdsPlus!!)
   }
 
   companion object {


### PR DESCRIPTION
Add new flag on sentence to show its SDS plus. This should replace the use of individual offence level indicators in a future change.