### PR TITLE
Fix for multiple sentences boundary issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/Tranche.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/Tranche.kt
@@ -40,12 +40,21 @@ interface Tranche {
 
       if (filteredSentences.any()) {
         val earliestSentencedAt = filteredSentences.minBy { it.sentencedAt }
-        filteredSentences.sumOf { it.getLengthInDays() }.let {
-          ChronoUnit.YEARS.between(
-            earliestSentencedAt.sentencedAt,
-            earliestSentencedAt.sentencedAt.plus(it.toLong(), ChronoUnit.DAYS),
-          )
+        var concurrentSentenceEndDate = earliestSentencedAt.sentencedAt
+
+        // Iterate over the sentences to update the concurrentSentenceEndDate
+        filteredSentences.forEach { sentence ->
+          // Update the concurrent end date by calculating the new end date from the current end date
+          concurrentSentenceEndDate = sentence.totalDuration().getEndDate(concurrentSentenceEndDate).plusDays(1)
         }
+
+        // Calculate the difference in years between the earliest sentenced date and the final concurrentSentenceEndDate
+        val yearsBetween = ChronoUnit.YEARS.between(
+          earliestSentencedAt.sentencedAt,
+          concurrentSentenceEndDate,
+        )
+
+        yearsBetween
       } else {
         0
       }
@@ -53,7 +62,7 @@ interface Tranche {
       if (filterOnType(sentenceToFilter, trancheCommencementDate, trancheTwoCommencementDate)) {
         ChronoUnit.YEARS.between(
           sentenceToFilter.sentencedAt,
-          sentenceToFilter.sentencedAt.plus(sentenceToFilter.getLengthInDays().toLong(), ChronoUnit.DAYS),
+          sentenceToFilter.sentencedAt.plus(sentenceToFilter.getLengthInDays().toLong(), ChronoUnit.DAYS).plusDays(1),
         )
       } else {
         0

--- a/src/test/resources/test_data/calculation-sds-early-tranching.csv
+++ b/src/test/resources/test_data/calculation-sds-early-tranching.csv
@@ -24,3 +24,6 @@ tranches,consec-terms-of-imprisonment,,alt-3-calculation-params
 tranches,calc-bug-1,,alt-3-calculation-params
 tranches,calc-bug-2,,alt-3-calculation-params
 tranches,calc-bug-3,,alt-3-calculation-params
+
+tranches,crs-2121_2x2.5,,alt-3-calculation-params
+tranches,crs-2121_2.5_plus_2.49,,alt-3-calculation-params

--- a/src/test/resources/test_data/calculation-sds-early-tranching.csv
+++ b/src/test/resources/test_data/calculation-sds-early-tranching.csv
@@ -27,3 +27,4 @@ tranches,calc-bug-3,,alt-3-calculation-params
 
 tranches,crs-2121_2x2.5,,alt-3-calculation-params
 tranches,crs-2121_2.5_plus_2.49,,alt-3-calculation-params
+tranches,crs-2121_5x1,,alt-3-calculation-params

--- a/src/test/resources/test_data/calculation-sds-early-tranching.csv
+++ b/src/test/resources/test_data/calculation-sds-early-tranching.csv
@@ -28,3 +28,4 @@ tranches,calc-bug-3,,alt-3-calculation-params
 tranches,crs-2121_2x2.5,,alt-3-calculation-params
 tranches,crs-2121_2.5_plus_2.49,,alt-3-calculation-params
 tranches,crs-2121_5x1,,alt-3-calculation-params
+tranches,crs-2121_4x1_plus_0.9,,alt-3-calculation-params

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2.5_plus_2.49.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2.5_plus_2.49.json
@@ -1,0 +1,73 @@
+{
+  "offender": {
+    "reference": "A4608EV",
+    "dateOfBirth": "2001-05-26",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2021-09-12",
+        "offenceCode": "MD71230"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 2,
+          "MONTHS": 6
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "b26081b5-2d29-3d5e-b49e-d9a773f4a04e",
+      "recallType": null,
+      "sentencedAt": "2023-02-16",
+      "caseSequence": 2,
+      "lineSequence": 1,
+      "caseReference": "T20220152",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-18",
+        "offenceCode": "MD71230"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 30,
+          "WEEKS": 0,
+          "YEARS": 2,
+          "MONTHS": 5
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "d2776338-c642-39ff-b9cd-49326afe9cef",
+      "recallType": null,
+      "sentencedAt": "2023-02-16",
+      "caseSequence": 1,
+      "lineSequence": 2,
+      "caseReference": "T20220103",
+      "consecutiveSentenceUUIDs": [
+        "b26081b5-2d29-3d5e-b49e-d9a773f4a04e"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2023-02-15",
+        "fromDate": "2022-05-19",
+        "numberOfDays": 273,
+        "appliesToSentencesFrom": "2023-02-16"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2x2.5.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2x2.5.json
@@ -1,6 +1,6 @@
 {
   "offender": {
-    "reference": "A4608EV",
+    "reference": "A1234EV",
     "dateOfBirth": "2001-05-26",
     "isActiveSexOffender": false
   },

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2x2.5.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2121_2x2.5.json
@@ -1,0 +1,73 @@
+{
+  "offender": {
+    "reference": "A4608EV",
+    "dateOfBirth": "2001-05-26",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2021-09-12",
+        "offenceCode": "MD71230"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 2,
+          "MONTHS": 6
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "b26081b5-2d29-3d5e-b49e-d9a773f4a04e",
+      "recallType": null,
+      "sentencedAt": "2023-02-16",
+      "caseSequence": 2,
+      "lineSequence": 1,
+      "caseReference": "T20220152",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-05-18",
+        "offenceCode": "MD71230"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 2,
+          "MONTHS": 6
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "d2776338-c642-39ff-b9cd-49326afe9cef",
+      "recallType": null,
+      "sentencedAt": "2023-02-16",
+      "caseSequence": 1,
+      "lineSequence": 2,
+      "caseReference": "T20220103",
+      "consecutiveSentenceUUIDs": [
+        "b26081b5-2d29-3d5e-b49e-d9a773f4a04e"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2023-02-15",
+        "fromDate": "2022-05-19",
+        "numberOfDays": 273,
+        "appliesToSentencesFrom": "2023-02-16"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2121_4x1_plus_0.9.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2121_4x1_plus_0.9.json
@@ -1,0 +1,129 @@
+{
+  "offender": {
+    "reference": "A1234EV",
+    "dateOfBirth": "2001-05-26",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "9a2f3c87-5f63-4f97-9833-d9f056b4a6a4",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "T20230101",
+      "consecutiveSentenceUUIDs": ["21f1c16a-9a4c-4cb5-a8a3-fc8db63507d8"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "21f1c16a-9a4c-4cb5-a8a3-fc8db63507d8",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "T20230102",
+      "consecutiveSentenceUUIDs": ["7a4e7182-3370-4db8-8b4b-d8f86c2ae2e8"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "7a4e7182-3370-4db8-8b4b-d8f86c2ae2e8",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 3,
+      "lineSequence": 3,
+      "caseReference": "T20230103",
+      "consecutiveSentenceUUIDs": ["1d7a23a8-f99e-44b0-8b15-4e45b799501d"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "1d7a23a8-f99e-44b0-8b15-4e45b799501d",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 4,
+      "lineSequence": 4,
+      "caseReference": "T20230104",
+      "consecutiveSentenceUUIDs": ["35b1de4b-9882-4967-a624-f16d89fbd224"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 11,
+          "DAYS": 30
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "35b1de4b-9882-4967-a624-f16d89fbd224",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 5,
+      "lineSequence": 5,
+      "caseReference": "T20230105",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2023-04-02",
+        "fromDate": "2023-03-11",
+        "numberOfDays": 23,
+        "appliesToSentencesFrom": "2023-04-03"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2121_5x1.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2121_5x1.json
@@ -1,0 +1,128 @@
+{
+  "offender": {
+    "reference": "A1234EV",
+    "dateOfBirth": "2001-05-26",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "9a2f3c87-5f63-4f97-9833-d9f056b4a6a4",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "T20230101",
+      "consecutiveSentenceUUIDs": ["21f1c16a-9a4c-4cb5-a8a3-fc8db63507d8"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "21f1c16a-9a4c-4cb5-a8a3-fc8db63507d8",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "T20230102",
+      "consecutiveSentenceUUIDs": ["7a4e7182-3370-4db8-8b4b-d8f86c2ae2e8"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "7a4e7182-3370-4db8-8b4b-d8f86c2ae2e8",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 3,
+      "lineSequence": 3,
+      "caseReference": "T20230103",
+      "consecutiveSentenceUUIDs": ["1d7a23a8-f99e-44b0-8b15-4e45b799501d"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "1d7a23a8-f99e-44b0-8b15-4e45b799501d",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 4,
+      "lineSequence": 4,
+      "caseReference": "T20230104",
+      "consecutiveSentenceUUIDs": ["35b1de4b-9882-4967-a624-f16d89fbd224"],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-03-03",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "35b1de4b-9882-4967-a624-f16d89fbd224",
+      "recallType": null,
+      "sentencedAt": "2023-04-03",
+      "caseSequence": 5,
+      "lineSequence": 5,
+      "caseReference": "T20230105",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2023-04-02",
+        "fromDate": "2023-03-11",
+        "numberOfDays": 23,
+        "appliesToSentencesFrom": "2023-04-03"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_2.5_plus_2.49.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_2.5_plus_2.49.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2027-05-17",
+    "CRD": "2024-09-10",
+    "HDCED4PLUS": "2024-05-21",
+    "ESED": "2028-02-14"
+  },
+  "effectiveSentenceLength": "P4Y11M30D",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_2x2.5.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_2x2.5.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2027-05-18",
+    "CRD": "2024-10-22",
+    "HDCED4PLUS": "2024-05-21",
+    "ESED": "2028-02-15"
+  },
+  "effectiveSentenceLength": "P5Y",
+  "sdsEarlyReleaseTranche": "TRANCHE_2",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_2"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_4x1_plus_0.9.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_4x1_plus_0.9.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-03-09",
+    "CRD": "2025-03-10",
+    "HDCED4PLUS": "2024-09-12",
+    "ESED": "2028-04-01"
+  },
+  "effectiveSentenceLength": "P4Y11M30D",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_5x1.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2121_5x1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-03-10",
+    "CRD": "2025-03-10",
+    "HDCED4PLUS": "2024-10-22",
+    "ESED": "2028-04-02"
+  },
+  "effectiveSentenceLength": "P5Y",
+  "sdsEarlyReleaseTranche": "TRANCHE_2",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_2"
+}


### PR DESCRIPTION
Initial version of the fix, for @Sean to review
Apply the totalduration based on the concurrent sentence start date of the previous sentence. This adds a single day for each new sentence.
A further test case will be added for several sentences reaching 5 years