### PR TITLE
Identify HDCED dates from before commencement that only come from 50% release

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseDefaultingRulesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseDefaultingRulesService.kt
@@ -35,7 +35,7 @@ class SDSEarlyReleaseDefaultingRulesService(
     val breakdownByReleaseDateType = earlyReleaseResult.breakdownByReleaseDateType.toMutableMap()
     var overriddenTranche = allocatedTranche
 
-    if (hasAnyReleaseBeforeTrancheCommencement(earlyReleaseResult, trancheCommencementDate)) {
+    if (hasAnyReleaseBeforeTrancheCommencement(earlyReleaseResult, standardReleaseResult, trancheCommencementDate)) {
       DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE.forEach { releaseDateType ->
         mergeDate(
           releaseDateType,
@@ -102,11 +102,15 @@ class SDSEarlyReleaseDefaultingRulesService(
     anInitialCalc.sentences.any { it.identificationTrack == SentenceIdentificationTrack.SDS_EARLY_RELEASE }
 
   fun hasAnyReleaseBeforeTrancheCommencement(
-    result: CalculationResult,
+    early: CalculationResult,
+    late: CalculationResult,
     trancheCommencementDate: LocalDate?,
   ): Boolean {
     return DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE
-      .mapNotNull { result.dates[it] }
+      .mapNotNull {
+          dateType ->
+        early.dates[dateType] ?: late.dates[dateType]
+      }
       .any { it < trancheCommencementDate }
   }
 

--- a/src/test/resources/test_data/calculation-sds-early-tranching.csv
+++ b/src/test/resources/test_data/calculation-sds-early-tranching.csv
@@ -29,3 +29,5 @@ tranches,crs-2121_2x2.5,,alt-3-calculation-params
 tranches,crs-2121_2.5_plus_2.49,,alt-3-calculation-params
 tranches,crs-2121_5x1,,alt-3-calculation-params
 tranches,crs-2121_4x1_plus_0.9,,alt-3-calculation-params
+
+tranches,crs-1871_ftr_consec,,alt-3-calculation-params

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-1871_ftr_consec.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-1871_ftr_consec.json
@@ -1,0 +1,196 @@
+{
+  "offender": {
+    "reference": "A1234BC",
+    "dateOfBirth": "1990-01-01",
+    "isActiveSexOffender": false
+  },
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-03-19",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "1f47da8a-255d-3e2e-a4b5-a3c7dec8f955",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-04-15",
+      "caseSequence": 2,
+      "lineSequence": 1,
+      "caseReference": "22DA1074824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-09-30",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 18,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "e532a54c-6db3-3375-be3d-78926d381659",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-04-15",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "22DA1074824",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-02-12",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "943a8727-78ea-325e-912b-197e77701aca",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-04-15",
+      "caseSequence": 1,
+      "lineSequence": 3,
+      "caseReference": "22DA1058624",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-31",
+        "offenceCode": "SE20001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 9,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "b71e09b6-3728-3b80-8e86-b1c40d52c812",
+      "recallType": null,
+      "sentencedAt": "2024-08-12",
+      "caseSequence": 3,
+      "lineSequence": 4,
+      "caseReference": "22DA1148124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-31",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 3,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "b8cfc318-9527-32a8-9e88-fd85bc74ecdd",
+      "recallType": null,
+      "sentencedAt": "2024-08-12",
+      "caseSequence": 3,
+      "lineSequence": 5,
+      "caseReference": "22DA1148124",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-11-07",
+        "offenceCode": "FA06001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 2,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "b1966a59-898a-3acf-afc3-711860b89660",
+      "recallType": null,
+      "sentencedAt": "2024-08-12",
+      "caseSequence": 4,
+      "lineSequence": 6,
+      "caseReference": "22DA1001224",
+      "consecutiveSentenceUUIDs": [
+        "b71e09b6-3728-3b80-8e86-b1c40d52c812"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-02-23",
+        "offenceCode": "TH68010"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 2,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "bd8d7232-2ed2-3c5b-9e0a-e0489cc5de2b",
+      "sentencedAt": "2024-08-12",
+      "caseSequence": 5,
+      "lineSequence": 7,
+      "caseReference": "22DA1100724",
+      "consecutiveSentenceUUIDs": [
+        "b1966a59-898a-3acf-afc3-711860b89660"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "toDate": "2024-08-09",
+        "fromDate": "2024-07-06",
+        "numberOfDays": 35,
+        "appliesToSentencesFrom": "2024-07-06"
+      }
+    ]
+  },
+  "returnToCustodyDate": "2024-08-10",
+  "fixedTermRecallDetails": {
+    "bookingId": 2919905,
+    "recallLength": 14,
+    "returnToCustodyDate": "2024-08-10"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-1871_ftr_consec.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-1871_ftr_consec.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2024-11-17",
+    "CRD": "2024-09-17",
+    "TUSED": "2025-09-17",
+    "HDCED": "2024-09-09",
+    "HDCED4PLUS": "2024-09-09",
+    "ESED": "2024-11-10"
+  },
+  "effectiveSentenceLength": "P6M27D",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}


### PR DESCRIPTION
Small tweak to how the defaulting service identifies whether a date… is before the tranche (if it comes only from the 50%)