### PR TITLE
Fix bulk comparison with SDS exclusion lookup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonService.kt
@@ -141,13 +141,13 @@ class BulkComparisonService(
     establishment: String? = "",
   ) {
     val sentenceAndOffencesWithReleaseArrangementsForAllBookings =
-      pcscLookupService.populateReleaseArrangements(
-        calculableSentenceEnvelopes.map { envelope ->
+      calculableSentenceEnvelopes.map { envelope ->
+        pcscLookupService.populateReleaseArrangements(
           envelope.sentenceAndOffences.flatMap { sentenceAndOffences ->
             sentenceAndOffences.offences.map { offence -> NormalisedSentenceAndOffence(sentenceAndOffences, offence) }
-          }
-        }.flatten(),
-      )
+          },
+        )
+      }.flatten()
     calculableSentenceEnvelopes.forEach { calculableSentenceEnvelope ->
       val sentenceAndOffencesWithReleaseArrangementsForBooking = sentenceAndOffencesWithReleaseArrangementsForAllBookings.filter { it.bookingId == calculableSentenceEnvelope.bookingId }
       val sdsPlusSentenceAndOffences = sentenceAndOffencesWithReleaseArrangementsForBooking.filter { it.isSDSPlus }


### PR DESCRIPTION
We were combining all sentences and offences and doing a single lookup which could produce too many offences and make the MO URL too long.