### PR TITLE
CRS-2105 fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationService.kt
@@ -115,7 +115,7 @@ class CalculationService(
   } else {
     resultWithPossibleEarlyRelease.copy(
       sdsEarlyReleaseAllocatedTranche = tranche,
-      sdsEarlyReleaseTranche = SDSEarlyReleaseTranche.TRANCHE_0,
+      sdsEarlyReleaseTranche = tranche,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationService.kt
@@ -26,9 +26,13 @@ class TrancheAllocationService(
     //
     // That looks at movements and date of release to determine release conditions applicable is yet to be implemented.
     val sentencesConsideredForTrancheRules =
-      booking.sentences.filter { sentence -> (sentence.identificationTrack == SentenceIdentificationTrack.SDS_EARLY_RELEASE
-        || sentence.identificationTrack == SentenceIdentificationTrack.SDS_STANDARD_RELEASE)
-        && (!sentence.isRecall() && sentence.sentencedAt.isBefore(trancheConfiguration.trancheOneCommencementDate))}
+      booking.sentences.filter { sentence ->
+        (
+          sentence.identificationTrack == SentenceIdentificationTrack.SDS_EARLY_RELEASE ||
+            sentence.identificationTrack == SentenceIdentificationTrack.SDS_STANDARD_RELEASE
+          ) &&
+          (!sentence.isRecall() && sentence.sentencedAt.isBefore(trancheConfiguration.trancheOneCommencementDate))
+      }
         .filter { it.sentencedAt.isBefore(trancheConfiguration.trancheOneCommencementDate) }
 
     var resultTranche: SDSEarlyReleaseTranche = SDSEarlyReleaseTranche.TRANCHE_0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationServiceTest.kt
@@ -87,7 +87,7 @@ class TrancheAllocationServiceTest {
   }
 
   @Test
-  fun `Single 4 year SDS not identified as early release track should be allocated to tranche 0`() {
+  fun `Single 4 year SDS not identified as early release track should be allocated to tranche 1`() {
     val testTranchOneCommencementDate = LocalDate.of(2024, 9, 10)
     val testTrancheTwoCommencementDate = LocalDate.of(2024, 10, 22)
     val trancheConfiguration = SDS40TrancheConfiguration(testTranchOneCommencementDate, testTrancheTwoCommencementDate)
@@ -99,7 +99,7 @@ class TrancheAllocationServiceTest {
       emptyMap(),
       emptyMap(),
       Period.ofYears(5),
-      sdsEarlyReleaseTranche = SDSEarlyReleaseTranche.TRANCHE_0,
+      sdsEarlyReleaseTranche = SDSEarlyReleaseTranche.TRANCHE_1,
     )
 
     val result = testTrancheAllocationService.calculateTranche(
@@ -114,7 +114,7 @@ class TrancheAllocationServiceTest {
         ),
       ),
     )
-    assertThat(result).isEqualTo(SDSEarlyReleaseTranche.TRANCHE_0)
+    assertThat(result).isEqualTo(SDSEarlyReleaseTranche.TRANCHE_1)
   }
 
   @Test

--- a/src/test/resources/test_data/calculation-sds-early-tranching.csv
+++ b/src/test/resources/test_data/calculation-sds-early-tranching.csv
@@ -59,4 +59,10 @@ tranches,crs-2105-ac-4-1,,
 tranches,crs-2105-ac-4-2,,
 tranches,crs-2105-ac-4-3,,
 
+tranches,crs-2105-rwe-1,,
+tranches,crs-2105-rwe-2,,
+tranches,crs-2105-rwe-3,,
+tranches,crs-2105-rwe-4,,
+tranches,crs-2105-rwe-5,,
+
 

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-1.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-1.json
@@ -1,0 +1,313 @@
+{
+  "offender": {
+    "reference": "A12345E",
+    "dateOfBirth": "1987-01-01",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1234567,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-09-08",
+        "offenceCode": "TH68037"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 9
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-11-15",
+      "caseSequence": 1,
+      "lineSequence": 13,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-09-08",
+        "offenceCode": "FA06001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 6
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-11-15",
+      "caseSequence": 1,
+      "lineSequence": 14,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-04-26",
+        "offenceCode": "FA06001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 3
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "56891006-8a7b-3c35-88b7-12900cc3716c",
+      "recallType": "STANDARD_RECALL",
+      "sentencedAt": "2023-11-15",
+      "caseSequence": 3,
+      "lineSequence": 15,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-05-12",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "a49e5006-f6f1-3495-8011-de954efbec5b",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 16,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-06-07",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "1d240192-ad21-3821-a70b-fffd1eb609a5",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 17,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "a49e5006-f6f1-3495-8011-de954efbec5b"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-04-04",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "39354ee8-092c-330a-bcc0-a50c3abba7dc",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 18,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "1d240192-ad21-3821-a70b-fffd1eb609a5"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-04-04",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "e415422e-15b1-3abc-8d97-ac09f1c545b5",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 19,
+      "caseReference": "93JD1236523",
+      "consecutiveSentenceUUIDs": [
+        "39354ee8-092c-330a-bcc0-a50c3abba7dc"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2023-05-04",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "3d2c8474-bf43-38f8-a3fb-ffeefdf5e499",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 20,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "e415422e-15b1-3abc-8d97-ac09f1c545b5"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2021-09-13",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "aea5266a-8b9c-39bf-8e8c-1af268f90720",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 21,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "3d2c8474-bf43-38f8-a3fb-ffeefdf5e499"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-03-28",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "a36ddf10-babb-356c-adb5-20514a4290aa",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 22,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "aea5266a-8b9c-39bf-8e8c-1af268f90720"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-03-05",
+        "offenceCode": "TH68001"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 2
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "bad67470-be79-3fc8-a998-b42f47e6cd54",
+      "recallType": null,
+      "sentencedAt": "2024-09-13",
+      "caseSequence": 9,
+      "lineSequence": 23,
+      "caseReference": "S12345678",
+      "consecutiveSentenceUUIDs": [
+        "a36ddf10-babb-356c-adb5-20514a4290aa"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "toDate": "2023-11-14",
+        "fromDate": "2023-05-27",
+        "numberOfDays": 172,
+        "appliesToSentencesFrom": "2023-11-15"
+      }
+    ],
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "toDate": "2024-06-06",
+        "fromDate": "2024-02-23",
+        "numberOfDays": 105,
+        "appliesToSentencesFrom": "2024-02-23"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-2.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-2.json
@@ -1,0 +1,75 @@
+{
+  "offender": {
+    "reference": "A1234567",
+    "dateOfBirth": "1971-01-01",
+    "isActiveSexOffender": true
+  },
+  "bookingId": 12345678,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-06-13",
+        "offenceCode": "SX03204"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 26,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "4f1e55ec-150c-3374-a7b4-6f1ef705f34e",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "sentencedAt": "2024-06-17",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-09-16",
+        "offenceCode": "SX03204"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 7,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "f245e50a-27b7-36db-9f61-231a55b4518b",
+      "recallType": null,
+      "sentencedAt": "2024-09-17",
+      "caseSequence": 2,
+      "lineSequence": 2,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    }
+  ],
+  "adjustments": {
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "toDate": "2024-09-15",
+        "fromDate": "2024-09-14",
+        "numberOfDays": 2,
+        "appliesToSentencesFrom": "2024-09-14"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": "2024-09-16",
+  "fixedTermRecallDetails": {
+    "bookingId": 12345678,
+    "recallLength": 14,
+    "returnToCustodyDate": "2024-09-16"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-3.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-3.json
@@ -1,0 +1,123 @@
+{
+  "offender": {
+    "reference": "A1234567",
+    "dateOfBirth": "1971-01-01",
+    "isActiveSexOffender": true
+  },
+  "bookingId": 12345678,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "1994-06-12",
+        "offenceCode": "SX56025-029N"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 8
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "f3837ea1-7b3b-3d7a-8392-a5dc18354abf",
+      "recallType": null,
+      "sentencedAt": "2024-06-28",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "1992-12-31",
+        "offenceCode": "SX56087-088N"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 4
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "e333d34f-5565-301a-83dd-80e599ae1cc8",
+      "recallType": null,
+      "sentencedAt": "2024-06-28",
+      "caseSequence": 1,
+      "lineSequence": 2,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "1992-12-31",
+        "offenceCode": "SX56025-029N"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 4
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "6a35e7fd-13d3-324f-ab3b-37fa226d091b",
+      "recallType": null,
+      "sentencedAt": "2024-06-28",
+      "caseSequence": 1,
+      "lineSequence": 3,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [
+        "f3837ea1-7b3b-3d7a-8392-a5dc18354abf"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "1992-12-31",
+        "offenceCode": "SX56025-029N"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 4
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "4fa61f24-9c6e-3deb-8748-73dedd6f9f5f",
+      "recallType": null,
+      "sentencedAt": "2024-06-28",
+      "caseSequence": 1,
+      "lineSequence": 4,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [
+        "6a35e7fd-13d3-324f-ab3b-37fa226d091b"
+      ],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2024-06-27",
+        "fromDate": "2024-05-17",
+        "numberOfDays": 42,
+        "appliesToSentencesFrom": "2024-06-28"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-4.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-4.json
@@ -1,0 +1,47 @@
+{
+  "offender": {
+    "reference": "A123456",
+    "dateOfBirth": "1951-01-01",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 2935033,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2024-06-16",
+        "offenceCode": "SE20002"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 12
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "cd4cee2e-c6d7-3282-9930-e12a23ef0233",
+      "recallType": null,
+      "sentencedAt": "2024-08-15",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "DOMESTIC_ABUSE"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2024-08-14",
+        "fromDate": "2024-06-17",
+        "numberOfDays": 59,
+        "appliesToSentencesFrom": "2024-08-15"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-5.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2105-rwe-5.json
@@ -1,0 +1,47 @@
+{
+  "offender": {
+    "reference": "A123456",
+    "dateOfBirth": "1991-01-01",
+    "isActiveSexOffender": true
+  },
+  "bookingId": 1234567,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2022-10-01",
+        "offenceCode": "SX03007"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 16
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "4bb3335d-e9d7-3d76-8a2f-8376e1691261",
+      "recallType": null,
+      "sentencedAt": "2024-07-05",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": "A1234567489",
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "toDate": "2024-07-04",
+        "fromDate": "2024-07-04",
+        "numberOfDays": 1,
+        "appliesToSentencesFrom": "2024-07-05"
+      }
+    ]
+  },
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-1.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2026-01-12",
+    "CRD": "2025-03-26",
+    "TUSED": "2026-03-26",
+    "HDCED": "2025-03-08",
+    "HDCED4PLUS": "2025-03-08",
+    "ESED": "2026-01-12"
+  },
+  "effectiveSentenceLength": "P2Y1M29D",
+  "sdsEarlyReleaseTranche": "TRANCHE_0",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_0"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-1.json
@@ -4,7 +4,6 @@
     "CRD": "2025-03-26",
     "TUSED": "2026-03-26",
     "HDCED": "2025-03-08",
-    "HDCED4PLUS": "2025-03-08",
     "ESED": "2026-01-12"
   },
   "effectiveSentenceLength": "P2Y1M29D",

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-2.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2024-12-17",
+    "TUSED": "2025-09-20",
+    "PRRD": "2024-09-29",
+    "ESED": "2024-12-15"
+  },
+  "effectiveSentenceLength": "P5M29D",
+  "sdsEarlyReleaseTranche": "TRANCHE_0",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_0"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-3.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2025-09-15",
+    "CRD": "2025-01-15",
+    "ESED": "2025-10-27"
+  },
+  "effectiveSentenceLength": "P1Y4M",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-4.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2025-06-16",
+    "CRD": "2024-12-16",
+    "TUSED": "2025-12-16",
+    "HDCED": "2024-09-17",
+    "HDCED4PLUS": "2024-09-17",
+    "ESED": "2025-08-14"
+  },
+  "effectiveSentenceLength": "P1Y",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-4.json
@@ -4,7 +4,6 @@
     "CRD": "2024-12-16",
     "TUSED": "2025-12-16",
     "HDCED": "2024-09-17",
-    "HDCED4PLUS": "2024-09-17",
     "ESED": "2025-08-14"
   },
   "effectiveSentenceLength": "P1Y",

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2105-rwe-5.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2025-11-03",
+    "CRD": "2025-03-04",
+    "TUSED": "2026-03-04",
+    "ESED": "2025-11-04"
+  },
+  "effectiveSentenceLength": "P1Y4M",
+  "sdsEarlyReleaseTranche": "TRANCHE_1",
+  "sdsEarlyReleaseAllocatedTranche": "TRANCHE_1"
+}


### PR DESCRIPTION
* Amend to match criteria of ALL SDS getting tranche allocated where when applicable regardless of exclusions
* Ensure that recalls prior to T1 are not considered as early release, pending future ticket to better assess TUSED of original sentence based on movements.