### PR TITLE
CMG-182 Add things-to-do endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/ToDoType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/ToDoType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations
+
+enum class ToDoType {
+  CALCULATION_REQUIRED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ThingsToDo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ThingsToDo.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ToDoType
+
+data class ThingsToDo(
+  val prisonerId: String,
+  val thingsToDo: List<ToDoType> = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ThingsToDoController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ThingsToDoController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ThingsToDo
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ThingsToDo
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ThingsToDoService
 
 @RestController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ThingsToDoController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ThingsToDoController.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ThingsToDo
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ThingsToDoService
+
+@RestController
+@RequestMapping("/things-to-do", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "ThingsToDoController", description = "Operations related to the things-to-do list for prisoners")
+class ThingsToDoController(
+  private val thingsToDoService: ThingsToDoService,
+) {
+  @GetMapping("/prisoner/{prisonerId}")
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR')")
+  @ResponseBody
+  @Operation(
+    summary = "Retrieve things-to-do for a prisoner",
+    description = "Provides a list of things-to-do for a specified prisoner based on their ID.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Successfully returns the things-to-do list"),
+      ApiResponse(responseCode = "401", description = "Unauthorized - valid Oauth2 token required"),
+      ApiResponse(responseCode = "403", description = "Forbidden - requires appropriate role"),
+    ],
+  )
+  fun getThingsToDo(
+    @Parameter(required = true, example = "A1234AB", description = "Prisoner's ID (also known as nomsId)")
+    @PathVariable prisonerId: String,
+  ): ThingsToDo {
+    log.info("Request to retrieve things-to-do list for prisoner ID: {}", prisonerId)
+    return thingsToDoService.getToDoList(prisonerId)
+  }
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(ThingsToDoController::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoService.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ToDoType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AdjustmentAnalysisResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalyzedBookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ThingsToDo
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
 
 @Service
@@ -30,6 +32,7 @@ class ThingsToDoService(
 
   private fun isCalculationRequired(offenderDetails: PrisonerDetails): Boolean {
     val sentencesAndOffences = sentenceAndOffenceService.getSentencesAndOffences(offenderDetails.bookingId)
+    // TODO fix bug that affects getAnalyzedAdjustments method - see CRS-2199
     val adjustments = adjustmentsService.getAnalyzedAdjustments(offenderDetails.bookingId)
 
     return hasNewOrUpdatedSentences(sentencesAndOffences) ||
@@ -55,12 +58,3 @@ class ThingsToDoService(
     }
   }
 }
-
-enum class ToDoType {
-  CALCULATION_REQUIRED,
-}
-
-data class ThingsToDo(
-  val prisonerId: String,
-  val thingsToDo: List<ToDoType> = emptyList(),
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoService.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AdjustmentAnalysisResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalyzedBookingAndSentenceAdjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+
+@Service
+class ThingsToDoService(
+  private val sentenceAndOffenceService: SentenceAndOffenceService,
+  private val adjustmentsService: AdjustmentsService,
+  private val prisonService: PrisonService,
+) {
+
+  fun getToDoList(prisonerId: String): ThingsToDo {
+    val offenderDetails = prisonService.getOffenderDetail(prisonerId)
+    val thingsToDo = if (isCalculationRequired(offenderDetails)) {
+      listOf(ToDoType.CALCULATION_REQUIRED)
+    } else {
+      emptyList()
+    }
+
+    return ThingsToDo(
+      prisonerId = prisonerId,
+      thingsToDo = thingsToDo,
+    )
+  }
+
+  private fun isCalculationRequired(offenderDetails: PrisonerDetails): Boolean {
+    val sentencesAndOffences = sentenceAndOffenceService.getSentencesAndOffences(offenderDetails.bookingId)
+    val adjustments = adjustmentsService.getAnalyzedAdjustments(offenderDetails.bookingId)
+
+    return hasNewOrUpdatedSentences(sentencesAndOffences) ||
+      hasNewBookingAdjustments(adjustments) ||
+      hasNewSentenceAdjustments(adjustments)
+  }
+
+  private fun hasNewOrUpdatedSentences(sentencesAndOffences: List<AnalysedSentenceAndOffence>): Boolean {
+    return sentencesAndOffences.any {
+      it.sentenceAndOffenceAnalysis in listOf(SentenceAndOffenceAnalysis.NEW, SentenceAndOffenceAnalysis.UPDATED)
+    }
+  }
+
+  private fun hasNewBookingAdjustments(adjustments: AnalyzedBookingAndSentenceAdjustments): Boolean {
+    return adjustments.bookingAdjustments.any {
+      it.analysisResult == AdjustmentAnalysisResult.NEW
+    }
+  }
+
+  private fun hasNewSentenceAdjustments(adjustments: AnalyzedBookingAndSentenceAdjustments): Boolean {
+    return adjustments.sentenceAdjustments.any {
+      it.analysisResult == AdjustmentAnalysisResult.NEW
+    }
+  }
+}
+
+enum class ToDoType {
+  CALCULATION_REQUIRED,
+}
+
+data class ThingsToDo(
+  val prisonerId: String,
+  val thingsToDo: List<ToDoType> = emptyList(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ThingsToDoServiceTest.kt
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ToDoType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalyzedBookingAndSentenceAdjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ThingsToDo
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SentenceAndOffenceServiceTest.Companion.offences
+import java.time.LocalDate
+
+class ThingsToDoServiceTest {
+  private val sentenceAndOffenceService = mock<SentenceAndOffenceService>()
+  private val adjustmentsService = mock<AdjustmentsService>()
+  private val prisonService = mock<PrisonService>()
+
+  private val thingsToDoService = ThingsToDoService(sentenceAndOffenceService, adjustmentsService, prisonService)
+
+  @Nested
+  inner class GetToDoListTests {
+
+    @Test
+    fun `Get things to do for a prisoner where there are things to do`() {
+      whenever(prisonService.getOffenderDetail(NOMS_ID)).thenReturn(PRISONER_DETAILS)
+      whenever(sentenceAndOffenceService.getSentencesAndOffences(BOOKING_ID)).thenReturn(SENTENCES)
+      whenever(adjustmentsService.getAnalyzedAdjustments(BOOKING_ID)).thenReturn(ADJUSTMENTS)
+
+      val thingsToDo = thingsToDoService.getToDoList(NOMS_ID)
+
+      assertThat(thingsToDo).isEqualTo(ThingsToDo(prisonerId = NOMS_ID, thingsToDo = listOf(ToDoType.CALCULATION_REQUIRED)))
+    }
+
+    @Test
+    fun `Get things to do for a prisoner when there is nothing to do`() {
+      whenever(prisonService.getOffenderDetail(NOMS_ID)).thenReturn(PRISONER_DETAILS)
+      whenever(sentenceAndOffenceService.getSentencesAndOffences(BOOKING_ID)).thenReturn(listOf(BASE_SENTENCE.copy(sentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.SAME)))
+      whenever(adjustmentsService.getAnalyzedAdjustments(BOOKING_ID)).thenReturn(ADJUSTMENTS)
+
+      val thingsToDo = thingsToDoService.getToDoList(NOMS_ID)
+
+      assertThat(thingsToDo).isEqualTo(ThingsToDo(prisonerId = NOMS_ID))
+    }
+  }
+
+  companion object {
+    const val NOMS_ID = "AA1234A"
+    const val BOOKING_ID = 1234L
+    private val PRISONER_DETAILS = PrisonerDetails(
+      bookingId = BOOKING_ID,
+      offenderNo = NOMS_ID,
+      firstName = "John",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.of(1970, 1, 1),
+    )
+    private val FIRST_JAN_2015: LocalDate = LocalDate.of(2015, 1, 1)
+    private val BASE_SENTENCE = AnalysedSentenceAndOffence(
+      bookingId = 1,
+      sentenceSequence = 1,
+      sentenceDate = FIRST_JAN_2015,
+      terms = listOf(
+        SentenceTerms(
+          years = 5,
+          months = 4,
+          weeks = 3,
+          days = 2,
+        ),
+      ),
+      sentenceStatus = "IMP",
+      sentenceCategory = "CAT",
+      sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+      sentenceTypeDescription = "Standard Determinate",
+      offence = offences[0],
+      lineSequence = 1,
+      caseSequence = 1,
+      caseReference = null,
+      fineAmount = null,
+      courtDescription = null,
+      consecutiveToSequence = null,
+      isSDSPlus = false,
+      hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
+      sentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.NEW,
+    )
+    val SENTENCES = listOf(BASE_SENTENCE)
+
+    val ADJUSTMENTS = AnalyzedBookingAndSentenceAdjustments(
+      bookingAdjustments = emptyList(),
+      sentenceAdjustments = emptyList(),
+    )
+  }
+}


### PR DESCRIPTION
this is as part of some work in CCARD, to display a list of TODO's in every service

This is the initial placeholder endpoint and is subject to change depending on what the TODO item needs to display