### PR TITLE
CRS-1981: HDCED4+ SDS+ consec chain fix for remand and tagged bail

### DIFF
--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -448,4 +448,7 @@ custom-examples,crs-1967-ersed-before-ard-and-mtd,,calculation-params
 
 custom-examples,crs-1994-ac3,,calculation-params
 custom-examples,crs-1994-ac7,,calculation-params
+custom-examples,crs-1981-ac1,,calculation-params
+custom-examples,crs-1981-ac2,,calculation-params
+custom-examples,crs-1981-ac3,,calculation-params
 

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac1.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac1.json
@@ -1,0 +1,56 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "1994-11-24",
+    "isActiveSexOffender": false
+  },
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 7
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e7e",
+      "isSDSPlus": true
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "consecutiveSentenceUUIDs": ["a31d5d02-611f-43b0-8b1a-4b1edc955e7e"]
+    }
+  ],
+  "adjustments": {
+    "REMAND":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 344,
+        "fromDate":"2021-05-27",
+        "toDate":"2022-05-05"
+      }
+    ],
+    "TAGGED_BAIL":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 143
+      }
+    ]
+
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac2.json
@@ -1,0 +1,56 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "1994-11-24",
+    "isActiveSexOffender": false
+  },
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 7
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e7e",
+      "isSDSPlus": true
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 3
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "consecutiveSentenceUUIDs": ["a31d5d02-611f-43b0-8b1a-4b1edc955e7e"]
+    }
+  ],
+  "adjustments": {
+    "REMAND":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 344,
+        "fromDate":"2021-05-27",
+        "toDate":"2022-05-05"
+      }
+    ],
+    "TAGGED_BAIL":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 143
+      }
+    ]
+
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac3.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1981-ac3.json
@@ -1,0 +1,56 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "1994-11-24",
+    "isActiveSexOffender": false
+  },
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 7
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e7e",
+      "isSDSPlus": true
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-06"
+      },
+      "duration": {
+        "durationElements": {
+          "WEEKS": 14
+        }
+      },
+      "sentencedAt": "2022-05-06",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "consecutiveSentenceUUIDs": ["a31d5d02-611f-43b0-8b1a-4b1edc955e7e"]
+    }
+  ],
+  "adjustments": {
+    "REMAND":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 344,
+        "fromDate":"2021-05-27",
+        "toDate":"2022-05-05"
+      }
+    ],
+    "TAGGED_BAIL":[
+      {
+        "appliesToSentencesFrom":"2022-05-06",
+        "numberOfDays": 143
+      }
+    ]
+
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac1.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2028-07-06",
+    "CRD": "2025-12-04",
+    "HDCED4PLUS": "2025-10-21",
+    "ESED": "2029-11-05"
+  },
+  "effectiveSentenceLength": "P7Y6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2031-01-04",
+    "CRD": "2027-03-06",
+    "HDCED4PLUS": "2026-09-08",
+    "ESED": "2032-05-05"
+  },
+  "effectiveSentenceLength": "P10Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac3.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1981-ac3.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2028-04-11",
+    "CRD": "2025-10-23",
+    "HDCED4PLUS": "2025-10-03",
+    "ESED": "2029-08-11"
+  },
+  "effectiveSentenceLength": "P7Y3M6D"
+}


### PR DESCRIPTION
Apply remand and tagged bail to the SDS+ notional CRD before calculating HDCED4+. This is to ensure that it is not before the CRD of the SDS+ sentences.