### PR TITLE
CRD-2182-view-json-person-comparison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/PersonComparisonJson.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/PersonComparisonJson.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import com.fasterxml.jackson.databind.JsonNode
+
+data class PersonComparisonJson(
+  val inputData: JsonNode,
+  val sentenceAndOffences: JsonNode?,
+  val adjustments: JsonNode?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/ComparisonPersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/repository/ComparisonPersonRepository.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.ComparisonPerson
 
 interface ComparisonPersonRepository : JpaRepository<ComparisonPerson, Long> {
@@ -11,5 +13,16 @@ interface ComparisonPersonRepository : JpaRepository<ComparisonPerson, Long> {
 
   fun findByComparisonIdAndShortReference(comparisonId: Long, shortReference: String): ComparisonPerson?
 
-  fun findByComparisonIdIsAndHdcedFourPlusDateIsNotNull(id: Long): List<ComparisonPerson>
+  @Query(
+    """
+      SELECT cr
+            FROM CalculationRequest cr
+            JOIN cr.reasonForCalculation reason
+            JOIN ComparisonPerson cp ON cp.calculationRequestId = cr.id
+            JOIN Comparison comparison ON cp.comparisonId = comparison.id
+      WHERE comparison.comparisonShortReference = :comparisonShortReference
+       AND cp.shortReference = :shortReference
+  """,
+  )
+  fun getJsonForBulkComparison(comparisonShortReference: String, shortReference: String): CalculationRequest?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ComparisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ComparisonController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ComparisonOve
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ComparisonPersonOverview
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ComparisonSummary
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CreateComparisonDiscrepancyRequest
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.PersonComparisonJson
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ComparisonInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ComparisonService
 
@@ -148,6 +149,30 @@ class ComparisonController(
     mismatchReference: String,
   ): ComparisonPersonOverview {
     return comparisonService.getComparisonPersonByShortReference(comparisonReference, mismatchReference)
+  }
+
+  @GetMapping("/{comparisonReference}/mismatch/{mismatchReference}/json")
+  @PreAuthorize("hasAnyRole('ROLE_RELEASE_DATE_COMPARER')")
+  @ResponseBody
+  @Operation(
+    summary = "Returns JSON data for a particular comparison",
+    description = "This endpoint returns JSON data mismatch for a particular comparison",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Returns JSON data for a comparison mismatch"),
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
+    ],
+  )
+  fun getComparisonPersonJson(
+    @Parameter(required = true, example = "A1B2C3D4", description = "The short reference of the comparison")
+    @PathVariable("comparisonReference")
+    comparisonReference: String,
+    @Parameter(required = true, example = "A1B2C3D4", description = "The short reference of the mismatch")
+    @PathVariable("mismatchReference") mismatchReference: String,
+  ): PersonComparisonJson {
+    return comparisonService.getComparisonPersonJson(comparisonReference, mismatchReference)
   }
 
   @PostMapping(value = ["{comparisonReference}/mismatch/{mismatchReference}/discrepancy"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ComparisonService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ComparisonPer
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ComparisonSummary
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CreateComparisonDiscrepancyRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.MismatchType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.PersonComparisonJson
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.ComparisonInput
@@ -196,6 +197,13 @@ class ComparisonService(
     }
 
     throw CrdWebException("Forbidden", HttpStatus.FORBIDDEN, 403.toString())
+  }
+
+  fun getComparisonPersonJson(comparisonShortReference: String, shortReference: String): PersonComparisonJson {
+    val comparison = comparisonPersonRepository.getJsonForBulkComparison(comparisonShortReference, shortReference)
+      ?: throw EntityNotFoundException("Could not find person comparison with comparisonShortReference $comparisonShortReference and shortReference $shortReference")
+
+    return PersonComparisonJson(comparison.inputData, comparison.sentenceAndOffences, comparison.adjustments)
   }
 
   private fun establishmentAndReleaseDateComparator(


### PR DESCRIPTION
New endpoint to expose underlying JSON data related to person comparison.

Data includes inputData, sentenceAndOffences and adjustments.

Remove unused method  findByComparisonIdIsAndHdcedFourPlusDateIsNotNull from ComparisonPersonRepository.