### PR TITLE
CRS-2210 Fixing bug with concurrent UAL license recalls.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineUalAdjustmentCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineUalAdjustmentCalculationHandler.kt
@@ -53,10 +53,17 @@ class TimelineUalAdjustmentCalculationHandler(
 
   private fun setAdjustmentsDuringCustodialPeriod(timelineCalculationDate: LocalDate, timelineTrackingData: TimelineTrackingData, ualDays: Long) {
     with(timelineTrackingData) {
+      val (sentencesBeforeReleaseDate, sentencesAfterReleaseDate) = custodialSentences.partition { timelineCalculationDate.isBeforeOrEqualTo(it.sentenceCalculation.adjustedDeterminateReleaseDate) }
       timelineCalculator.setAdjustments(
-        custodialSentences.filter { timelineCalculationDate.isBeforeOrEqualTo(it.sentenceCalculation.adjustedDeterminateReleaseDate) },
+        sentencesBeforeReleaseDate,
         SentenceAdjustments(
           ualDuringCustody = ualDays,
+        ),
+      )
+      timelineCalculator.setAdjustments(
+        sentencesAfterReleaseDate.filter { it.isRecall() },
+        SentenceAdjustments(
+          ualAfterDeterminateRelease = ualDays,
         ),
       )
     }

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -634,5 +634,5 @@ custom-examples,crs-2162-1,,,
 custom-examples,crs-2162-2,,,
 
 validation,CRS-2207,,,
-
+custom-examples,crs-2210-concurrent-recall-ual-timeline-bug,,,
 

--- a/src/test/resources/test_data/calculation_breakdown_response/hdc4/crs-2159-prisoner-1.json
+++ b/src/test/resources/test_data/calculation_breakdown_response/hdc4/crs-2159-prisoner-1.json
@@ -7,9 +7,9 @@
       "dates": {
         "SLED": {
           "unadjusted": "2024-11-26",
-          "adjusted": "2024-04-01",
+          "adjusted": "2024-04-15",
           "daysFromSentenceStart": 92,
-          "adjustedByDays": 239
+          "adjustedByDays": 225
         },
         "PRRD": {
           "unadjusted": "2024-10-11",
@@ -29,9 +29,9 @@
       "dates": {
         "SLED": {
           "unadjusted": "2024-11-26",
-          "adjusted": "2024-04-01",
+          "adjusted": "2024-04-15",
           "daysFromSentenceStart": 92,
-          "adjustedByDays": 239
+          "adjustedByDays": 225
         },
         "PRRD": {
           "unadjusted": "2024-10-11",

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2210-concurrent-recall-ual-timeline-bug.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2210-concurrent-recall-ual-timeline-bug.json
@@ -1,0 +1,124 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2021-11-29",
+        "offenceCode": "TH68026"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 27
+        }
+      },
+      "sentencedAt": "2022-02-14",
+      "identifier": "9ca95246-1810-32fc-9602-7b2c8f1418d7",
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2021-11-29",
+        "offenceCode": "RT88026"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 8
+        }
+      },
+      "sentencedAt": "2022-02-14",
+      "identifier": "fe3cb79a-4a5d-3353-96f9-c3e64bb1b4e9",
+      "consecutiveSentenceUUIDs": [
+        "9ca95246-1810-32fc-9602-7b2c8f1418d7"
+      ],
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2019-12-14",
+        "offenceCode": "PU86003"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 5
+        }
+      },
+      "sentencedAt": "2022-02-14",
+      "consecutiveSentenceUUIDs": [
+        "fe3cb79a-4a5d-3353-96f9-c3e64bb1b4e9"
+      ],
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-01-14",
+        "offenceCode": "BA76001"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 1
+        }
+      },
+      "sentencedAt": "2022-02-14",
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-10-19",
+        "offenceCode": "TH68037"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 24
+        }
+      },
+      "sentencedAt": "2022-12-09",
+      "recallType": "STANDARD_RECALL"
+    },
+    {
+      "offence": {
+        "committedAt": "2022-10-19",
+        "offenceCode": "TH68073"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 12
+        }
+      },
+      "sentencedAt": "2022-12-09",
+      "recallType": "STANDARD_RECALL"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "appliesToSentencesFrom": "2022-02-14",
+        "numberOfDays": 76,
+        "fromDate": "2021-11-30",
+        "toDate": "2022-02-13"
+      },
+      {
+        "appliesToSentencesFrom": "2022-02-14",
+        "numberOfDays": 42,
+        "fromDate": "2019-04-09",
+        "toDate": "2019-05-20"
+      }
+    ],
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "appliesToSentencesFrom": "2023-06-24",
+        "numberOfDays": 12,
+        "fromDate": "2023-06-24",
+        "toDate": "2023-07-05"
+      },
+      {
+        "appliesToSentencesFrom": "2024-02-10",
+        "numberOfDays": 6,
+        "fromDate": "2024-02-10",
+        "toDate": "2024-02-15"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2210-concurrent-recall-ual-timeline-bug.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2210-concurrent-recall-ual-timeline-bug.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SLED": "2025-03-05",
+    "PRRD": "2025-03-05",
+    "ESED": "2025-06-13"
+  },
+  "effectiveSentenceLength": "P3Y4M"
+}


### PR DESCRIPTION
Bug where UAL occurs before the overall CRD. but after a concurrent CRD. UAL should only apply to the concurrent sentence if its a recall and shouldn't affect its original determinate release date.