### PR TITLE
Extract calculation options from booking and feature toggles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Booking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Booking.kt
@@ -12,7 +12,6 @@ data class Booking(
   val returnToCustodyDate: LocalDate? = null,
   val fixedTermRecallDetails: FixedTermRecallDetails? = null,
   val bookingId: Long = -1L,
-  val calculateErsed: Boolean = false,
 ) {
   @JsonIgnore
   lateinit var consecutiveSentences: List<ConsecutiveSentence>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationOptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationOptions.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+data class CalculationOptions(
+  val calculateErsed: Boolean,
+  val allowSDSEarlyRelease: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
@@ -24,7 +24,6 @@ class BookingService() {
       bookingId = prisonerDetails.bookingId,
       returnToCustodyDate = prisonApiSourceData.returnToCustodyDate?.returnToCustodyDate,
       fixedTermRecallDetails = prisonApiSourceData.fixedTermRecallDetails,
-      calculateErsed = calculationUserInputs.calculateErsed,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownService.kt
@@ -34,10 +34,9 @@ open class CalculationBreakdownService(
         adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences),
         bookingId = prisonerDetails.bookingId,
         returnToCustodyDate = returnToCustodyDate?.returnToCustodyDate,
-        calculateErsed = calculationUserInputs.calculateErsed,
       )
       try {
-        calculationTransactionalService.calculateWithBreakdown(booking, calculation).right()
+        calculationTransactionalService.calculateWithBreakdown(booking, calculation, calculationUserInputs).right()
       } catch (e: BreakdownChangedSinceLastCalculation) {
         BreakdownMissingReason.BREAKDOWN_CHANGED_SINCE_LAST_CALCULATION.left()
       } catch (e: UnsupportedCalculationBreakdown) {
@@ -63,8 +62,7 @@ open class CalculationBreakdownService(
       adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences),
       bookingId = prisonerDetails.bookingId,
       returnToCustodyDate = returnToCustodyDate?.returnToCustodyDate,
-      calculateErsed = calculationUserInputs.calculateErsed,
     )
-    return calculationTransactionalService.calculateWithBreakdown(booking, calculation)
+    return calculationTransactionalService.calculateWithBreakdown(booking, calculation, calculationUserInputs)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
@@ -1,42 +1,47 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 
 @Service
 class CalculationService(
   private val bookingCalculationService: BookingCalculationService,
   private val bookingExtractionService: BookingExtractionService,
   private val bookingTimelineService: BookingTimelineService,
+  private val featureToggles: FeatureToggles,
 ) {
 
-  fun calculateReleaseDates(booking: Booking): Pair<Booking, CalculationResult> {
-    val workingBooking = calculate(booking)
+  fun calculateReleaseDates(booking: Booking, calculationUserInputs: CalculationUserInputs): Pair<Booking, CalculationResult> {
+    val options = CalculationOptions(calculationUserInputs.calculateErsed, featureToggles.sdsEarlyRelease)
+    val workingBooking = calculate(booking, options)
     // apply any rules to calculate the dates
     return workingBooking to bookingExtractionService.extract(workingBooking)
   }
 
-  fun calculate(booking: Booking): Booking {
+  fun calculate(booking: Booking, options: CalculationOptions): Booking {
     var workingBooking: Booking = booking
 
     // identify the types of the sentences
     workingBooking =
       bookingCalculationService
-        .identify(workingBooking)
+        .identify(workingBooking, options)
 
     // calculate the dates within the sentences (Generate initial sentence calculations)
     workingBooking =
       bookingCalculationService
-        .calculate(workingBooking)
+        .calculate(workingBooking, options)
 
     workingBooking =
       bookingCalculationService
-        .createConsecutiveSentences(workingBooking)
+        .createConsecutiveSentences(workingBooking, options)
 
     workingBooking =
       bookingCalculationService
-        .createSingleTermSentences(workingBooking)
+        .createSingleTermSentences(workingBooking, options)
 
     workingBooking = bookingTimelineService
       .walkTimelineOfBooking(workingBooking)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/RelevantRemandService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/RelevantRemandService.kt
@@ -47,7 +47,7 @@ class RelevantRemandService(
       )
     }
 
-    val result = calculationService.calculateReleaseDates(booking)
+    val result = calculationService.calculateReleaseDates(booking, calculationUserInputs)
     val calculationResult = result.second
     val releaseDateTypes = listOf(ReleaseDateType.CRD, ReleaseDateType.ARD, ReleaseDateType.MTD)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationService.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Releas
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.SentenceIdentificationTrack
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExtendedDeterminateSentence
@@ -21,9 +22,9 @@ class SentenceCalculationService(
   private val releasePointMultiplierLookup: ReleasePointMultiplierLookup,
 ) {
 
-  fun calculate(sentence: CalculableSentence, booking: Booking): SentenceCalculation {
+  fun calculate(sentence: CalculableSentence, booking: Booking, options: CalculationOptions): SentenceCalculation {
     // create association between the sentence and it's calculation
-    sentence.sentenceCalculation = getSentenceCalculation(booking, sentence)
+    sentence.sentenceCalculation = getSentenceCalculation(booking, sentence, options)
     return sentenceAdjustedCalculationService.calculateDatesFromAdjustments(sentence, booking)
   }
 
@@ -104,7 +105,7 @@ class SentenceCalculationService(
     return ConsecutiveSentenceAggregator(sentences.map(durationSupplier)).calculateDays(sentenceStartDate)
   }
 
-  private fun getSentenceCalculation(booking: Booking, sentence: CalculableSentence): SentenceCalculation {
+  private fun getSentenceCalculation(booking: Booking, sentence: CalculableSentence, options: CalculationOptions): SentenceCalculation {
     val release = if (sentence is ConsecutiveSentence) {
       getConsecutiveRelease(sentence)
     } else {
@@ -145,7 +146,7 @@ class SentenceCalculationService(
       unadjustedDeterminateReleaseDate,
       numberOfDaysToPostRecallReleaseDate,
       unadjustedPostRecallReleaseDate,
-      booking.calculateErsed,
+      options.calculateErsed,
       booking.adjustments,
       returnToCustodyDate = booking.returnToCustodyDate,
       numberOfDaysToParoleEligibilityDate = release.numberOfDaysToParoleEligibilityDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/unuseddeductions/service/UnusedDeductionsCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/unuseddeductions/service/UnusedDeductionsCalculationService.kt
@@ -42,7 +42,7 @@ class UnusedDeductionsCalculationService(
       return UnusedDeductionCalculationResponse(null, validationMessages)
     }
 
-    val result = calculationService.calculateReleaseDates(booking)
+    val result = calculationService.calculateReleaseDates(booking, calculationUserInputs)
     val releaseDateTypes = listOf(ReleaseDateType.CRD, ReleaseDateType.ARD, ReleaseDateType.MTD)
     val calculationResult = result.second
     val releaseDate = calculationResult.dates.filter { releaseDateTypes.contains(it.key) }.minOfOrNull { it.value }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/JsonTransformation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/JsonTransformation.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.TestUtil
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -26,9 +28,11 @@ class JsonTransformation {
     return mapper.readValue(json, StandardDeterminateSentence::class.java)
   }
 
-  fun loadBooking(testData: String): Booking {
+  fun loadBooking(testData: String): Pair<Booking, CalculationUserInputs> {
     val json = getJsonTest("$testData.json", "overall_calculation")
-    return mapper.readValue(json, Booking::class.java)
+    val jsonTree = mapper.readTree(json)
+    val calculateErsed = if (jsonTree.has("calculateErsed")) jsonTree.get("calculateErsed").booleanValue() else false
+    return mapper.readValue(json, Booking::class.java) to CalculationUserInputs(calculateErsed = calculateErsed)
   }
 
   fun loadCalculationResult(testData: String): CalculationResult {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonServiceTest.kt
@@ -179,7 +179,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -234,7 +234,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -282,7 +282,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, null, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -317,7 +317,7 @@ class BulkComparisonServiceTest {
       ),
     )
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, null, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -343,7 +343,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine if a mismatch report is valid and is a match`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, calculatedReleaseDates, null)
 
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
@@ -363,7 +363,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine mismatch invalid and not potential HDC4+ due being a sex offender`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -389,7 +389,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine mismatch invalid and not potential HDC4+ due to sentence type`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -417,7 +417,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine mismatch invalid and not potential HDC4+ due to sentence length under 4 years`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -445,7 +445,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine validation error mismatch not potential HDC4+ when there is a EDS sentence consecutive to an SDS sentence`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -481,7 +481,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine validation error mismatch not potential HDC4+ when there is a SDS sentence consecutive to an SOPC sentence`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -517,7 +517,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine potential HDC4+ mismatch`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
       booking,
@@ -542,7 +542,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine unsupported sentence type not HDC4+ because active sex offender`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(ValidationMessage(ValidationCode.UNSUPPORTED_SENTENCE_TYPE)),
       booking,
@@ -568,7 +568,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine unsupported sentence type not HDC4+ because indeterminate sentence type`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.FTR_28_DAYS_SENTENCE_LT_12_MONTHS),
@@ -599,7 +599,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine unsupported sentence type not HDC4+ because duration less than 4 years`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.UNSUPPORTED_SENTENCE_TYPE),
@@ -637,7 +637,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine unsupported sentence type not HDC4+ because of SDS+ offence`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.UNSUPPORTED_SENTENCE_TYPE),
@@ -679,7 +679,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine if a mismatch report is not valid due to unsupported sentence type and potential HDC4+`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.FTR_28_DAYS_SENTENCE_LT_12_MONTHS),
@@ -716,7 +716,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `should be unsupported sentence type for HDC4+ when unsupported sentence and consecutive SDS sentences of more than 4 years`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.FTR_28_DAYS_SENTENCE_LT_12_MONTHS),
@@ -804,7 +804,7 @@ class BulkComparisonServiceTest {
   @Test
   fun `Determine if a mismatch is reported as an unsupported sentence type for an unsupported calculation validation`() {
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(
       listOf(
         ValidationMessage(ValidationCode.UNSUPPORTED_CALCULATION_DTO_WITH_RECALL),
@@ -850,7 +850,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
 
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
@@ -897,7 +897,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -948,7 +948,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,
@@ -997,7 +997,7 @@ class BulkComparisonServiceTest {
     )
 
     val booking =
-      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123, true)
+      Booking(Offender("a", LocalDate.of(1980, 1, 1), true), emptyList(), Adjustments(), null, null, 123)
     val validationResult = ValidationResult(emptyList(), booking, duplicatedReleaseDates, null)
     whenever(calculationTransactionalService.validateAndCalculate(any(), any(), any(), any(), any(), any())).thenReturn(
       validationResult,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownServiceTest.kt
@@ -107,7 +107,7 @@ class CalculationBreakdownServiceTest {
     whenever(prisonApiDataMapper.mapSentencesAndOffences(calculationRequestWithEverythingForBreakdown)).thenReturn(listOf(originalSentence))
     whenever(prisonApiDataMapper.mapPrisonerDetails(calculationRequestWithEverythingForBreakdown)).thenReturn(prisonerDetails)
     whenever(prisonApiDataMapper.mapBookingAndSentenceAdjustments(calculationRequestWithEverythingForBreakdown)).thenReturn(adjustments)
-    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any())).then {
+    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any(), any())).then {
       throw BreakdownChangedSinceLastCalculation("Calculation no longer agrees with algorithm.")
     }
 
@@ -128,7 +128,7 @@ class CalculationBreakdownServiceTest {
     whenever(prisonApiDataMapper.mapSentencesAndOffences(calculationRequestWithEverythingForBreakdown)).thenReturn(listOf(originalSentence))
     whenever(prisonApiDataMapper.mapPrisonerDetails(calculationRequestWithEverythingForBreakdown)).thenReturn(prisonerDetails)
     whenever(prisonApiDataMapper.mapBookingAndSentenceAdjustments(calculationRequestWithEverythingForBreakdown)).thenReturn(adjustments)
-    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any())).then {
+    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any(), any())).then {
       throw UnsupportedCalculationBreakdown("Bang!")
     }
 
@@ -150,7 +150,7 @@ class CalculationBreakdownServiceTest {
     whenever(prisonApiDataMapper.mapSentencesAndOffences(calculationRequestWithEverythingForBreakdown)).thenReturn(listOf(originalSentence))
     whenever(prisonApiDataMapper.mapPrisonerDetails(calculationRequestWithEverythingForBreakdown)).thenReturn(prisonerDetails)
     whenever(prisonApiDataMapper.mapBookingAndSentenceAdjustments(calculationRequestWithEverythingForBreakdown)).thenReturn(adjustments)
-    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any())).thenReturn(expectedBreakdown)
+    whenever(calculationTransactionalService.calculateWithBreakdown(any(), any(), any())).thenReturn(expectedBreakdown)
     val results = service.getBreakdownSafely(calculationRequestWithEverythingForBreakdown)
     assertThat(results).isEqualTo(expectedBreakdown.right())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.TestUtil
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationType
@@ -59,6 +60,7 @@ class ManualCalculationServiceTest {
   private val serviceUserService = mock<ServiceUserService>()
   private val nomisCommentService = mock<NomisCommentService>()
   private val bookingCalculationService = mock<BookingCalculationService>()
+  private val featureToggles = FeatureToggles()
   private val manualCalculationService = ManualCalculationService(
     prisonService,
     bookingService,
@@ -71,6 +73,7 @@ class ManualCalculationServiceTest {
     nomisCommentService,
     TEST_BUILD_PROPERTIES,
     bookingCalculationService,
+    featureToggles,
   )
   private val calculationRequestArgumentCaptor = argumentCaptor<CalculationRequest>()
 
@@ -89,8 +92,8 @@ class ManualCalculationServiceTest {
         ),
       )
       workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
-      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
-      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.identify(any(), any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(workingBooking)
       whenever(prisonService.getSentencesAndOffences(BOOKING_ID)).thenReturn(
         listOf(
           SentenceAndOffenceWithReleaseArrangements(BASE_DETERMINATE_SENTENCE.copy(sentenceCalculationType = SentenceCalculationType.NP.name), false, SDSEarlyReleaseExclusionType.NO),
@@ -153,8 +156,8 @@ class ManualCalculationServiceTest {
         ),
       )
       workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
-      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
-      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.identify(any(), any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(workingBooking)
 
       // Act
       val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
@@ -176,8 +179,8 @@ class ManualCalculationServiceTest {
         ),
       )
       workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
-      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
-      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.identify(any(), any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(workingBooking)
 
       // Act
       val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
@@ -204,8 +207,8 @@ class ManualCalculationServiceTest {
         ),
       )
       workingBooking = BookingHelperTest().createConsecutiveSentences(workingBooking)
-      whenever(bookingCalculationService.identify(any())).thenReturn(workingBooking)
-      whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.identify(any(), any())).thenReturn(workingBooking)
+      whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(workingBooking)
 
       // Act
       val result = manualCalculationService.calculateEffectiveSentenceLength(BOOKING, MANUAL_ENTRY)
@@ -258,8 +261,8 @@ class ManualCalculationServiceTest {
       ),
     )
     booking = BookingHelperTest().createConsecutiveSentences(booking)
-    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
-    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
+    whenever(bookingCalculationService.identify(any(), any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(booking)
     whenever(prisonService.getPrisonApiSourceData(PRISONER_ID)).thenReturn(FAKE_SOURCE_DATA)
     whenever(calculationRequestRepository.save(any())).thenReturn(CALCULATION_REQUEST_WITH_OUTCOMES)
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
@@ -294,8 +297,8 @@ class ManualCalculationServiceTest {
       ),
     )
     booking = BookingHelperTest().createConsecutiveSentences(booking)
-    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
-    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
+    whenever(bookingCalculationService.identify(any(), any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(booking)
     whenever(prisonService.getPrisonApiSourceData(PRISONER_ID)).thenReturn(FAKE_SOURCE_DATA)
     whenever(calculationRequestRepository.save(any())).thenReturn(CALCULATION_REQUEST_WITH_OUTCOMES)
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
@@ -337,8 +340,8 @@ class ManualCalculationServiceTest {
     whenever(calculationRequestRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REQUEST_WITH_OUTCOMES))
     whenever(calculationReasonRepository.findById(any())).thenReturn(Optional.of(CALCULATION_REASON))
     whenever(bookingService.getBooking(FAKE_SOURCE_DATA, CalculationUserInputs())).thenReturn(BOOKING)
-    whenever(bookingCalculationService.identify(any())).thenReturn(booking)
-    whenever(bookingCalculationService.createConsecutiveSentences(any())).thenReturn(booking)
+    whenever(bookingCalculationService.identify(any(), any())).thenReturn(booking)
+    whenever(bookingCalculationService.createConsecutiveSentences(any(), any())).thenReturn(booking)
     whenever(serviceUserService.getUsername()).thenReturn(USERNAME)
     whenever(nomisCommentService.getManualNomisComment(any(), any(), any())).thenReturn("The NOMIS Reason")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceCalculationServiceTest.kt
@@ -12,11 +12,11 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationP
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationParamsTestConfigHelper.hdced4ConfigurationForTests
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationParamsTestConfigHelper.hdcedConfigurationForTests
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationParamsTestConfigHelper.releasePointMultiplierConfigurationForTests
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustment
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
 import java.time.LocalDate
@@ -33,20 +33,19 @@ class SentenceCalculationServiceTest {
   private val hdced4Calculator = Hdced4Calculator(hdced4Configuration)
   private val ersedCalculator = ErsedCalculator(ersedConfigurationForTests())
   private val releasePointMultiplierLookup = ReleasePointMultiplierLookup(releasePointMultiplierConfigurationForTests())
-  private val featureToggles = FeatureToggles(botus = false, sdsEarlyRelease = false)
   private val sentenceAdjustedCalculationService = SentenceAdjustedCalculationService(hdcedCalculator, tusedCalculator, hdced4Calculator, ersedCalculator)
   private val sentenceCalculationService: SentenceCalculationService = SentenceCalculationService(sentenceAdjustedCalculationService, releasePointMultiplierLookup)
-  private val sentenceIdentificationService: SentenceIdentificationService = SentenceIdentificationService(tusedCalculator, hdced4Calculator, featureToggles)
+  private val sentenceIdentificationService: SentenceIdentificationService = SentenceIdentificationService(tusedCalculator, hdced4Calculator)
   private val jsonTransformation = JsonTransformation()
   private val offender = jsonTransformation.loadOffender("john_doe")
 
   @Test
   fun `Example 9`() {
     val sentence = jsonTransformation.loadSentence("2_year_sep_2013")
-    sentenceIdentificationService.identify(sentence, offender)
+    sentenceIdentificationService.identify(sentence, offender, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     val offender = Offender("A1234BC", LocalDate.of(1980, 1, 1))
     val booking = Booking(offender, mutableListOf(sentence), Adjustments())
-    val calculation = sentenceCalculationService.calculate(sentence, booking)
+    val calculation = sentenceCalculationService.calculate(sentence, booking, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     assertEquals(calculation.expiryDate, LocalDate.of(2015, 9, 20))
     assertEquals(calculation.releaseDate, LocalDate.of(2014, 9, 20))
     assertEquals(LocalDate.of(2014, 3, 25), calculation.homeDetentionCurfewEligibilityDate)
@@ -57,14 +56,14 @@ class SentenceCalculationServiceTest {
   @Test
   fun `Example 10`() {
     val sentence = jsonTransformation.loadSentence("3_year_dec_2012")
-    sentenceIdentificationService.identify(sentence, offender)
+    sentenceIdentificationService.identify(sentence, offender, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     val offender = Offender("A1234BC", LocalDate.of(1980, 1, 1))
     val adjustments = mutableMapOf<AdjustmentType, MutableList<Adjustment>>()
     adjustments[AdjustmentType.REMAND] = mutableListOf(Adjustment(appliesToSentencesFrom = sentence.sentencedAt, numberOfDays = 35))
     adjustments[AdjustmentType.TAGGED_BAIL] = mutableListOf(Adjustment(appliesToSentencesFrom = sentence.sentencedAt, numberOfDays = 10))
 
     val booking = Booking(offender, mutableListOf(sentence), Adjustments(adjustments))
-    val calculation = sentenceCalculationService.calculate(sentence, booking)
+    val calculation = sentenceCalculationService.calculate(sentence, booking, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     assertEquals(LocalDate.of(2015, 10, 30), calculation.expiryDate)
     assertEquals(LocalDate.of(2014, 5, 1), calculation.releaseDate)
     assertEquals(LocalDate.of(2013, 11, 3), calculation.homeDetentionCurfewEligibilityDate)
@@ -75,12 +74,12 @@ class SentenceCalculationServiceTest {
   @Test
   fun `Example 11`() {
     val sentence = jsonTransformation.loadSentence("8_month_dec_2012")
-    sentenceIdentificationService.identify(sentence, offender)
+    sentenceIdentificationService.identify(sentence, offender, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     val adjustments = mutableMapOf<AdjustmentType, MutableList<Adjustment>>()
     adjustments[AdjustmentType.REMAND] = mutableListOf(Adjustment(appliesToSentencesFrom = sentence.sentencedAt, numberOfDays = 10))
     val offender = Offender("A1234BC", LocalDate.of(1980, 1, 1))
     val booking = Booking(offender, mutableListOf(sentence), Adjustments(adjustments))
-    val calculation = sentenceCalculationService.calculate(sentence, booking)
+    val calculation = sentenceCalculationService.calculate(sentence, booking, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     assertEquals(LocalDate.of(2013, 8, 6), calculation.expiryDate)
     assertEquals(LocalDate.of(2013, 4, 7), calculation.releaseDate)
     assertEquals(LocalDate.of(2013, 2, 6), calculation.homeDetentionCurfewEligibilityDate)
@@ -91,13 +90,13 @@ class SentenceCalculationServiceTest {
   @Test
   fun `Example 12`() {
     val sentence = jsonTransformation.loadSentence("8_month_feb_2015")
-    sentenceIdentificationService.identify(sentence, offender)
+    sentenceIdentificationService.identify(sentence, offender, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     val adjustments = mutableMapOf<AdjustmentType, MutableList<Adjustment>>()
     adjustments[AdjustmentType.REMAND] = mutableListOf(Adjustment(appliesToSentencesFrom = sentence.sentencedAt, numberOfDays = 21))
     val offender = Offender("A1234BC", LocalDate.of(1980, 1, 1))
     val booking = Booking(offender, mutableListOf(sentence), Adjustments(adjustments))
 
-    val calculation = sentenceCalculationService.calculate(sentence, booking)
+    val calculation = sentenceCalculationService.calculate(sentence, booking, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     assertEquals(LocalDate.of(2015, 9, 24), calculation.expiryDate)
     assertEquals(LocalDate.of(2015, 5, 26), calculation.releaseDate)
     assertEquals(LocalDate.of(2016, 5, 26), calculation.topUpSupervisionDate)
@@ -109,12 +108,12 @@ class SentenceCalculationServiceTest {
   @Test
   fun `5 year sentence no HDCED`() {
     val sentence = jsonTransformation.loadSentence("5_year_march_2017")
-    sentenceIdentificationService.identify(sentence, offender)
+    sentenceIdentificationService.identify(sentence, offender, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     val adjustments = mutableMapOf<AdjustmentType, MutableList<Adjustment>>()
     adjustments[AdjustmentType.REMAND] = mutableListOf(Adjustment(appliesToSentencesFrom = sentence.sentencedAt, numberOfDays = 21))
     val offender = Offender("A1234BC", LocalDate.of(1980, 1, 1))
     val booking = Booking(offender, mutableListOf(sentence), Adjustments(adjustments))
-    val calculation = sentenceCalculationService.calculate(sentence, booking)
+    val calculation = sentenceCalculationService.calculate(sentence, booking, CalculationOptions(calculateErsed = false, allowSDSEarlyRelease = false))
     assertEquals(LocalDate.of(2022, 2, 22), calculation.expiryDate)
     assertEquals(LocalDate.of(2019, 8, 24), calculation.releaseDate)
     assertEquals("[SLED, CRD, HDCED, HDCED4PLUS]", calculation.sentence.releaseDateTypes.getReleaseDateTypes().toString())


### PR DESCRIPTION
Moved the calculate ersed flag and SDS early release flag into their own options object to be passed around for calcluation. This allows modification of the options for recalculation for SDS4x as well as improves cohesion of booking object.