### PR TITLE
CRS-2157 fix failing test - fridaty release date is not applicable if release date is in the past

### DIFF
--- a/src/test/resources/test_data/hint-text.csv
+++ b/src/test/resources/test_data/hint-text.csv
@@ -1,3 +1,4 @@
 testCase
+ped-hints
 hdced-to-prrd-hint
 hdced-adjusted-to-crd

--- a/src/test/resources/test_data/hint-text/expected-results/ped-hints.json
+++ b/src/test/resources/test_data/hint-text/expected-results/ped-hints.json
@@ -13,7 +13,6 @@
     "type": "PED",
     "date": "2024-10-12",
     "hints": [
-      "Friday, 11 October 2024 when adjusted to a working day",
       "50% date has been applied",
       "PED adjusted for the CRD of a concurrent sentence or default term",
       "The post recall release date (PRRD) of Tuesday, 18 March 2025 is later than the PED"


### PR DESCRIPTION
This test was failing on Friday (11 Oct 2024) because the release date of the prisoner was 12 Oct 2024 (in the future on a Saturday) - so the 'non working day' logic was being applied and a hint saying release him on Friday was shown

But now the release date is in the past, so the hint will never be shown going forward (as per the logic in the code)