### PR TITLE
RCLL-108 Add endpoint to allow record-a-recall service to performs a transitory calculation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/CalculationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/CalculationStatus.kt
@@ -5,4 +5,5 @@ enum class CalculationStatus {
   CONFIRMED,
   ERROR,
   TEST,
+  RECORD_A_RECALL,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/CalculationReasonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/CalculationReasonRepository.kt
@@ -8,4 +8,6 @@ interface CalculationReasonRepository : JpaRepository<CalculationReason, Long> {
   fun findAllByIsActiveTrueOrderByDisplayRankAsc(): List<CalculationReason>
 
   fun findTopByIsBulkTrue(): Optional<CalculationReason>
+
+  fun findByDisplayName(display: String): CalculationReason?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/RecallService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/RecallService.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationStatus.RECORD_A_RECALL
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRequestModel
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
+
+@Service
+class RecallService(
+  private val calculationTransactionalService: CalculationTransactionalService,
+  private val calculationReasonRepository: CalculationReasonRepository,
+) {
+
+  fun calculateForRecordARecall(prisonerId: String): CalculatedReleaseDates {
+    val recallReason = calculationReasonRepository.findByDisplayName(RECALL_REASON)
+      ?: throw EntityNotFoundException()
+
+    val calculationRequestModel = CalculationRequestModel(
+      calculationReasonId = recallReason.id,
+      otherReasonDescription = RECALL_REASON,
+      calculationUserInputs = null,
+    )
+    return calculationTransactionalService.calculate(
+      prisonerId,
+      calculationRequestModel,
+      activeDataOnly = false,
+      calculationType = RECORD_A_RECALL,
+    )
+  }
+
+  companion object {
+    const val RECALL_REASON = "Requested by record-a-recall service"
+  }
+}

--- a/src/main/resources/migration/common/V60__record_a_recall_calculation_reason.sql
+++ b/src/main/resources/migration/common/V60__record_a_recall_calculation_reason.sql
@@ -1,0 +1,2 @@
+-- These calcs are not pushed to nomis, but nomis_comment populated due to mandatory constraint
+INSERT INTO calculation_reason (display_name, is_active, is_other, nomis_comment) VALUES ('Requested by record-a-recall service', false, false, 'Record a recall');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
@@ -64,11 +64,21 @@ open class IntegrationTestBase internal constructor() {
     roles: List<String> = listOf(),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles)
 
-  protected fun createPreliminaryCalculation(prisonerid: String): CalculatedReleaseDates = webTestClient.post()
-    .uri("/calculation/$prisonerid")
+  protected fun createPreliminaryCalculation(prisonerId: String): CalculatedReleaseDates = webTestClient.post()
+    .uri("/calculation/$prisonerId")
     .accept(MediaType.APPLICATION_JSON)
     .bodyValue(CalculationRequestModel(CalculationUserInputs(), 1L))
     .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody(CalculatedReleaseDates::class.java)
+    .returnResult().responseBody!!
+
+  protected fun createCalculationForRecordARecall(prisonerId: String): CalculatedReleaseDates = webTestClient.post()
+    .uri("/calculation/record-a-recall/$prisonerId")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf("ROLE_RECORD_A_RECALL")))
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
@@ -987,6 +987,24 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     assertThat(calculation.validationMessages).isEmpty()
   }
 
+  @Test
+  fun `Run calculation using the record-a-recall endpoint for a prisoner (based on example 13 from the unit tests)`() {
+    val result = createCalculationForRecordARecall(PRISONER_ID)
+
+    val calculationRequest = calculationRequestRepository.findById(result.calculationRequestId)
+      .orElseThrow { EntityNotFoundException("No calculation request exists for id ${result.calculationRequestId}") }
+
+    assertThat(calculationRequest.calculationStatus).isEqualTo("RECORD_A_RECALL")
+    assertThat(result.dates[SLED]).isEqualTo(LocalDate.of(2016, 11, 6))
+    assertThat(result.dates[CRD]).isEqualTo(LocalDate.of(2016, 1, 6))
+    assertThat(result.dates[TUSED]).isEqualTo(LocalDate.of(2017, 1, 6))
+    assertThat(result.dates[HDCED]).isEqualTo(LocalDate.of(2015, 8, 7))
+    assertThat(result.dates[ESED]).isEqualTo(LocalDate.of(2016, 11, 16))
+    assertThat(calculationRequest.inputData["offender"]["reference"].asText()).isEqualTo(PRISONER_ID)
+    assertThat(calculationRequest.inputData["sentences"][0]["offence"]["committedAt"].asText())
+      .isEqualTo("2015-03-17")
+  }
+
   val calculationRequestModel = CalculationRequestModel(CalculationUserInputs(), 1L)
 
   companion object {


### PR DESCRIPTION
The calculation will be performed and stored as a transitory calc (status =  RECORD_A_RECALL), therefore will not appear in the CRD UI or be published to NOMIS.