### PR TITLE
CRS-2162 The validation for the overlapping-remand-logic should use the adjustedDeterminateReleaseDate (rather than unadjusted)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/AdjustmentValidationService.kt
@@ -238,7 +238,7 @@ class AdjustmentValidationService(
       .map {
         LocalDateRange.of(
           it.sentencedAt,
-          it.sentenceCalculation.unadjustedDeterminateReleaseDate,
+          it.sentenceCalculation.adjustedDeterminateReleaseDate,
         )
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
@@ -38,12 +38,7 @@ class ValidationIntTest(private val mockManageOffencesClient: MockManageOffences
       listOf(
         ValidationMessage(
           REMAND_OVERLAPS_WITH_SENTENCE,
-          arguments = listOf(
-            "2000-04-29",
-            "2001-02-27",
-            "2000-04-28",
-            "2000-04-30",
-          ),
+          arguments = listOf("2000-04-29", "2001-02-25", "2000-04-28", "2000-04-30"),
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -229,10 +229,9 @@ class CalculationTransactionalServiceTest {
       assertThat(returnedValidationMessages[0].code.toString()).isEqualTo(expectedValidationMessage)
     } else {
       assertThat(returnedValidationMessages).isEmpty()
+      assertEquals(bookingData.dates, calculatedReleaseDates.dates)
+      assertEquals(bookingData.effectiveSentenceLength, calculatedReleaseDates.effectiveSentenceLength)
     }
-
-    assertEquals(bookingData.dates, calculatedReleaseDates.dates)
-    assertEquals(bookingData.effectiveSentenceLength, calculatedReleaseDates.effectiveSentenceLength)
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/unuseddeductions/controller/UnusedDeductionsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/unuseddeductions/controller/UnusedDeductionsControllerIntTest.kt
@@ -142,7 +142,7 @@ class UnusedDeductionsControllerIntTest : IntegrationTestBase() {
       .expectBody(UnusedDeductionCalculationResponse::class.java)
       .returnResult().responseBody!!
 
-    Assertions.assertThat(calculation.validationMessages).contains(ValidationMessage(ValidationCode.REMAND_OVERLAPS_WITH_SENTENCE, arguments = listOf("2021-02-01", "2021-05-02", adjustments[0].fromDate.toString(), adjustments[0].toDate.toString())))
+    Assertions.assertThat(calculation.validationMessages).contains(ValidationMessage(ValidationCode.REMAND_OVERLAPS_WITH_SENTENCE, arguments = listOf("2021-02-01", "2021-03-13", adjustments[0].fromDate.toString(), adjustments[0].toDate.toString())))
   }
 
   @Test
@@ -172,7 +172,7 @@ class UnusedDeductionsControllerIntTest : IntegrationTestBase() {
       .expectBody(UnusedDeductionCalculationResponse::class.java)
       .returnResult().responseBody!!
 
-    Assertions.assertThat(calculation.validationMessages).contains(ValidationMessage(ValidationCode.REMAND_OVERLAPS_WITH_SENTENCE, arguments = listOf("2021-02-01", "2021-05-02", adjustments[0].fromDate.toString(), adjustments[0].toDate.toString())))
+    Assertions.assertThat(calculation.validationMessages).contains(ValidationMessage(ValidationCode.REMAND_OVERLAPS_WITH_SENTENCE, arguments = listOf("2021-02-01", "2021-04-20", adjustments[0].fromDate.toString(), adjustments[0].toDate.toString())))
   }
 
   @Test

--- a/src/test/resources/test_data/overall_calculation/validation/CRS-2082.json
+++ b/src/test/resources/test_data/overall_calculation/validation/CRS-2082.json
@@ -54,7 +54,7 @@
         "toDate": "2024-04-15",
         "fromDate": "2024-03-29",
         "numberOfDays": 18,
-        "appliesToSentencesFrom": "2024-02-16"
+        "appliesToSentencesFrom": "2024-04-16"
       }
     ]
   }


### PR DESCRIPTION
+ change how the range of sentences is determined (relates to fixing CRS-2082)
TODO Add explicit TDD's for the scenario in the ticket
(not done yet as the final release dates after the calculation finishes dont match the ticket, that will be investigated next)