### PR TITLE
CRS-1942: Fix SDS early release exclusion markers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SDSEarlyReleaseExclusionForOffenceCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SDSEarlyReleaseExclusionForOffenceCode.kt
@@ -4,5 +4,5 @@ data class SDSEarlyReleaseExclusionForOffenceCode(val offenceCode: String, val s
 enum class SDSEarlyReleaseExclusionSchedulePart {
   SEXUAL,
   VIOLENT,
-  NO,
+  NONE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupService.kt
@@ -161,7 +161,7 @@ class OffenceSDSReleaseArrangementLookupService(
     return when (exclusionsForOffences[sentenceAndOffence.offence.offenceCode]!!.schedulePart) {
       SDSEarlyReleaseExclusionSchedulePart.SEXUAL -> SDSEarlyReleaseExclusionType.SEXUAL
       SDSEarlyReleaseExclusionSchedulePart.VIOLENT -> if (fourYearsOrMore(sentenceAndOffence)) SDSEarlyReleaseExclusionType.VIOLENT else SDSEarlyReleaseExclusionType.NO
-      SDSEarlyReleaseExclusionSchedulePart.NO -> SDSEarlyReleaseExclusionType.NO
+      SDSEarlyReleaseExclusionSchedulePart.NONE -> SDSEarlyReleaseExclusionType.NO
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -197,7 +197,7 @@ class ManageOffencesMockServer : WireMockServer(WIREMOCK_PORT) {
                 {{#each request.query.offenceCodes as |offenceCode|}}
                 {
                     "offenceCode": "{{{offenceCode}}}",
-                    "schedulePart": "NO"
+                    "schedulePart": "NONE"
                 }{{#if @last}}{{else}},{{/if}}
                 {{/each}}
             ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesApiClientIntTest.kt
@@ -37,7 +37,7 @@ class ManageOffencesApiClientIntTest(private val mockManageOffencesClient: MockM
               """[
                 {
                     "offenceCode": "N01",
-                    "schedulePart": "NO"
+                    "schedulePart": "NONE"
                 },
                 {
                     "offenceCode": "S01",
@@ -57,7 +57,7 @@ class ManageOffencesApiClientIntTest(private val mockManageOffencesClient: MockM
     assertThat(manageOffencesApiClient.getSexualOrViolentForOffenceCodes(listOf("S01", "V01", "N01")))
       .isEqualTo(
         listOf(
-          SDSEarlyReleaseExclusionForOffenceCode("N01", SDSEarlyReleaseExclusionSchedulePart.NO),
+          SDSEarlyReleaseExclusionForOffenceCode("N01", SDSEarlyReleaseExclusionSchedulePart.NONE),
           SDSEarlyReleaseExclusionForOffenceCode("S01", SDSEarlyReleaseExclusionSchedulePart.SEXUAL),
           SDSEarlyReleaseExclusionForOffenceCode("V01", SDSEarlyReleaseExclusionSchedulePart.VIOLENT),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesServiceTest.kt
@@ -29,7 +29,7 @@ class ManageOffencesServiceTest {
     val moResult = listOf(
       SDSEarlyReleaseExclusionForOffenceCode("SX01", SDSEarlyReleaseExclusionSchedulePart.SEXUAL),
       SDSEarlyReleaseExclusionForOffenceCode("V01", SDSEarlyReleaseExclusionSchedulePart.VIOLENT),
-      SDSEarlyReleaseExclusionForOffenceCode("N01", SDSEarlyReleaseExclusionSchedulePart.NO),
+      SDSEarlyReleaseExclusionForOffenceCode("N01", SDSEarlyReleaseExclusionSchedulePart.NONE),
     )
     whenever(mockManageOffencesApiClient.getSexualOrViolentForOffenceCodes(listOf("SX01", "V01", "N01"))).thenReturn(moResult)
     val testResult = underTest.getSexualOrViolentForOffenceCodes(listOf("SX01", "V01", "N01"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupServiceTest.kt
@@ -166,7 +166,7 @@ class OffenceSDSReleaseArrangementLookupServiceTest {
   fun `should not set an SDS exclusion if offence is neither sexual or violent`() {
     whenever(mockManageOffencesService.getSexualOrViolentForOffenceCodes(listOf(OFFENCE_CODE_NON_SDS_PLUS))).thenReturn(
       listOf(
-        SDSEarlyReleaseExclusionForOffenceCode(OFFENCE_CODE_NON_SDS_PLUS, SDSEarlyReleaseExclusionSchedulePart.NO),
+        SDSEarlyReleaseExclusionForOffenceCode(OFFENCE_CODE_NON_SDS_PLUS, SDSEarlyReleaseExclusionSchedulePart.NONE),
       ),
     )
     val withReleaseArrangements = underTest.populateReleaseArrangements(listOf(nonSDSPlusSentenceAndOffenceFourYears))


### PR DESCRIPTION
Wrong value used for no match from manage offences. Should be NONE but was NO