### PR TITLE
CRS-2126 Testing - set alt-dev to have T1 commencement date of (today)

### DIFF
--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -14,7 +14,7 @@ generic-service:
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
-    SPRING_PROFILES_ACTIVE: "alt-3-calculation-params"
+    SPRING_PROFILES_ACTIVE: "alt-4-calculation-params"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk

--- a/src/main/resources/application-alt-4-calculation-params.yml
+++ b/src/main/resources/application-alt-4-calculation-params.yml
@@ -1,0 +1,27 @@
+release-point-multipliers:
+  multipliers:
+    - tracks:
+        - EDS_AUTOMATIC_RELEASE
+        - SDS_TWO_THIRDS_RELEASE
+        - SDS_PLUS_RELEASE
+      multiplier: 0.66666
+    - tracks:
+        - EDS_DISCRETIONARY_RELEASE,
+        - SOPC_PED_AT_TWO_THIRDS,
+        - SOPC_PED_AT_HALFWAY,
+        - AFINE_ARD_AT_FULL_TERM,
+        - BOTUS
+      multiplier: 1.0
+    - tracks:
+        - SDS_EARLY_RELEASE
+      multiplier: 0.40
+  historicMultipliers:
+    - tracks:
+        - SDS_EARLY_RELEASE
+      multiplier: 0.5
+  default: 0.5
+hdced4:
+  hdc4-commencement-date: 2024-06-10
+sds-early-release-tranches:
+  tranche-one-date: 2024-09-09
+  tranche-two-date: 2024-10-22


### PR DESCRIPTION
* Enable testing of changes for CRS-2126 by setting T1 commencement to current date