### PR TITLE
SDS40 Recall TUSED 50/40 calc bug

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -668,13 +668,13 @@ class CalculationTransactionalServiceTest {
     val hdced4Calculator = Hdced4Calculator(hdcedConfiguration, sentenceAggregator, releasePointMultiplierLookup)
     val ersedCalculator = ErsedCalculator(ersedConfiguration)
     val featureToggles = FeatureToggles(botus = false, sdsEarlyRelease = isNotDefaultParams)
-    val sdsEarlyReleaseDefaultingRulesService = SDSEarlyReleaseDefaultingRulesService()
     val sentenceAdjustedCalculationService =
       SentenceAdjustedCalculationService(hdcedCalculator, tusedCalculator, hdced4Calculator, ersedCalculator)
     val sentenceCalculationService =
       SentenceCalculationService(sentenceAdjustedCalculationService, releasePointMultiplierLookup, sentenceAggregator)
     val sentencesExtractionService = SentencesExtractionService()
     val sentenceIdentificationService = SentenceIdentificationService(tusedCalculator, hdced4Calculator)
+    val sdsEarlyReleaseDefaultingRulesService = SDSEarlyReleaseDefaultingRulesService(sentencesExtractionService)
     val bookingCalculationService = BookingCalculationService(
       sentenceCalculationService,
       sentenceIdentificationService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseDefaultingRulesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseDefaultingRulesServiceTest.kt
@@ -33,7 +33,7 @@ import java.util.*
 class SDSEarlyReleaseDefaultingRulesServiceTest {
 
   private val testCommencementDate = LocalDate.of(2024, 7, 29)
-  private val service = SDSEarlyReleaseDefaultingRulesService()
+  private val service = SDSEarlyReleaseDefaultingRulesService(SentencesExtractionService())
 
   @Test
   fun `should not require recalculation if no SDS early release`() {
@@ -367,7 +367,28 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
       hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
     )
     sentence.identificationTrack = identificationTrack
-    return Booking(
+    val date = LocalDate.of(2024, 1, 1)
+    val sentenceCalculation = SentenceCalculation(
+      sentence,
+      3,
+      4.0,
+      4,
+      4,
+      date,
+      date,
+      unadjustedDeterminateReleaseDate = testCommencementDate.plusDays(1),
+      1,
+      date,
+      false,
+      Adjustments(
+        mutableMapOf(AdjustmentType.REMAND to mutableListOf(Adjustment(numberOfDays = 1, appliesToSentencesFrom = date))),
+      ),
+      date,
+      date,
+    )
+    sentence.sentenceCalculation = sentenceCalculation
+
+    val booking = Booking(
       Offender("a", LocalDate.of(1980, 1, 1), true),
       listOf(
         sentence,
@@ -377,5 +398,7 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
       null,
       123,
     )
+    booking.consecutiveSentences = emptyList()
+    return booking
   }
 }

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -494,3 +494,6 @@ custom-examples,crs-2049-added-days-ersed-ac1,,alt-3-calculation-params
 custom-examples,crs-2049-added-days-ersed-ac2,,alt-3-calculation-params
 custom-examples,crs-2049-added-days-ersed-ac3,,alt-3-calculation-params
 custom-examples,crs-2072-sds40-recall-tused-bug,,alt-3-calculation-params
+custom-examples,SDS40-TUSED-50-Bug,,alt-3-calculation-params
+custom-examples,SDS40-TUSED-50-Bug-ex-2,,alt-3-calculation-params
+custom-examples,SDS40-TUSED-50-Bug-ex-3,,alt-3-calculation-params

--- a/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug-ex-2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug-ex-2.json
@@ -1,0 +1,153 @@
+{
+  "offender": {
+    "reference": "A1234AA",
+    "dateOfBirth": "1985-01-01",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2021-09-27",
+        "offenceCode": "TH68079"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 15
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "644a3db1-5522-33e3-8a8f-d578d249df13",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-10-25",
+      "caseSequence": 1,
+      "lineSequence": 6,
+      "caseReference": "LR",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-02-01",
+        "offenceCode": "TH68006"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 3
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "d51a20a1-04cc-3ec5-a2c0-040856b624dd",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-10-25",
+      "caseSequence": 1,
+      "lineSequence": 7,
+      "caseReference": "LR",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-04-26",
+        "offenceCode": "TH68078"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 4
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07811190-fe7d-3a52-ad38-4ca39faf7140",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-10-25",
+      "caseSequence": 2,
+      "lineSequence": 8,
+      "caseReference": "LR",
+      "consecutiveSentenceUUIDs": [
+        "644a3db1-5522-33e3-8a8f-d578d249df13"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-07-14",
+        "offenceCode": "FA06001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 4
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "f534d5f5-a423-3222-bcbc-34f4e9d0bb40",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-10-25",
+      "caseSequence": 2,
+      "lineSequence": 9,
+      "caseReference": "LR",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-17",
+        "offenceCode": "TH68079"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 161,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "dfbd8efa-ae69-3cc9-8dc1-5232a2a9339e",
+      "recallType": null,
+      "sentencedAt": "2024-06-26",
+      "caseSequence": 4,
+      "lineSequence": 10,
+      "caseReference": "46ZY1395024",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2024-05-20",
+        "fromDate": "2024-05-18",
+        "numberOfDays": 3,
+        "appliesToSentencesFrom": "2024-06-26"
+      }
+    ],
+    "RECALL_REMAND": [
+      {
+        "toDate": "2023-10-24",
+        "fromDate": "2023-08-09",
+        "numberOfDays": 77,
+        "appliesToSentencesFrom": "2023-10-25"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug-ex-3.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug-ex-3.json
@@ -1,0 +1,145 @@
+{
+  "offender": {
+    "reference": "A1234AA",
+    "dateOfBirth": "1988-01-01",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-11-07",
+        "offenceCode": "OF61131"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 15
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "ac46978d-8147-346a-b628-f832561d203e",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2024-02-14",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "13LD1166523",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-01-10",
+        "offenceCode": "DA05001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 2,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "95e47b57-fcdd-318d-8305-157e677c26bc",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2024-02-14",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "13LD0050023",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2021-03-03",
+        "offenceCode": "PU86116"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 2,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "cd434ecb-ecb0-3c1f-8e5e-ad0d3f0aeb56",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2024-02-14",
+      "caseSequence": 2,
+      "lineSequence": 3,
+      "caseReference": "13LD0050023",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-01",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "e7acfe9e-4c3b-3153-a90d-ec022fb81b8e",
+      "recallType": null,
+      "sentencedAt": "2024-07-03",
+      "caseSequence": 3,
+      "lineSequence": 4,
+      "caseReference": "13LD0672024",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-01",
+        "offenceCode": "PH97003"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 12,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "70c770c3-acac-319d-88d9-c23a75aa0864",
+      "recallType": null,
+      "sentencedAt": "2024-07-03",
+      "caseSequence": 3,
+      "lineSequence": 5,
+      "caseReference": "13LD0672024",
+      "consecutiveSentenceUUIDs": [
+        "e7acfe9e-4c3b-3153-a90d-ec022fb81b8e"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "toDate": "2024-02-13",
+        "fromDate": "2023-11-08",
+        "numberOfDays": 98,
+        "appliesToSentencesFrom": "2024-02-14"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/SDS40-TUSED-50-Bug.json
@@ -1,0 +1,330 @@
+{
+  "offender": {
+    "reference": "A1234AA",
+    "dateOfBirth": "1986-01-01",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-04-30",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07b6a46e-19b9-34c5-a774-42f43e69bf3b",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-05-08",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "16XL0892824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-01",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07b6a46e-19b9-34c5-a774-42f43e69bf3b",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-05-08",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "16XL0892824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-04-30",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07b6a46e-19b9-34c5-a774-42f43e69bf3b",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-05-08",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "16XL0892824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-01",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07b6a46e-19b9-34c5-a774-42f43e69bf3b",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-05-08",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "16XL0892824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-03",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 16,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "07b6a46e-19b9-34c5-a774-42f43e69bf3b",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-05-08",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "16XL0892824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-25",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 4,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "c9fbce5c-54d1-3367-b07a-68cf472b4374",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 3,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-27",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 4,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "10c68c3e-7946-3a49-93cb-e062fe642307",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 4,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-25",
+        "offenceCode": "CJ88001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 4,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "372d0e7b-0220-32b6-8fd9-512272b1633a",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 5,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-22",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "291bd414-68a9-32f3-9965-33457304866a",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 6,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-14",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "4f5f2760-6611-354b-9786-78efbab5f517",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 7,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-15",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "5c64a902-3831-396c-80ae-7b7c1f2dd244",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 8,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-21",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "e5e7cf08-aedb-33c2-9a47-e0231b4b1347",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 9,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-07-22",
+        "offenceCode": "PU86116"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "8f63f750-c9d5-3817-b84f-236ce486393c",
+      "recallType": null,
+      "sentencedAt": "2024-07-29",
+      "caseSequence": 3,
+      "lineSequence": 10,
+      "caseReference": "16XL1413124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {},
+  "historicalTusedData": null,
+  "returnToCustodyDate": "2024-07-27",
+  "fixedTermRecallDetails": {
+    "bookingId": 1,
+    "recallLength": 14,
+    "returnToCustodyDate": "2024-07-27"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug-ex-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug-ex-2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-03-08",
+    "TUSED": "2025-08-26",
+    "PRRD": "2025-03-08",
+    "ESED": "2025-05-24"
+  },
+  "effectiveSentenceLength": "P1Y7M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug-ex-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug-ex-3.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-02-04",
+    "TUSED": "2025-09-19",
+    "PRRD": "2025-02-04",
+    "ESED": "2025-05-13"
+  },
+  "effectiveSentenceLength": "P1Y3M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/SDS40-TUSED-50-Bug.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2025-01-26",
+    "CRD": "2024-10-09",
+    "TUSED": "2025-10-09",
+    "HDCED": "2024-09-10",
+    "HDCED4PLUS": "2024-09-10",
+    "ESED": "2025-01-26"
+  },
+  "effectiveSentenceLength": "P8M19D"
+}


### PR DESCRIPTION
* Reworks fix applied previously which worked for a subset of recalls, but resulted in the wrong TUSED being used for others with CRDs post commencement date.