### PR TITLE
Add logic to calculate ESL for Manual Release date entries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
@@ -148,17 +148,17 @@ class ManualCalculationService(
 
   fun calculateEffectiveSentenceLength(booking: Booking, manualEntryRequest: ManualEntryRequest): Period {
     if (hasIndeterminateSentences(booking.bookingId)) {
-      return Period.of(0, 0, 0)
+      return Period.ZERO
     } else {
       val identifiedBooking = bookingCalculationService.identify(booking)
       val consecutiveSentencesBooking = bookingCalculationService.createConsecutiveSentences(identifiedBooking)
       val sentences = consecutiveSentencesBooking.getAllExtractableSentences()
-      val earliestSentenceDate = sentences.minOf { it.sentencedAt }
+      val earliestSentenceDate = sentences.minOfOrNull { it.sentencedAt }
       val sed = getSED(manualEntryRequest)
-      return if (sed != null) {
+      return if (sed != null && earliestSentenceDate != null) {
         Period.between(earliestSentenceDate, sed)
       } else {
-        Period.of(0, 0, 0)
+        Period.ZERO
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
@@ -152,16 +152,12 @@ class ManualCalculationService(
     } else {
       val identifiedBooking = bookingCalculationService.identify(booking)
       val consecutiveSentencesBooking = bookingCalculationService.createConsecutiveSentences(identifiedBooking)
-      if (consecutiveSentencesBooking.consecutiveSentences.isNotEmpty()) {
-        val sentences = consecutiveSentencesBooking.getAllExtractableSentences()
-        val earliestSentenceDate = sentences.minOf { it.sentencedAt }
-        val sedOptional = getSED(manualEntryRequest)
-        if (sedOptional.isPresent) {
-          val sed = sedOptional.get()
-          return Period.between(earliestSentenceDate, sed)
-        } else {
-          return Period.of(0, 0, 0)
-        }
+      val sentences = consecutiveSentencesBooking.getAllExtractableSentences()
+      val earliestSentenceDate = sentences.minOf { it.sentencedAt }
+      val sedOptional = getSED(manualEntryRequest)
+      if (sedOptional.isPresent) {
+        val sed = sedOptional.get()
+        return Period.between(earliestSentenceDate, sed)
       } else {
         return Period.of(0, 0, 0)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
@@ -154,23 +154,18 @@ class ManualCalculationService(
       val consecutiveSentencesBooking = bookingCalculationService.createConsecutiveSentences(identifiedBooking)
       val sentences = consecutiveSentencesBooking.getAllExtractableSentences()
       val earliestSentenceDate = sentences.minOf { it.sentencedAt }
-      val sedOptional = getSED(manualEntryRequest)
-      if (sedOptional.isPresent) {
-        val sed = sedOptional.get()
-        return Period.between(earliestSentenceDate, sed)
+      val sed = getSED(manualEntryRequest)
+      return if (sed != null) {
+        Period.between(earliestSentenceDate, sed)
       } else {
-        return Period.of(0, 0, 0)
+        Period.of(0, 0, 0)
       }
     }
   }
 
-  fun getSED(manualEntryRequest: ManualEntryRequest): Optional<LocalDate> {
+  fun getSED(manualEntryRequest: ManualEntryRequest): LocalDate? {
     val sed = manualEntryRequest.selectedManualEntryDates.find { it.dateType == ReleaseDateType.SED }
-    return if (sed != null) {
-      Optional.ofNullable(sed.date?.toLocalDate())
-    } else {
-      Optional.empty()
-    }
+    return sed?.date?.toLocalDate()
   }
 
   private companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -105,6 +105,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.Period
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.MONTHS
 import java.time.temporal.ChronoUnit.WEEKS
@@ -635,7 +636,7 @@ fun transform(
   )
 }
 
-fun transform(dates: Map<ReleaseDateType, LocalDate?>?): OffenderKeyDates {
+fun transform(dates: Map<ReleaseDateType, LocalDate?>?, effectiveSentenceLength: Period): OffenderKeyDates {
   if (dates!!.containsKey(None)) {
     return OffenderKeyDates(null)
   }
@@ -657,9 +658,9 @@ fun transform(dates: Map<ReleaseDateType, LocalDate?>?): OffenderKeyDates {
     effectiveSentenceEndDate = dates[ESED],
     sentenceLength = String.format(
       "%02d/%02d/%02d",
-      0,
-      0,
-      0,
+      effectiveSentenceLength.years,
+      effectiveSentenceLength.months,
+      effectiveSentenceLength.days,
     ),
     homeDetentionCurfewApprovedDate = dates[HDCAD],
     tariffDate = dates[Tariff],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
@@ -42,7 +42,9 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Upda
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationOutcomeRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.BookingHelperTest
 import java.time.LocalDate
+import java.time.Period
 import java.time.temporal.ChronoUnit
 import java.util.*
 
@@ -56,6 +58,7 @@ class ManualCalculationServiceTest {
   private val eventService = mock<EventService>()
   private val serviceUserService = mock<ServiceUserService>()
   private val nomisCommentService = mock<NomisCommentService>()
+  private val bookingCalculationService = mock<BookingCalculationService>()
   private val manualCalculationService = ManualCalculationService(
     prisonService,
     bookingService,
@@ -67,8 +70,162 @@ class ManualCalculationServiceTest {
     serviceUserService,
     nomisCommentService,
     TEST_BUILD_PROPERTIES,
+    bookingCalculationService,
   )
   private val calculationRequestArgumentCaptor = argumentCaptor<CalculationRequest>()
+
+  @Nested
+  inner class CalculateESLTests {
+    @Test
+    fun `Check ESL is calculated correctly for determinate sentences without SED`() {
+      // Arrange
+      val sentenceOne = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+        sentencedAt = LocalDate.of(2022, 1, 1),
+      )
+      var workingBooking = BOOKING.copy(
+        sentences = listOf(
+          sentenceOne,
+        ),
+      )
+      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
+      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(prisonService.getSentencesAndOffences(BOOKING_ID)).thenReturn(
+        listOf(
+          SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE.copy(sentenceCalculationType = SentenceCalculationType.NP.name), false, SDSEarlyReleaseExclusionType.NO),
+          SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE, false, SDSEarlyReleaseExclusionType.NO),
+        ),
+      )
+
+      // Act
+      val result = manualCalculationService.calculateEffectiveSentenceLength(
+        BOOKING,
+        ManualEntryRequest(
+          listOf(
+            ManualEntrySelectedDate(
+              ReleaseDateType.LED,
+              "None",
+              SubmittedDate(1, 1, 2026),
+            ),
+          ),
+          1L,
+          "",
+        ),
+      )
+
+      // Assert
+      assertThat(result).isEqualTo(Period.of(0, 0, 0))
+    }
+
+    @Test
+    fun `Check ESL is calculated correctly for indeterminate sentences`() {
+      // Arrange
+      val sentenceOne = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+        sentencedAt = LocalDate.of(2022, 1, 1),
+      )
+      var workingBooking = BOOKING.copy(
+        sentences = listOf(
+          sentenceOne,
+        ),
+      )
+      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
+      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(prisonService.getSentencesAndOffences(BOOKING_ID)).thenReturn(
+        listOf(
+          SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE.copy(sentenceCalculationType = SentenceCalculationType.TWENTY.name), false, SDSEarlyReleaseExclusionType.NO),
+          SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE, false, SDSEarlyReleaseExclusionType.NO),
+        ),
+      )
+
+      // Act
+      val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
+
+      // Assert
+      assertThat(result).isEqualTo(Period.of(0, 0, 0))
+    }
+
+    @Test
+    fun `Check ESL is calculated correctly (2 concurrent) for determinate sentences`() {
+      // Arrange
+      val sentenceOne = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+        sentencedAt = LocalDate.of(2022, 1, 1),
+      )
+      val sentenceTwo = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+        sentencedAt = LocalDate.of(2021, 1, 1),
+      )
+      var workingBooking = BOOKING.copy(
+        sentences = listOf(
+          sentenceOne,
+          sentenceTwo,
+        ),
+      )
+      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
+      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+
+      // Act
+      val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
+
+      // Assert
+      assertThat(result).isEqualTo(Period.of(5, 0, 0))
+    }
+
+    @Test
+    fun `Check ESL is calculated correctly (single) for determinate sentences`() {
+      // Arrange
+      val sentenceOne = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+        sentencedAt = LocalDate.of(2022, 1, 1),
+      )
+      var workingBooking = BOOKING.copy(
+        sentences = listOf(
+          sentenceOne,
+        ),
+      )
+      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
+      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+
+      // Act
+      val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
+
+      // Assert
+      assertThat(result).isEqualTo(Period.of(4, 0, 0))
+    }
+
+    @Test
+    fun `Check ESL is calculated correctly (consecutive) for determinate sentences`() {
+      // Arrange
+      val consecutiveSentenceOne = StandardSENTENCE.copy(
+        consecutiveSentenceUUIDs = emptyList(),
+      )
+      val consecutiveSentenceTwo = StandardSENTENCE.copy(
+        identifier = UUID.randomUUID(),
+        sentencedAt = LocalDate.of(2023, 1, 1),
+        consecutiveSentenceUUIDs = listOf(StandardSENTENCE.identifier),
+      )
+      var workingBooking = BOOKING.copy(
+        sentences = listOf(
+          consecutiveSentenceOne,
+          consecutiveSentenceTwo,
+        ),
+      )
+      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
+      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+
+      // Act
+      val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
+
+      // Assert
+      assertThat(result).isEqualTo(Period.of(4, 10, 29))
+    }
+  }
 
   @Nested
   inner class IndeterminateSentencesTests {
@@ -103,6 +260,18 @@ class ManualCalculationServiceTest {
 
   @Test
   fun `Check noDates is set correctly when indeterminate`() {
+    val sentenceOne = StandardSENTENCE.copy(
+      consecutiveSentenceUUIDs = emptyList(),
+      sentencedAt = LocalDate.of(2022, 1, 1),
+    )
+    var booking = BOOKING.copy(
+      sentences = listOf(
+        sentenceOne,
+      ),
+    )
+    booking = BookingHelperTest().createConsecutiveSentences(booking)
+    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
     whenever(prisonService.getPrisonApiSourceData(PRISONER_ID)).thenReturn(FAKE_SOURCE_DATA)
     whenever(calculationRequestRepository.save(any())).thenReturn(CALCULATION_REQUEST_WITH_OUTCOMES)
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
@@ -127,6 +296,18 @@ class ManualCalculationServiceTest {
 
   @Test
   fun `Check noDates is set correctly for determinate manual entry`() {
+    val sentenceOne = StandardSENTENCE.copy(
+      consecutiveSentenceUUIDs = emptyList(),
+      sentencedAt = LocalDate.of(2022, 1, 1),
+    )
+    var booking = BOOKING.copy(
+      sentences = listOf(
+        sentenceOne,
+      ),
+    )
+    booking = BookingHelperTest().createConsecutiveSentences(booking)
+    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
     whenever(prisonService.getPrisonApiSourceData(PRISONER_ID)).thenReturn(FAKE_SOURCE_DATA)
     whenever(calculationRequestRepository.save(any())).thenReturn(CALCULATION_REQUEST_WITH_OUTCOMES)
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
@@ -153,11 +334,23 @@ class ManualCalculationServiceTest {
 
   @Test
   fun `Check type is set to Genuine Override when its a genuine override`() {
+    val sentenceOne = StandardSENTENCE.copy(
+      consecutiveSentenceUUIDs = emptyList(),
+      sentencedAt = LocalDate.of(2022, 1, 1),
+    )
+    var booking = BOOKING.copy(
+      sentences = listOf(
+        sentenceOne,
+      ),
+    )
+    booking = BookingHelperTest().createConsecutiveSentences(booking)
     whenever(prisonService.getPrisonApiSourceData(PRISONER_ID)).thenReturn(FAKE_SOURCE_DATA)
     whenever(calculationRequestRepository.save(any())).thenReturn(CALCULATION_REQUEST_WITH_OUTCOMES)
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
     whenever(calculationReasonRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REASON))
     whenever(bookingService.getBooking(FAKE_SOURCE_DATA, CalculationUserInputs())).thenReturn(BOOKING)
+    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
     whenever(serviceUserService.getUsername()).thenReturn(USERNAME)
     whenever(nomisCommentService.getManualNomisComment(any(), any(), any())).thenReturn("The NOMIS Reason")
 
@@ -288,7 +481,17 @@ class ManualCalculationServiceTest {
       hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
     )
     private val BOOKING = Booking(OFFENDER, listOf(StandardSENTENCE), Adjustments(), null, null, BOOKING_ID)
-
+    private val MANUAL_ENTRY = ManualEntryRequest(
+      listOf(
+        ManualEntrySelectedDate(
+          ReleaseDateType.SED,
+          "None",
+          SubmittedDate(1, 1, 2026),
+        ),
+      ),
+      1L,
+      "",
+    )
     const val USERNAME = "user1"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
@@ -121,18 +121,6 @@ class ManualCalculationServiceTest {
     @Test
     fun `Check ESL is calculated correctly for indeterminate sentences`() {
       // Arrange
-      val sentenceOne = StandardSENTENCE.copy(
-        consecutiveSentenceUUIDs = emptyList(),
-        sentencedAt = LocalDate.of(2022, 1, 1),
-      )
-      var workingBooking = BOOKING.copy(
-        sentences = listOf(
-          sentenceOne,
-        ),
-      )
-      workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
-      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
-      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
       whenever(prisonService.getSentencesAndOffences(BOOKING_ID)).thenReturn(
         listOf(
           SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE.copy(sentenceCalculationType = SentenceCalculationType.TWENTY.name), false, SDSEarlyReleaseExclusionType.NO),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/util/BookingHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/util/BookingHelperTest.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AbstractSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustment
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+class BookingHelperTest {
+
+  private fun createSentenceChain(
+    start: AbstractSentence,
+    chain: MutableList<AbstractSentence>,
+    sentencesByPrevious: Map<UUID, List<AbstractSentence>>,
+    chains: MutableList<MutableList<AbstractSentence>> = mutableListOf(mutableListOf()),
+  ) {
+    val originalChain = chain.toMutableList()
+    sentencesByPrevious[start.identifier]?.forEachIndexed { index, it ->
+      if (index == 0) {
+        chain.add(it)
+        createSentenceChain(it, chain, sentencesByPrevious, chains)
+      } else {
+        // This sentence has two sentences consecutive to it. This is not allowed in practice, however it can happen
+        // when a sentence in NOMIS has multiple offices, which means it becomes multiple sentences in our model.
+        val chainCopy = originalChain.toMutableList()
+        chains.add(chainCopy)
+        chainCopy.add(it)
+        createSentenceChain(it, chainCopy, sentencesByPrevious, chains)
+      }
+    }
+  }
+
+  fun createConsecutiveSentences(booking: Booking): Booking {
+    val (baseSentences, consecutiveSentences) = booking.sentences.partition { it.consecutiveSentenceUUIDs.isEmpty() }
+    val sentencesByPrevious = consecutiveSentences.groupBy {
+      it.consecutiveSentenceUUIDs.first()
+    }
+
+    val chains: MutableList<MutableList<AbstractSentence>> = mutableListOf(mutableListOf())
+
+    baseSentences.forEach {
+      val chain: MutableList<AbstractSentence> = mutableListOf()
+      chains.add(chain)
+      chain.add(it)
+      createSentenceChain(it, chain, sentencesByPrevious, chains)
+    }
+
+    booking.consecutiveSentences = chains.filter { it.size > 1 }
+      .map {
+        val cs = ConsecutiveSentence(it)
+        cs.sentenceCalculation = BookingHelperTest.SENTENCE_CALCULATION
+        cs
+      }
+    booking.consecutiveSentences.forEach { it.sentenceCalculation }
+
+    booking.sentenceGroups = emptyList()
+    return booking
+  }
+
+  companion object {
+    const val BOOKING_ID = 100091L
+    private val OFFENCE = Offence(LocalDate.of(2020, 1, 1))
+    private val FIRST_MAY_2018: LocalDate = LocalDate.of(2018, 5, 1)
+    private val ONE_DAY_DURATION = Duration(mapOf(ChronoUnit.DAYS to 1L))
+    private val STANDARD_SENTENCE = StandardDeterminateSentence(
+      offence = BookingHelperTest.OFFENCE,
+      duration = BookingHelperTest.ONE_DAY_DURATION,
+      sentencedAt = LocalDate.of(2020, 1, 1),
+      isSDSPlus = false,
+      hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
+    )
+    val SENTENCE_CALCULATION = SentenceCalculation(
+      BookingHelperTest.STANDARD_SENTENCE,
+      3,
+      4.0,
+      4,
+      BookingHelperTest.FIRST_MAY_2018,
+      BookingHelperTest.FIRST_MAY_2018,
+      1,
+      BookingHelperTest.FIRST_MAY_2018,
+      false,
+      Adjustments(
+        mutableMapOf(
+          AdjustmentType.REMAND to mutableListOf(
+            Adjustment(
+              numberOfDays = 1,
+              appliesToSentencesFrom = BookingHelperTest.FIRST_MAY_2018,
+            ),
+          ),
+        ),
+      ),
+      BookingHelperTest.FIRST_MAY_2018,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NormalisedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
@@ -43,6 +42,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SentencesExtractionService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.BookingHelperTest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ADJUSTMENT_FUTURE_DATED_ADA
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ADJUSTMENT_FUTURE_DATED_RADA
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ADJUSTMENT_FUTURE_DATED_UAL
@@ -1300,7 +1300,7 @@ class ValidationServiceTest {
             consecutiveSentenceTwo,
           ),
         )
-        workingBooking = createConsecutiveSentences(workingBooking)
+        workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
         val result = validationService.validateBookingAfterCalculation(
           workingBooking,
         )
@@ -1335,7 +1335,7 @@ class ValidationServiceTest {
             consecutiveSentenceTwo,
           ),
         )
-        workingBooking = createConsecutiveSentences(workingBooking)
+        workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
         val result = validationService.validateBookingAfterCalculation(
           workingBooking,
         )
@@ -1365,7 +1365,7 @@ class ValidationServiceTest {
             consecutiveSentenceTwo,
           ),
         )
-        workingBooking = createConsecutiveSentences(workingBooking)
+        workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
         val result = validationService.validateBookingAfterCalculation(
           workingBooking,
         )
@@ -1378,6 +1378,7 @@ class ValidationServiceTest {
         )
       }
 
+      // Copying this
       @Test
       fun `Test 14 day aggregate Type sentence and aggregate duration greater than 12 months`() {
         val consecutiveSentenceOne = FTR_SDS_SENTENCE.copy(
@@ -1400,7 +1401,7 @@ class ValidationServiceTest {
             consecutiveSentenceTwo,
           ),
         )
-        workingBooking = createConsecutiveSentences(workingBooking)
+        workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
         val result = validationService.validateBookingAfterCalculation(
           workingBooking,
         )
@@ -1855,33 +1856,6 @@ class ValidationServiceTest {
         ),
       ),
     )
-  }
-
-  fun createConsecutiveSentences(booking: Booking): Booking {
-    val (baseSentences, consecutiveSentences) = booking.sentences.partition { it.consecutiveSentenceUUIDs.isEmpty() }
-    val sentencesByPrevious = consecutiveSentences.groupBy {
-      it.consecutiveSentenceUUIDs.first()
-    }
-
-    val chains: MutableList<MutableList<AbstractSentence>> = mutableListOf(mutableListOf())
-
-    baseSentences.forEach {
-      val chain: MutableList<AbstractSentence> = mutableListOf()
-      chains.add(chain)
-      chain.add(it)
-      createSentenceChain(it, chain, sentencesByPrevious, chains)
-    }
-
-    booking.consecutiveSentences = chains.filter { it.size > 1 }
-      .map {
-        val cs = ConsecutiveSentence(it)
-        cs.sentenceCalculation = SENTENCE_CALCULATION
-        cs
-      }
-    booking.consecutiveSentences.forEach { it.sentenceCalculation }
-
-    booking.sentenceGroups = emptyList()
-    return booking
   }
 
   private fun createSentenceChain(


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CRS-1937.

This PR addresses the calculation of ESL for manual entry journey and saves that to NOMIS after converting to Years Months and Days. When there is Indeterminate sentences or absence of SED then the release date is set to 0 Years, 0 Months and 0 days 