### PR TITLE
CRS-1997 Stop preventing HDCED when there are  EDS/SOPC sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AFineSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetentionAndTrainingOrderSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -513,10 +513,7 @@ class BookingExtractionService(
     val latestAdjustedReleaseDate = mostRecentSentencesByReleaseDate[0].sentenceCalculation.releaseDate
     val mostRecentReleaseIsPrrd =
       mostRecentSentencesByReleaseDate.any { it.releaseDateTypes.getReleaseDateTypes().contains(PRRD) }
-    val mostRecentReleaseIsPed =
-      mostRecentSentencesByReleaseDate.any { it.releaseDateTypes.getReleaseDateTypes().contains(PED) }
-    // For now we can't calculate HDCED if there is a consecutive sentence with EDS or SOPC sentences
-    if (!mostRecentReleaseIsPrrd && !mostRecentReleaseIsPed && sentences.none { it is ConsecutiveSentence && it.hasAnyEdsOrSopcSentence() }) {
+    if (!mostRecentReleaseIsPrrd) {
       val latestNonRecallRelease = extractionService.mostRecentSentenceOrNull(
         sentences.filter { !it.isRecall() && !it.isDto() },
         SentenceCalculation::releaseDate,
@@ -609,10 +606,7 @@ class BookingExtractionService(
     val latestAdjustedReleaseDate = mostRecentSentencesByReleaseDate[0].sentenceCalculation.releaseDate
     val mostRecentReleaseIsPrrd =
       mostRecentSentencesByReleaseDate.any { it.releaseDateTypes.getReleaseDateTypes().contains(PRRD) }
-    // For now we can't calculate HDCED if there is a consecutive sentence with EDS or SOPC sentences
-    if (!mostRecentReleaseIsPrrd && sentences.none { (it is ConsecutiveSentence && it.hasAnyEdsOrSopcSentence()) } &&
-      sentences.none { (it is ConsecutiveSentence && it.releaseDateTypes.contains(PED)) }
-    ) {
+    if (!mostRecentReleaseIsPrrd) {
       val latestNonRecallRelease = extractionService.mostRecentSentenceOrNull(
         sentences.filter { !it.isRecall() && !it.isDto() },
         SentenceCalculation::releaseDate,

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -452,3 +452,8 @@ custom-examples,crs-1981-ac1,,calculation-params
 custom-examples,crs-1981-ac2,,calculation-params
 custom-examples,crs-1981-ac3,,calculation-params
 
+custom-examples,crs-1997-ac1-hdc-eds-concurrent-sds,,calculation-params
+custom-examples,crs-1997-ac2-hdc-eds-concurrent-sds,,calculation-params
+custom-examples,crs-1997-ac3-hdc-sopc-consec-sds,,calculation-params
+custom-examples,crs-1997-ac4-hdc-eds-consec-sds,,calculation-params
+custom-examples,crs-1997-ac5-hdc-sopc-consec-sds,,calculation-params

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac1-hdc-eds-concurrent-sds.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac1-hdc-eds-concurrent-sds.json
@@ -1,0 +1,40 @@
+{
+  "offender":{
+    "reference": "ABC123D",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences":[
+    {
+      "type":"ExtendedDeterminateSentence",
+      "offence":{
+        "committedAt":"2023-01-25"
+      },
+      "custodialDuration":{
+        "durationElements":{
+          "YEARS": 5
+        }
+      },
+      "extensionDuration":{
+        "durationElements":{
+          "YEARS": 3
+        }
+      },
+      "automaticRelease":false,
+      "sentencedAt":"2023-01-25"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-01-25"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 4
+        }
+      },
+      "sentencedAt": "2023-01-25",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "isSDSPlus": false
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac2-hdc-eds-concurrent-sds.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac2-hdc-eds-concurrent-sds.json
@@ -1,0 +1,41 @@
+{
+  "offender":{
+    "reference": "ABC123D",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences":[
+    {
+      "type":"ExtendedDeterminateSentence",
+      "offence":{
+        "committedAt":"2023-01-25"
+      },
+      "custodialDuration":{
+        "durationElements":{
+          "YEARS": 5
+        }
+      },
+      "extensionDuration":{
+        "durationElements":{
+          "YEARS": 3
+        }
+      },
+      "automaticRelease":false,
+      "sentencedAt":"2023-01-25"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-01-25"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 10,
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2023-01-25",
+      "hasAnSDSEarlyReleaseExclusion": "NO",
+      "isSDSPlus": false
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac3-hdc-sopc-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac3-hdc-sopc-consec-sds.json
@@ -1,0 +1,53 @@
+{
+  "offender":{
+    "reference": "ABC123D",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences":[
+    {
+      "type":"SopcSentence",
+      "offence":{
+        "committedAt":"2022-02-24"
+      },
+      "custodialDuration":{
+        "durationElements":{
+          "YEARS": 4
+        }
+      },
+      "extensionDuration":{
+        "durationElements":{
+          "YEARS": 1
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "identifier":"83fd11aa-a579-3b93-aaba-937e138aec88"
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 2
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "consecutiveSentenceUUIDs":[
+        "83fd11aa-a579-3b93-aaba-937e138aec88"
+      ]
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 4
+        }
+      },
+      "sentencedAt":"2023-08-02"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac4-hdc-eds-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac4-hdc-eds-consec-sds.json
@@ -1,0 +1,54 @@
+{
+  "offender":{
+    "reference": "ABC123D",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences":[
+    {
+      "type":"ExtendedDeterminateSentence",
+      "offence":{
+        "committedAt":"2022-02-24"
+      },
+      "custodialDuration":{
+        "durationElements":{
+          "YEARS": 4,
+          "MONTHS": 3
+        }
+      },
+      "extensionDuration":{
+        "durationElements":{
+          "YEARS": 2
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "identifier":"83fd11aa-a579-3b93-aaba-937e138aec88"
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 2
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "consecutiveSentenceUUIDs":[
+        "83fd11aa-a579-3b93-aaba-937e138aec88"
+      ]
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 10
+        }
+      },
+      "sentencedAt":"2023-08-02"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac5-hdc-sopc-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1997-ac5-hdc-sopc-consec-sds.json
@@ -1,0 +1,53 @@
+{
+  "offender":{
+    "reference": "ABC123D",
+    "dateOfBirth": "1970-03-03"
+  },
+  "sentences":[
+    {
+      "type":"SopcSentence",
+      "offence":{
+        "committedAt":"2022-02-24"
+      },
+      "custodialDuration":{
+        "durationElements":{
+          "YEARS": 4
+        }
+      },
+      "extensionDuration":{
+        "durationElements":{
+          "YEARS": 1
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "identifier":"83fd11aa-a579-3b93-aaba-937e138aec88"
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 2
+        }
+      },
+      "sentencedAt":"2023-01-25",
+      "consecutiveSentenceUUIDs":[
+        "83fd11aa-a579-3b93-aaba-937e138aec88"
+      ]
+    },
+    {
+      "type": "StandardSentence",
+      "offence":{
+        "committedAt":"2022-11-25"
+      },
+      "duration":{
+        "durationElements":{
+          "YEARS": 10
+        }
+      },
+      "sentencedAt":"2023-08-02"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1012-hdc-for-eds-sopc-ac4.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1012-hdc-for-eds-sopc-ac4.json
@@ -2,6 +2,8 @@
   "dates": {
     "SLED": "2024-05-09",
     "CRD": "2023-04-12",
+    "HDCED": "2023-04-09",
+    "HDCED4PLUS": "2023-04-09",
     "ESED": "2024-06-23"
   },
   "effectiveSentenceLength": "P2Y2M"

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac1-hdc-eds-concurrent-sds.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac1-hdc-eds-concurrent-sds.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2031-01-24",
+    "CRD": "2028-01-24",
+    "PED": "2026-05-26",
+    "ESED": "2031-01-24"
+  },
+  "effectiveSentenceLength": "P8Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac2-hdc-eds-concurrent-sds.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac2-hdc-eds-concurrent-sds.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2033-07-24",
+    "CRD": "2028-04-24",
+    "HDCED4PLUS": "2028-01-24",
+    "ESED": "2033-07-24"
+  },
+  "effectiveSentenceLength": "P10Y6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac3-hdc-sopc-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac3-hdc-sopc-consec-sds.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2030-01-24",
+    "CRD": "2028-01-25",
+    "PED": "2026-09-25",
+    "ESED": "2030-01-24"
+  },
+  "effectiveSentenceLength": "P7Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac4-hdc-eds-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac4-hdc-eds-consec-sds.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2033-08-01",
+    "CRD": "2028-08-01",
+    "HDCED4PLUS": "2028-04-25",
+    "ESED": "2033-08-01"
+  },
+  "effectiveSentenceLength": "P10Y6M8D"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac5-hdc-sopc-consec-sds.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1997-ac5-hdc-sopc-consec-sds.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2033-08-01",
+    "CRD": "2028-08-01",
+    "HDCED4PLUS": "2028-02-04",
+    "ESED": "2033-08-01"
+  },
+  "effectiveSentenceLength": "P10Y6M8D"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-876-eds-sds-ac15.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-876-eds-sds-ac15.json
@@ -2,6 +2,7 @@
   "dates": {
     "SLED": "2025-02-12",
     "CRD": "2020-12-07",
+    "HDCED4PLUS":"2020-06-11",
     "ESED": "2025-02-12"
   },
   "effectiveSentenceLength": "P10Y"


### PR DESCRIPTION
* Enables HDCED to be generated for chains that have EDS/SOPC in them, when it was previously omitted from the results.