### PR TITLE
CRS-2186-shpo-offence-violation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SHPOValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SHPOValidationService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSe
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.SDS_40_COMMENCEMENT_DATE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.SHPO_OFFENCE_COMMENCEMENT_DATE
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 
 @Service
 class SHPOValidationService {
@@ -59,14 +60,14 @@ class SHPOValidationService {
 
   private fun isConsecutiveSdsHistoricSentenceInValid(consecutiveSentence: ConsecutiveSentence): Boolean =
     consecutiveSentence.sentencedAt.isBefore(SDS_40_COMMENCEMENT_DATE) &&
-      consecutiveSentence.sentenceCalculation.releaseDate.isAfter(SDS_40_COMMENCEMENT_DATE)
+      consecutiveSentence.sentenceCalculation.adjustedHistoricDeterminateReleaseDate.isAfterOrEqualTo(SDS_40_COMMENCEMENT_DATE)
 
   private fun isSdsSentenceInvalid(sentence: CalculableSentence): Boolean =
-    sentence.sentencedAt >= SDS_40_COMMENCEMENT_DATE &&
+    sentence.sentencedAt.isAfterOrEqualTo(SDS_40_COMMENCEMENT_DATE) &&
       sentence.offence.committedAt < SHPO_OFFENCE_COMMENCEMENT_DATE
 
   private fun isSdsHistoricSentenceInvalid(sentence: StandardDeterminateSentence): Boolean =
     sentence.sentencedAt.isBefore(SDS_40_COMMENCEMENT_DATE) &&
-      sentence.sentenceCalculation.releaseDate.isAfter(SDS_40_COMMENCEMENT_DATE) &&
+      sentence.sentenceCalculation.adjustedHistoricDeterminateReleaseDate.isAfterOrEqualTo(SDS_40_COMMENCEMENT_DATE) &&
       sentence.offence.committedAt < SHPO_OFFENCE_COMMENCEMENT_DATE
 }

--- a/src/test/resources/test_data/calculation-validation-examples.csv
+++ b/src/test/resources/test_data/calculation-validation-examples.csv
@@ -22,6 +22,7 @@ validation,CRS-2175-rwe-1,,,
 validation,CRS-2175-crd-t1-boundary,,,UNABLE_TO_DETERMINE_SHPO_RELEASE_PROVISIONS
 validation,CRS-2186-ac1-1,,,SHPO_INVALID_DATE
 validation,CRS-2186-ac1-2,,,SHPO_INVALID_DATE
+validation,CRS-2186-ac1-3,,,SHPO_INVALID_DATE
 validation,CRS-2186-ac2-1,,,SHPO_INVALID_DATE
 validation,CRS-2186-ac2-2,,,SHPO_INVALID_DATE
 validation,CRS-2186-reg-1,,,

--- a/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-1.json
@@ -29,7 +29,7 @@
       "lineSequence": 1,
       "caseReference": "A12345678",
       "consecutiveSentenceUUIDs": [],
-      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+      "hasAnSDSEarlyReleaseExclusion": "NO"
     },
     {
       "type": "StandardSentence",

--- a/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-2.json
@@ -29,7 +29,7 @@
       "lineSequence": 1,
       "caseReference": "A12345678",
       "consecutiveSentenceUUIDs": [],
-      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+      "hasAnSDSEarlyReleaseExclusion": "NO"
     },
     {
       "type": "StandardSentence",

--- a/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/validation/CRS-2186-ac1-3.json
@@ -1,0 +1,38 @@
+{
+  "offender": {
+    "reference": "A1234AA",
+    "dateOfBirth": "1992-11-13",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1,
+  "sentences": [
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2020-11-30",
+        "offenceCode": "SE20012"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 72,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "5c64a902-3831-396c-80ae-7b7c1f2dd244",
+      "recallType": null,
+      "sentencedAt": "2024-08-13",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "caseReference": null,
+      "consecutiveSentenceUUIDs": [],
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "adjustments": {},
+  "historicalTusedData": null,
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}


### PR DESCRIPTION
Use inclusive isAfterOrEqualTo check for SDS40 date.

Use adjustedHistoricDeterminateReleaseDate when checking if sentences commited pre SDS40 sentences fall in scope of SDS40 after release.