### PR TITLE
CRS-2145 - TUSED producing recalls imposed on or after 2024-09-10 should be supported

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -222,17 +222,17 @@ class CalculationTransactionalServiceTest {
       "Example $exampleType/$exampleNumber outcome BookingCalculation: {}",
       TestUtil.objectMapper().writeValueAsString(calculatedReleaseDates),
     )
-    val bookingData = jsonTransformation.loadCalculationResult("$exampleType/$exampleNumber")
 
     if (expectedValidationMessage != null) {
       assertThat(returnedValidationMessages).hasSize(1) // etc
       assertThat(returnedValidationMessages[0].code.toString()).isEqualTo(expectedValidationMessage)
     } else {
+      val bookingData = jsonTransformation.loadCalculationResult("$exampleType/$exampleNumber")
       assertThat(returnedValidationMessages).isEmpty()
+      // if the validation is thrown - CRDS can't always determine the correct release dates
+      assertEquals(bookingData.dates, calculatedReleaseDates.dates)
+      assertEquals(bookingData.effectiveSentenceLength, calculatedReleaseDates.effectiveSentenceLength)
     }
-
-    assertEquals(bookingData.dates, calculatedReleaseDates.dates)
-    assertEquals(bookingData.effectiveSentenceLength, calculatedReleaseDates.effectiveSentenceLength)
   }
 
   @ParameterizedTest

--- a/src/test/resources/test_data/calculation-validation-examples.csv
+++ b/src/test/resources/test_data/calculation-validation-examples.csv
@@ -3,3 +3,11 @@ validation,CRS-2078,,,ADJUSTMENT_AFTER_RELEASE_ADA
 validation,CRS-2082,,,REMAND_OVERLAPS_WITH_SENTENCE
 validation,CRS-2082_inttest,,,REMAND_OVERLAPS_WITH_SENTENCE
 custom-examples,crs-2136-incorrect-tused-length,,,
+custom-examples,crs-2145-ac1,,,
+custom-examples,crs-2145-ac2,,,
+custom-examples,crs-2145-ac3,,,
+custom-examples,crs-2145-ac4,,,
+custom-examples,crs-2145-ac5,,,UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE
+custom-examples,crs-2145-ac6,,,UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE
+custom-examples,crs-2145-ac7,,,UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE
+custom-examples,crs-2145-ac8,,,UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac1.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac1.json
@@ -1,0 +1,21 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "sentencedAt": "2024-09-10",
+      "sentenceType": "LR_ORA",
+      "recallType": "STANDARD_RECALL"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac2.json
@@ -13,7 +13,7 @@
           "MONTHS": 8
         }
       },
-      "sentencedAt": "2024-09-24",
+      "sentencedAt": "2024-09-20",
       "sentenceType": "14FTR_ORA",
       "recallType": "FIXED_TERM_RECALL_14"
     }

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac2.json
@@ -1,0 +1,22 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 8
+        }
+      },
+      "sentencedAt": "2024-09-24",
+      "sentenceType": "14FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_14"
+    }
+  ],
+  "returnToCustodyDate": "2024-12-27"
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
@@ -11,7 +11,7 @@
       },
       "duration": {
         "durationElements": {
-          "MONTHS": 11
+          "MONTHS": 10
         }
       },
       "sentencedAt": "2024-09-11",
@@ -24,7 +24,7 @@
       },
       "duration": {
         "durationElements": {
-          "MONTHS": 11
+          "MONTHS": 10
         }
       },
       "sentencedAt": "2024-09-11",

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
@@ -1,0 +1,52 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 11
+        }
+      },
+      "sentencedAt": "2024-09-11",
+      "sentenceType": "LR_YOI_ORA",
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 11
+        }
+      },
+      "sentencedAt": "2024-09-11",
+      "sentenceType": "LR_YOI_ORA",
+      "recallType": "STANDARD_RECALL"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "numberOfDays": 20,
+        "appliesToSentencesFrom": "2020-12-15",
+        "fromDate": "2024-08-22",
+        "toDate": "2024-09-10"
+      }
+    ],
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "appliesToSentencesFrom": "2024-08-03",
+        "numberOfDays": 3,
+        "fromDate": "2025-06-08",
+        "toDate": "2025-06-10"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac3.json
@@ -5,6 +5,7 @@
   },
   "sentences": [
     {
+      "identifier": "d309682d-6733-3bfc-b7ad-7024162a341c",
       "offence": {
         "committedAt": "2022-12-31"
       },
@@ -28,7 +29,8 @@
       },
       "sentencedAt": "2024-09-11",
       "sentenceType": "LR_YOI_ORA",
-      "recallType": "STANDARD_RECALL"
+      "recallType": "STANDARD_RECALL",
+      "consecutiveSentenceUUIDs": ["d309682d-6733-3bfc-b7ad-7024162a341c"]
     }
   ],
   "adjustments": {
@@ -42,7 +44,7 @@
     ],
     "UNLAWFULLY_AT_LARGE": [
       {
-        "appliesToSentencesFrom": "2024-08-03",
+        "appliesToSentencesFrom": "2024-09-11",
         "numberOfDays": 3,
         "fromDate": "2025-06-08",
         "toDate": "2025-06-10"

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac4.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac4.json
@@ -5,6 +5,7 @@
   },
   "sentences": [
     {
+      "identifier": "d309682d-6733-3bfc-b7ad-7024162a341c",
       "offence": {
         "committedAt": "2022-12-31"
       },
@@ -28,7 +29,8 @@
       },
       "sentencedAt": "2024-09-18",
       "sentenceType": "FTR_ORA",
-      "recallType": "FIXED_TERM_RECALL_28"
+      "recallType": "FIXED_TERM_RECALL_28",
+      "consecutiveSentenceUUIDs": ["d309682d-6733-3bfc-b7ad-7024162a341c"]
     }
   ],
   "adjustments": {

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac4.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac4.json
@@ -1,0 +1,44 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 5
+        }
+      },
+      "sentencedAt": "2024-09-18",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 7
+        }
+      },
+      "sentencedAt": "2024-09-18",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28"
+    }
+  ],
+  "adjustments": {
+    "RECALL_TAGGED_BAIL": [
+      {
+        "numberOfDays": 40,
+        "appliesToSentencesFrom": "2024-09-18",
+        "fromDate": "2024-09-18"
+      }
+    ]
+  },
+  "returnToCustodyDate": "2025-04-03"
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac5.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac5.json
@@ -1,0 +1,52 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 11
+        }
+      },
+      "sentencedAt": "2024-07-13",
+      "sentenceType": "LR_ORA",
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 4
+        }
+      },
+      "sentencedAt": "2024-09-11",
+      "sentenceType": "LR_ORA",
+      "recallType": "STANDARD_RECALL"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "numberOfDays": 20,
+        "appliesToSentencesFrom": "2024-06-23",
+        "fromDate": "2024-06-23",
+        "toDate": "2024-07-12"
+      }
+    ],
+    "ADDITIONAL_DAYS_AWARDED": [
+      {
+        "numberOfDays": 5,
+        "appliesToSentencesFrom": "2024-09-20",
+        "fromDate": "2024-09-20",
+        "toDate": "2024-09-24"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac6.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac6.json
@@ -1,0 +1,48 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-08-10",
+      "sentenceType": "14FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_14"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-08-10",
+      "sentenceType": "14FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_14"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 7
+        }
+      },
+      "sentencedAt": "2024-09-24",
+      "sentenceType": "14FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_14"
+    }
+  ],
+  "returnToCustodyDate": "2024-12-14"
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac7.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac7.json
@@ -1,0 +1,51 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 9
+        }
+      },
+      "sentencedAt": "2024-09-10",
+      "sentenceType": "LR_YOI_ORA",
+      "recallType": "STANDARD_RECALL",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e7e"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-09-10",
+      "sentenceType": "LR_YOI_ORA",
+      "recallType": "STANDARD_RECALL",
+      "consecutiveSentenceUUIDs": [
+        "a31d5d02-611f-43b0-8b1a-4b1edc955e7e"
+      ]
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 23
+        }
+      },
+      "sentencedAt": "2024-09-09",
+      "sentenceType": "LR_YOI_ORA",
+      "recallType": "STANDARD_RECALL"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac8.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2145-ac8.json
@@ -1,0 +1,87 @@
+{
+  "offender": {
+    "reference": "ABC123D",
+    "dateOfBirth": "2004-11-05"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 17
+        }
+      },
+      "sentencedAt": "2024-05-03",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e7e"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-09-10",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "consecutiveSentenceUUIDs": [
+        "a31d5d02-611f-43b0-8b1a-4b1edc955e7e"
+      ]
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-09-02",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "identifier": "a31d5d02-611f-43b0-8b1a-4b1edc955e8a"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-12-31"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 2
+        }
+      },
+      "sentencedAt": "2024-09-02",
+      "sentenceType": "FTR_ORA",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "consecutiveSentenceUUIDs": [
+        "a31d5d02-611f-43b0-8b1a-4b1edc955e8a"
+      ]
+    }
+  ],
+  "returnToCustodyDate": "2024-12-07",
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "numberOfDays": 15,
+        "appliesToSentencesFrom": "2024-04-18",
+        "fromDate": "2024-04-18",
+        "toDate": "2024-05-02"
+      }
+    ],
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "numberOfDays": 5,
+        "appliesToSentencesFrom": "2024-12-02",
+        "fromDate": "2024-12-02",
+        "toDate": "2024-12-06"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac1.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-09-09",
+    "PRRD": "2025-09-09",
+    "TUSED": "2026-02-02",
+    "ESED": "2025-09-09"
+  },
+  "effectiveSentenceLength": "P1Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-05-19",
+    "PRRD": "2025-01-09",
+    "TUSED": "2025-12-25",
+    "ESED": "2025-09-09"
+  },
+  "effectiveSentenceLength": "P8M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac2.json
@@ -3,7 +3,7 @@
     "SLED": "2025-05-19",
     "PRRD": "2025-01-09",
     "TUSED": "2025-12-25",
-    "ESED": "2025-09-09"
+    "ESED": "2025-05-19"
   },
   "effectiveSentenceLength": "P8M"
 }

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2026-06-23",
+    "TUSED": "2026-05-19",
+    "PRRD": "2026-06-23",
+    "ESED": "2026-06-23"
+  },
+  "effectiveSentenceLength": "P11M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
@@ -3,7 +3,7 @@
     "SLED": "2026-06-23",
     "TUSED": "2026-05-19",
     "PRRD": "2026-06-23",
-    "ESED": "2026-06-23"
+    "ESED": "2026-07-10"
   },
-  "effectiveSentenceLength": "P11M"
+  "effectiveSentenceLength": "P22M"
 }

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac3.json
@@ -1,9 +1,9 @@
 {
   "dates": {
-    "SLED": "2026-06-23",
-    "TUSED": "2026-05-19",
-    "PRRD": "2026-06-23",
-    "ESED": "2026-07-10"
+    "SLED": "2026-04-23",
+    "TUSED": "2026-04-24",
+    "PRRD": "2026-04-23",
+    "ESED": "2026-05-10"
   },
-  "effectiveSentenceLength": "P22M"
+  "effectiveSentenceLength": "P1Y8M"
 }

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac4.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac4.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2026-06-23",
+    "TUSED": "2026-05-19",
+    "PRRD": "2026-06-23",
+    "ESED": "2026-06-23"
+  },
+  "effectiveSentenceLength": "P11M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac4.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2145-ac4.json
@@ -1,9 +1,9 @@
 {
   "dates": {
-    "SLED": "2026-06-23",
-    "TUSED": "2026-05-19",
-    "PRRD": "2026-06-23",
-    "ESED": "2026-06-23"
+    "SLED": "2025-08-08",
+    "TUSED": "2026-01-01",
+    "PRRD": "2025-04-30",
+    "ESED": "2025-09-17"
   },
-  "effectiveSentenceLength": "P11M"
+  "effectiveSentenceLength": "P1Y"
 }


### PR DESCRIPTION
- Add test cases for ACs
- Amend the validation framework for scenarios where the validation means no dates are known
- Add a log message for the sentence that would be excluded

@scott-lace-moj  - some tests not producing expected date values