### PR TITLE
CRS-1852 Add historical TUSED to BOTUS sentence.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
@@ -21,6 +21,7 @@ import org.hibernate.Hibernate
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import org.hibernate.annotations.Type
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -109,6 +110,9 @@ data class CalculationRequest(
   val reasonForCalculation: CalculationReason? = null,
 
   val otherReasonForCalculation: String? = null,
+
+  @Enumerated(value = EnumType.STRING)
+  val historicalTusedSource: HistoricalTusedSource? = null,
 
   val version: String = "1",
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/HistoricalTusedSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/HistoricalTusedSource.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations
+
+enum class HistoricalTusedSource {
+  CRDS,
+  CRDS_OVERRIDDEN,
+  NOMIS,
+  NOMIS_OVERRIDDEN,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/SentenceIdentificationTrack.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/SentenceIdentificationTrack.kt
@@ -18,6 +18,7 @@ enum class SentenceIdentificationTrack {
   DTO_BEFORE_PCSC,
   DTO_AFTER_PCSC,
   BOTUS,
+  BOTUS_WITH_HISTORIC_TUSED,
   ;
 
   fun calculateErsed(): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Booking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Booking.kt
@@ -12,6 +12,7 @@ data class Booking(
   val returnToCustodyDate: LocalDate? = null,
   val fixedTermRecallDetails: FixedTermRecallDetails? = null,
   val bookingId: Long = -1L,
+  val historicalTusedData: HistoricalTusedData? = null,
 ) {
   @JsonIgnore
   lateinit var consecutiveSentences: List<ConsecutiveSentence>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/BotusSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/BotusSentence.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import java.time.LocalDate
 import java.util.*
 
@@ -11,6 +12,8 @@ data class BotusSentence(
   override val consecutiveSentenceUUIDs: List<UUID> = listOf(),
   override val caseSequence: Int? = null,
   override val lineSequence: Int? = null,
+  var latestTusedDate: LocalDate? = null,
+  var latestTusedSource: HistoricalTusedSource? = null,
 ) : AbstractSentence(offence, sentencedAt, identifier, consecutiveSentenceUUIDs, caseSequence, lineSequence) {
   override val isSDSPlus = false
   override fun buildString(): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculatedReleaseDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculatedReleaseDates.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.SentenceCalcDates
 import java.time.LocalDate
@@ -25,6 +26,7 @@ data class CalculatedReleaseDates(
   val calculationReason: CalculationReason?,
   val otherReasonDescription: String? = null,
   val calculationDate: LocalDate?,
+  val historicalTusedSource: HistoricalTusedSource? = null,
 ) {
   fun toSentenceCalcDates(): SentenceCalcDates {
     return SentenceCalcDates(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationResult.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import java.time.LocalDate
 import java.time.Period
@@ -10,4 +11,5 @@ data class CalculationResult(
   val otherDates: Map<ReleaseDateType, LocalDate> = mapOf(),
   val effectiveSentenceLength: Period,
   val ersedNotApplicableDueToDtoLaterThanCrd: Boolean = false,
+  val historicalTusedSource: HistoricalTusedSource? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/HistoricalTusedData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/HistoricalTusedData.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
+import java.time.LocalDate
+
+data class HistoricalTusedData(
+  val tused: LocalDate?,
+  val historicalTusedSource: HistoricalTusedSource,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisTusedData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisTusedData.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import java.time.LocalDate
+
+data class NomisTusedData(
+  val latestTused: LocalDate?,
+  var latestOverrideTused: LocalDate?,
+  val comment: String?,
+  val offenderNo: String,
+) {
+  fun getLatestTusedDate(): LocalDate? {
+    return latestOverrideTused ?: latestTused
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PrisonApiSourceData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/PrisonApiSourceData.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
 
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.HistoricalTusedData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 
 data class PrisonApiSourceData(
@@ -10,4 +11,5 @@ data class PrisonApiSourceData(
   val returnToCustodyDate: ReturnToCustodyDate?,
   // TODO This fixedTermTermRecallDetails variable can replace returnToCustodyDate - to be done as tech debt ticket
   val fixedTermRecallDetails: FixedTermRecallDetails? = null,
+  val historicalTusedData: HistoricalTusedData? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingService.kt
@@ -15,7 +15,7 @@ class BookingService() {
 
     val offender = transform(prisonerDetails)
     val adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences)
-    val sentences = sentenceAndOffences.map { transform(it, calculationUserInputs) }
+    val sentences = sentenceAndOffences.map { transform(it, calculationUserInputs, prisonApiSourceData.historicalTusedData) }
 
     return Booking(
       offender = offender,
@@ -24,6 +24,7 @@ class BookingService() {
       bookingId = prisonerDetails.bookingId,
       returnToCustodyDate = prisonApiSourceData.returnToCustodyDate?.returnToCustodyDate,
       fixedTermRecallDetails = prisonApiSourceData.fixedTermRecallDetails,
+      historicalTusedData = prisonApiSourceData.historicalTusedData,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BotusTusedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BotusTusedService.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.CRDS
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.CRDS_OVERRIDDEN
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.NOMIS
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.NOMIS_OVERRIDDEN
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.HistoricalTusedData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisTusedData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
+import java.util.UUID
+
+@Service
+class BotusTusedService(
+  val calculationRequestRepository: CalculationRequestRepository,
+) {
+
+  val uuidRegex = Regex("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}")
+
+  fun identifyTused(nomisTusedData: NomisTusedData): HistoricalTusedData {
+    val historicalTusedSource = when {
+      !isValidUUID(nomisTusedData.comment) -> {
+        if (nomisTusedData.latestOverrideTused == null) NOMIS else NOMIS_OVERRIDDEN
+      }
+      else -> {
+        if (nomisTusedData.latestOverrideTused == null) CRDS else CRDS_OVERRIDDEN
+      }
+    }
+
+    return HistoricalTusedData(nomisTusedData.getLatestTusedDate(), historicalTusedSource)
+  }
+
+  private fun isValidUUID(comment: String?): Boolean {
+    if (comment == null) return false
+
+    return try {
+      val uuid = uuidRegex.find(comment, 0)?.value ?: return false
+      !calculationRequestRepository.findByCalculationReference(UUID.fromString(uuid)).isEmpty
+    } catch (e: IllegalArgumentException) {
+      false
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Calcul
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus.CONFIRMED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus.ERROR
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus.PRELIMINARY
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.BreakdownChangedSinceLastCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CalculationDataHasChangedError
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CalculationNotFoundException
@@ -257,12 +258,11 @@ class CalculationTransactionalService(
           calculationUserInputs,
           calculationFragments,
           calculationType,
+          HistoricalTusedSource.NOMIS,
           buildProperties.version,
         ),
       )
-
     val calculationResult = calculationService.calculateReleaseDates(booking, calculationUserInputs).second
-
     calculationResult.dates.forEach {
       calculationOutcomeRepository.save(transform(calculationRequest, it.key, it.value))
     }
@@ -280,6 +280,7 @@ class CalculationTransactionalService(
       calculationReason = reasonForCalculation,
       otherReasonDescription = otherCalculationReason,
       calculationDate = calculationRequest.calculatedAt.toLocalDate(),
+      historicalTusedSource = calculationResult.historicalTusedSource,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DetailedCalculationResultsService.kt
@@ -39,7 +39,7 @@ open class DetailedCalculationResultsService(
 
     return DetailedCalculationResults(
       calculationContext(calculationRequestId, calculationRequest),
-      calculationResultEnrichmentService.addDetailToCalculationDates(releaseDates, sentenceAndOffences, calculationBreakdown),
+      calculationResultEnrichmentService.addDetailToCalculationDates(releaseDates, sentenceAndOffences, calculationBreakdown, calculationRequest.historicalTusedSource),
       approvedDates(calculationRequest.approvedDatesSubmissions.firstOrNull()),
       CalculationOriginalData(
         prisonerDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/LatestCalculationService.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.LatestCalculation
@@ -98,6 +99,7 @@ class LatestCalculationService(
     location: String?,
     sentenceAndOffences: List<SentenceAndOffence>?,
     breakdown: CalculationBreakdown?,
+    historicalTusedSource: HistoricalTusedSource? = null,
   ): LatestCalculation {
     val dates = offenderKeyDatesService.releaseDates(prisonerCalculation)
     return LatestCalculation(
@@ -108,7 +110,7 @@ class LatestCalculationService(
       location,
       reason,
       calculationSource,
-      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown).values.toList(),
+      calculationResultEnrichmentService.addDetailToCalculationDates(dates, sentenceAndOffences, breakdown, historicalTusedSource).values.toList(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
@@ -96,9 +96,14 @@ class SentenceIdentificationService(
     sentence.releaseDateTypes = ReleaseDateTypes(releaseDateTypes.toList(), sentence, offender)
   }
 
-  private fun identifyBotusSentence(sentence: CalculableSentence): List<ReleaseDateType> {
+  private fun identifyBotusSentence(sentence: BotusSentence): List<ReleaseDateType> {
     sentence.identificationTrack = BOTUS
-    return listOf(ARD, SED)
+    var releaseDateTypes: List<ReleaseDateType> = mutableListOf(ARD, SED)
+    if (sentence.latestTusedDate != null) {
+      sentence.identificationTrack = SentenceIdentificationTrack.BOTUS_WITH_HISTORIC_TUSED
+      releaseDateTypes += TUSED
+    }
+    return releaseDateTypes
   }
 
   private fun identifyDtoSentence(sentence: CalculableSentence): List<ReleaseDateType> {

--- a/src/main/resources/application-calculation-params.yml
+++ b/src/main/resources/application-calculation-params.yml
@@ -33,6 +33,7 @@ release-point-multipliers:
         - SOPC_PED_AT_HALFWAY,
         - AFINE_ARD_AT_FULL_TERM,
         - BOTUS
+        - BOTUS_WITH_HISTORIC_TUSED
       multiplier: 1.0
   default: 0.5
 

--- a/src/main/resources/migration/common/V53__add_historical_tused_source_column.sql
+++ b/src/main/resources/migration/common/V53__add_historical_tused_source_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calculation_request ADD COLUMN historical_tused_source varchar(255);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisTusedDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/NomisTusedDataTest.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class NomisTusedDataTest {
+
+  @Test
+  fun getLatestTusedDate() {
+    val nomisTusedData = NomisTusedData(LocalDate.of(2024, 5, 4), null, null, "A12345AB")
+
+    assertEquals(LocalDate.of(2024, 5, 4), nomisTusedData.getLatestTusedDate())
+
+    nomisTusedData.latestOverrideTused = LocalDate.of(2023, 6, 9)
+
+    assertEquals(LocalDate.of(2023, 6, 9), nomisTusedData.getLatestTusedDate())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BotusTusedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BotusTusedServiceTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.CRDS
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.CRDS_OVERRIDDEN
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.NOMIS
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource.NOMIS_OVERRIDDEN
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.HistoricalTusedData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisTusedData
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
+import java.time.LocalDate
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class BotusTusedServiceTest {
+
+  @Mock
+  lateinit var calculationRequestRepository: CalculationRequestRepository
+
+  @InjectMocks
+  lateinit var botusTusedService: BotusTusedService
+
+  @Test
+  fun `Check that historical TUSEDs from NOMIS are correctly categorised `() {
+    whenever(calculationRequestRepository.findByCalculationReference(any())).thenReturn(Optional.of(CalculationRequest()))
+
+    assertThat(botusTusedService.identifyTused(CALCULATED_DATE_WITH_CRD_COMMENT)).isEqualTo(
+      HistoricalTusedData(
+        FIRST_OF_MARCH,
+        CRDS,
+      ),
+    )
+
+    assertThat(botusTusedService.identifyTused(OVERRIDDEN_DATE_WITH_CRD_COMMENT)).isEqualTo(
+      HistoricalTusedData(
+        FIRST_OF_APRIL,
+        CRDS_OVERRIDDEN,
+      ),
+    )
+
+    assertThat(botusTusedService.identifyTused(CALCULATED_DATE_WITH_NULL_COMMENT)).isEqualTo(
+      HistoricalTusedData(
+        FIRST_OF_MARCH,
+        NOMIS,
+      ),
+    )
+
+    assertThat(botusTusedService.identifyTused(CALCULATED_DATE_WITHOUT_CRD_COMMENT)).isEqualTo(
+      HistoricalTusedData(
+        FIRST_OF_MARCH,
+        NOMIS,
+      ),
+    )
+
+    assertThat(botusTusedService.identifyTused(OVERRRIDDEN_DATE_WITHOUT_CRD_COMMENT)).isEqualTo(
+      HistoricalTusedData(
+        FIRST_OF_APRIL,
+        NOMIS_OVERRIDDEN,
+      ),
+    )
+  }
+
+  private companion object {
+    private val CRD_COMMENT = """
+    The information shown was calculated using the Calculate Release Dates service. 
+    The calculation ID is: d00edc6d-01bf-441b-bb15-d4bc6b7b1cf5
+  """
+
+    private val FIRST_OF_MARCH = LocalDate.of(2024, 3, 1)
+    private val FIRST_OF_APRIL = LocalDate.of(2024, 4, 1)
+
+    private val CALCULATED_DATE_WITH_CRD_COMMENT = NomisTusedData(FIRST_OF_MARCH, null, CRD_COMMENT, "A1234AB")
+
+    private val CALCULATED_DATE_WITH_NULL_COMMENT = NomisTusedData(FIRST_OF_MARCH, null, null, "A1234AB")
+
+    private val OVERRIDDEN_DATE_WITH_CRD_COMMENT =
+      NomisTusedData(FIRST_OF_MARCH, FIRST_OF_APRIL, CRD_COMMENT, "A1234AB")
+
+    private val CALCULATED_DATE_WITHOUT_CRD_COMMENT = NomisTusedData(FIRST_OF_MARCH, null, "UPDATE", "A1234AB")
+
+    private val OVERRRIDDEN_DATE_WITHOUT_CRD_COMMENT =
+      NomisTusedData(FIRST_OF_MARCH, FIRST_OF_APRIL, "UPDATE", "A1234AB")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.HistoricalTusedSource
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
@@ -782,6 +783,16 @@ class CalculationResultEnrichmentServiceTest {
         ReleaseDateHint("Adjusted to Mid term date (MTD) of the Detention and training order (DTO)"),
       ),
     )
+  }
+
+  @ParameterizedTest
+  @EnumSource(HistoricalTusedSource::class)
+  fun `TUSEDs that have historical status should get the appropriate hint`(source: HistoricalTusedSource) {
+    val tusedType = getReleaseDateAndStubAdjustments(ReleaseDateType.TUSED, LocalDate.of(2020, 5, 9))
+    val releaseDates = listOf(tusedType)
+    val calculationBreakdown = CalculationBreakdown(emptyList(), null)
+    val results = calculationResultEnrichmentService().addDetailToCalculationDates(releaseDates, null, calculationBreakdown, source)
+    assertThat(results[tusedType.type]?.hints).isEqualTo(listOf(ReleaseDateHint("TUSED recorded in NOMIS at time of release")))
   }
 
   private fun getReleaseDateAndStubAdjustments(type: ReleaseDateType, date: LocalDate): ReleaseDate {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -91,7 +91,9 @@ import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.MONTHS
 import java.time.temporal.ChronoUnit.WEEKS
 import java.time.temporal.ChronoUnit.YEARS
-import java.util.*
+import java.util.Date
+import java.util.Optional
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class CalculationTransactionalServiceTest {
@@ -742,7 +744,7 @@ class CalculationTransactionalServiceTest {
 
     val INPUT_DATA: JsonNode =
       JacksonUtil.toJsonNode(
-        "{\"offender\":{\"reference\":\"A1234AJ\",\"dateOfBirth\":\"1980-01-01\",\"isActiveSexOffender\":false}," +
+        "{\"historicalTusedData\":null, \"offender\":{\"reference\":\"A1234AJ\",\"dateOfBirth\":\"1980-01-01\",\"isActiveSexOffender\":false}," +
           "\"sentences\":[{\"type\":\"StandardSentence\",\"offence\":{\"committedAt\":\"2021-02-03\"," +
           "\"offenceCode\":null},\"duration\":{\"durationElements\":{\"DAYS\":0,\"WEEKS\":0,\"MONTHS\":0,\"YEARS\":5}}," +
           "\"sentencedAt\":\"2021-02-03\",\"identifier\":\"5ac7a5ae-fa7b-4b57-a44f-8eddde24f5fa\"," +

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenderKeyDatesServiceTest.kt
@@ -29,7 +29,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDatesA
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 open class OffenderKeyDatesServiceTest {
@@ -75,7 +76,7 @@ open class OffenderKeyDatesServiceTest {
     val detailedDates = mapOf(ReleaseDateType.HDCED to DetailedDate(ReleaseDateType.HDCED, ReleaseDateType.HDCED.description, LocalDate.of(2024, 1, 1), emptyList()))
 
     whenever(prisonService.getNOMISOffenderKeyDates(any())).thenReturn(offenderKeyDates.right())
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull())).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull(), isNull())).thenReturn(detailedDates)
     whenever(prisonService.getNOMISCalcReasons()).thenReturn(listOf(NomisCalculationReason(code = "FS", description = "Further Sentence")))
 
     val result = underTest.getNomisCalculationSummary(offenderSentCalcId)
@@ -142,7 +143,7 @@ open class OffenderKeyDatesServiceTest {
 
     whenever(prisonService.getOffenderKeyDates(any())).thenReturn(offenderKeyDates.right())
     whenever(calculationRequestRepository.findById(calcRequestId)).thenReturn(Optional.of(calcRequest))
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull())).thenReturn(detailedDates)
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull(), isNull())).thenReturn(detailedDates)
 
     val result = underTest.getKeyDatesByCalcId(calcRequestId)
 
@@ -233,7 +234,7 @@ open class OffenderKeyDatesServiceTest {
 
     whenever(prisonService.getOffenderKeyDates(any())).thenReturn(offenderKeyDates.right())
     whenever(calculationRequestRepository.findById(calcRequestId)).thenReturn(Optional.of(calcRequest))
-    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull()))
+    whenever(calculationResultEnrichmentService.addDetailToCalculationDates(Mockito.anyList(), isNull(), isNull(), isNull()))
       .thenThrow(NoSuchElementException("Error"))
 
     val exception = assertThrows<CrdWebException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiClientIntTest.kt
@@ -69,6 +69,26 @@ class PrisonApiClientIntTest(private val mockPrisonService: MockPrisonService) :
     assertThat(prisonApiClient.getOffenderKeyDates(bookingId)).isEqualTo(expectedError.left())
   }
 
+  @ParameterizedTest
+  @CsvSource(
+    "400,Bad request",
+    "403,User not authorised to access Tused",
+    "404,No Tused could be retrieved for Nomis ID A12345AB",
+    "500,Unknown: status code was 500",
+  )
+  fun `latest tudsed returns sensible errors`(status: Int, expectedError: String) {
+    val nomisId = "A12345AB"
+    mockPrisonService.withStub(
+      get("/api/offender-dates/latest-tused/$nomisId")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status),
+        ),
+    )
+    assertThat(prisonApiClient.getLatestTusedDataForBotus(nomisId)).isEqualTo(expectedError.left())
+  }
+
   @Test
   fun `can get NOMIS calc reasons`() {
     mockPrisonService.withStub(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonServiceTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CaseLo
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CaseLoadType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Agency
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CaseLoad
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisTusedData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NormalisedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.OffenderKeyDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RestResponsePage
@@ -27,7 +28,8 @@ import java.time.LocalDateTime
 class PrisonServiceTest {
   private val prisonApiClient = mock<PrisonApiClient>()
   private val offenceSDSReleaseArrangementLookupService = mock<OffenceSDSReleaseArrangementLookupService>()
-  private val prisonService = PrisonService(prisonApiClient, offenceSDSReleaseArrangementLookupService)
+  private val botusTusedService = mock<BotusTusedService>()
+  private val prisonService = PrisonService(prisonApiClient, offenceSDSReleaseArrangementLookupService, botusTusedService)
 
   @Test
   fun `getCurrentUserPrisonsList should exclude prisons where the establishment is KTI`() {
@@ -88,6 +90,15 @@ class PrisonServiceTest {
     whenever(prisonApiClient.getOffenderKeyDates(bookingId)).thenReturn(expected.right())
     val keyDates = prisonService.getOffenderKeyDates(bookingId)
     assertThat(keyDates).isEqualTo(expected.right())
+  }
+
+  @Test
+  fun `Latest Tused Data should be returned`() {
+    val nomisId = "A1234AA"
+    val expected = NomisTusedData(LocalDate.of(2023, 1, 3), LocalDate.of(2023, 1, 3), null, nomisId)
+    whenever(prisonApiClient.getLatestTusedDataForBotus(nomisId)).thenReturn(expected.right())
+    val latestTusedData = prisonService.getLatestTusedDataForBotus(nomisId)
+    assertThat(latestTusedData).isEqualTo(expected.right())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseDateMultiplierLookupTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseDateMultiplierLookupTest.kt
@@ -63,6 +63,7 @@ class ReleaseDateMultiplierLookupTest {
           SentenceIdentificationTrack.DTO_BEFORE_PCSC -> 0.5
           SentenceIdentificationTrack.DTO_AFTER_PCSC -> 0.5
           SentenceIdentificationTrack.BOTUS -> 1.00
+          SentenceIdentificationTrack.BOTUS_WITH_HISTORIC_TUSED -> 1.00
         }
       }.map { Arguments.of(it.key, it.value) }.stream()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationServiceTest.kt
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit.YEARS
 @ExtendWith(MockitoExtension::class)
 class SentenceIdentificationServiceTest {
   private val workingDayService = mock<WorkingDayService>()
+  private val botusTusedService = mock<BotusTusedService>()
   private val tusedCalculator = TusedCalculator(workingDayService)
   private val hdced4Calculator = Hdced4Calculator(hdcedConfigurationForTests(), SentenceAggregator(), ReleasePointMultiplierLookup(releasePointMultiplierConfigurationForTests()))
   private val sentenceIdentificationService: SentenceIdentificationService = SentenceIdentificationService(tusedCalculator, hdced4Calculator)


### PR DESCRIPTION
If a historical TUSED is present in NOMIS it will be added to the BOTUS sentence dates if it has not expired (is after the ARD/SED of the BOTUS senetence).