### PR TITLE
Create a local version of data-extraction-cron job

### DIFF
--- a/helm_deploy/calculate-release-dates-api/templates/_helpers.tpl
+++ b/helm_deploy/calculate-release-dates-api/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the name of the cronjob resource.
+Cronjob resource names have a maximum length of 52 characters - see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#:~:text=Even%20when%20the%20name%20is,no%20more%20than%2063%20characters
+
+The default behaviour is to use the release name (truncated to 27) appended with `-data-analytics-extractor` giving a maximum length of 52.
+This behaviour can be overriden by providing a `cronJobNameOverride`. If provided in the values it will be used, truncated at 52.
+*/}}
+{{- define "generic-data-analytics-extractor.cronjob-name" -}}
+{{- if .Values.cronJobNameOverride -}}
+{{- .Values.cronJobNameOverride | trunc 52 -}}
+{{- else -}}
+{{ .Release.Name | trunc 27 -}}-data-analytics-extractor-crds
+{{- end -}}
+{{- end -}}

--- a/helm_deploy/calculate-release-dates-api/templates/_helpers.tpl
+++ b/helm_deploy/calculate-release-dates-api/templates/_helpers.tpl
@@ -25,7 +25,7 @@ Cronjob resource names have a maximum length of 52 characters - see https://kube
 The default behaviour is to use the release name (truncated to 27) appended with `-data-analytics-extractor` giving a maximum length of 52.
 This behaviour can be overriden by providing a `cronJobNameOverride`. If provided in the values it will be used, truncated at 52.
 */}}
-{{- define "generic-data-analytics-extractor.cronjob-name" -}}
+{{- define "data-analytics-extractor-crds.cronjob-name" -}}
 {{- if .Values.cronJobNameOverride -}}
 {{- .Values.cronJobNameOverride | trunc 52 -}}
 {{- else -}}

--- a/helm_deploy/calculate-release-dates-api/templates/data-analytics-extractor-crds.yaml
+++ b/helm_deploy/calculate-release-dates-api/templates/data-analytics-extractor-crds.yaml
@@ -1,0 +1,79 @@
+# Temporarily define a project specific version to allow specification of resources to job
+{{- $databaseSecretName := .Values.databaseSecretName | required ".Values.databaseSecretName is required." -}}
+{{- $destinationS3SecretName := .Values.destinationS3SecretName | required ".Values.destinationS3SecretName is required." -}}
+{{- $serviceAccountName := .Values.serviceAccountName | required ".Values.serviceAccountName is required." -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "data-analytics-extractor-crds.cronjob-name" . }}
+  labels:
+    app: {{ template "app.fullname" . }}
+    release: {{ .Release.Name }}
+spec:
+  {{- if not .Values.enabled }}
+  suspend: true
+  {{- end }}
+  schedule: {{ .Values.cronJobSchedule }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  # Check if we fail to create jobs within this 2 minute window and count as a missed schedule
+  # The Cron controller will stop creating jobs after 100 consecutive missed schedules
+  # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          serviceAccountName: {{ $serviceAccountName }}
+          restartPolicy: "Never"
+          containers:
+            - name: {{ template "app.fullname" . }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: Always
+              args: [{{ .Values.args }}]
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $databaseSecretName }}
+                      key: {{ .Values.databaseAddressSecretKey }}
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $databaseSecretName }}
+                      key: {{ .Values.databaseNameSecretKey }}
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $databaseSecretName }}
+                      key: {{ .Values.databaseUsernameSecretKey }}
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $databaseSecretName }}
+                      key: {{ .Values.databasePasswordSecretKey }}
+                - name: S3_DESTINATION
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $destinationS3SecretName }}
+                      key: {{ .Values.destinationS3SecretKey }}
+                - name: AWS_DEFAULT_REGION
+                  value: "{{ .Values.awsDefaultRegion }}"
+                - name: SAVE_EVENTS_LOG
+                  value: "{{ .Values.saveEventsLog }}"
+                - name: DATA_PRODUCT_NAME
+                  value: "{{ .Values.dataProductName }}"
+              resources:
+                requests:
+                  memory: 2G
+                limits:
+                  memory: 1G
+  {{- if .Values.dataPlatformApiAuthSecretName }}
+  - name: API_AUTH
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.dataPlatformApiAuthSecretName }}
+        key: {{ .Values.dataPlatformApiAuthSecretKey }}
+  {{- end }}

--- a/helm_deploy/calculate-release-dates-api/values.yaml
+++ b/helm_deploy/calculate-release-dates-api/values.yaml
@@ -50,9 +50,17 @@ generic-service:
 generic-prometheus-alerts:
   targetApplication: calculate-release-dates-api
 
-generic-data-analytics-extractor:
+data-analytics-extractor-crds:
   enabled: true
   databaseSecretName: rds-instance-output
   destinationS3SecretName: analytical-platform-reporting-s3-bucket
   serviceAccountName: calculate-release-dates-to-ap-s3
   args: "extract_table_names.py && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"
+  resources:
+    requests:
+      memory: 2G
+    limits:
+      memory: 1G
+  image:
+    repository: ministryofjustice/data-engineering-data-extractor
+    tag: v1.2.2

--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -37,6 +37,6 @@ generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: legacy-replacement-alerts-non-prod
 
-generic-data-analytics-extractor:
+data-analytics-extractor-crds:
   enabled: false
   cronJobNameOverride: calculate-release-dates-alt

--- a/helm_deploy/values-alt-preprod.yaml
+++ b/helm_deploy/values-alt-preprod.yaml
@@ -41,6 +41,6 @@ generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: legacy-replacement-alerts-non-prod
 
-generic-data-analytics-extractor:
+data-analytics-extractor-crds:
   enabled: false
   cronJobNameOverride: calculate-release-dates-alt


### PR DESCRIPTION
* Enables us to define the resources for the job, to avoid an OOM in extraction


**A change suggestion is being made to https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-data-analytics-extractor/values.yaml such that this local version will no longer be required**