### PR TITLE
CRS-2202-tranche3-recalls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
@@ -17,7 +17,6 @@ enum class SDSEarlyReleaseExclusionType {
   DOMESTIC_ABUSE_T3,
   NATIONAL_SECURITY_T3,
   TERRORISM_T3,
-  MURDER,
   MURDER_T3,
   NO,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/manageoffencesapi/SDSEarlyReleaseExclusionForOffenceCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/manageoffencesapi/SDSEarlyReleaseExclusionForOffenceCode.kt
@@ -12,7 +12,6 @@ enum class SDSEarlyReleaseExclusionSchedulePart {
   DOMESTIC_ABUSE_T3,
   NATIONAL_SECURITY_T3,
   TERRORISM_T3,
-  MURDER,
   MURDER_T3,
   NONE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/OffenceSDSReleaseArrangementLookupService.kt
@@ -162,7 +162,6 @@ class OffenceSDSReleaseArrangementLookupService(
       SDSEarlyReleaseExclusionSchedulePart.TERRORISM_T3 -> SDSEarlyReleaseExclusionType.TERRORISM_T3
       SDSEarlyReleaseExclusionSchedulePart.TERRORISM -> SDSEarlyReleaseExclusionType.TERRORISM
       SDSEarlyReleaseExclusionSchedulePart.MURDER_T3 -> SDSEarlyReleaseExclusionType.MURDER_T3
-      SDSEarlyReleaseExclusionSchedulePart.MURDER -> SDSEarlyReleaseExclusionType.MURDER
       SDSEarlyReleaseExclusionSchedulePart.VIOLENT_T3 ->
         if (fourYearsOrMore(sentenceAndOffence)) SDSEarlyReleaseExclusionType.VIOLENT_T3 else SDSEarlyReleaseExclusionType.NO
       SDSEarlyReleaseExclusionSchedulePart.VIOLENT ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineCalculationHandler.kt
@@ -16,17 +16,6 @@ abstract class TimelineCalculationHandler(
 ) {
   abstract fun handle(timelineCalculationDate: LocalDate, timelineTrackingData: TimelineTrackingData): TimelineHandleResult
 
-  /**
-   * Return lambda function which receives the sentence track and returns the
-   * sentence multiplier for use when calculating the earliest release date.
-   *
-   * 1. If timelineCalculationDate if on or after tranche three commencement date and
-   *    the track is SDS_STANDARD_RELEASE_T3_EXCLUSION, then return default SDS_STANDARD multiplier,
-   *    as related offence is now excluded from early release
-   * 2. If timelineCalculationDate date is on or after trancheOneCommencementDate, return multiplier which
-   *    may be eligible for early release (early release scheme commenced as of tranche one)
-   * 3. Default to historic multipliers, which are pre early release
-   */
   fun multiplierFnForDate(
     timelineCalculationDate: LocalDate,
     earlyReleaseCommencementDate: LocalDate?,

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -497,6 +497,18 @@ tranches,crs-2192-ac1-8,,,
 tranches,crs-2192-ac2-1,,,
 tranches,crs-2192-ac2-2,,,
 
+tranches,crs-2202-ac1-1,,,UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE
+tranches,crs-2202-ac1-2,,,
+tranches,crs-2202-ac1-3,,,
+tranches,crs-2202-ac1-4,,,
+tranches,crs-2202-ac1-5,,,
+tranches,crs-2202-ac1-6,,,
+tranches,crs-2202-ac1-7,,,
+tranches,crs-2202-ac1-8,,,
+tranches,crs-2202-ac2-1,,,
+tranches,crs-2202-ac2-3,,,
+tranches,crs-2202-ac3-1,,,
+
 custom-examples,crs-2062-SDS40-tused-bug,,,
 custom-examples,crs-2063-SDS40-FTR-tused,,,
 

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-1.json
@@ -1,0 +1,33 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "ST19001"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "sentencedAt": "2024-04-03",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "DOMESTIC_ABUSE_T3"
+    }
+  ],
+  "adjustments": {
+    "ADDITIONAL_DAYS_AWARDED": [
+      {
+        "appliesToSentencesFrom": "2024-06-20",
+        "numberOfDays": 2,
+        "fromDate": "2024-06-20",
+        "toDate": "2024-06-22"
+      }
+    ]
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-2.json
@@ -1,0 +1,43 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "SE20006"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 2
+        }
+      },
+      "sentencedAt": "2023-04-03",
+      "identifier": "f3837ea1-7b3b-3d7a-8392-a5dc18354abf",
+      "consecutiveSentenceUUIDs": [],
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL"
+    },
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "MD71446"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 2
+        }
+      },
+      "sentencedAt": "2023-04-03",
+      "identifier": "6a35e7fd-13d3-324f-ab3b-37fa226d091b",
+      "consecutiveSentenceUUIDs": [
+        "f3837ea1-7b3b-3d7a-8392-a5dc18354abf"
+      ],
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-3.json
@@ -1,0 +1,44 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "SE20006"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1
+        }
+      },
+      "sentencedAt": "2024-06-03",
+      "identifier": "f3837ea1-7b3b-3d7a-8392-a5dc18354abf",
+      "consecutiveSentenceUUIDs": [],
+      "recallType": "FIXED_TERM_RECALL_28",
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL_T3"
+    },
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "MD71446"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2024-06-03",
+      "identifier": "6a35e7fd-13d3-324f-ab3b-37fa226d091b",
+      "consecutiveSentenceUUIDs": [
+        "f3837ea1-7b3b-3d7a-8392-a5dc18354abf"
+      ],
+      "recallType": "FIXED_TERM_RECALL_28",
+      "hasAnSDSEarlyReleaseExclusion": "NO"
+    }
+  ],
+  "returnToCustodyDate": "2025-03-10",
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-4.json
@@ -1,0 +1,32 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "SE20012"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 3
+        }
+      },
+      "sentencedAt": "2024-10-11",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL_T3"
+    }
+  ],
+  "adjustments": {
+    "RECALL_TAGGED_BAIL": [
+      {
+        "appliesToSentencesFrom": "2024-10-11",
+        "numberOfDays": 5
+      }
+    ]
+  },
+  "returnToCustodyDate": "2024-12-20",
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-5.json
@@ -1,0 +1,34 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "SE20012"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 9
+        }
+      },
+      "sentencedAt": "2024-09-12",
+      "recallType": "FIXED_TERM_RECALL_14",
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL_T3"
+    }
+  ],
+  "adjustments": {
+    "RECALL_REMAND": [
+      {
+        "appliesToSentencesFrom": "2024-09-12",
+        "numberOfDays": 5,
+        "fromDate": "2024-09-12",
+        "toDate": "2024-09-23"
+      }
+    ]
+  },
+  "returnToCustodyDate": "2025-01-06",
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-6.json
@@ -1,0 +1,24 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "COML026"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 5
+        }
+      },
+      "sentencedAt": "2024-09-16",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "hasAnSDSEarlyReleaseExclusion": "VIOLENT"
+    }
+  ],
+  "returnToCustodyDate": "2027-06-01",
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-7.json
@@ -1,0 +1,34 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "PH97005"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1,
+          "MONTHS": 10
+        }
+      },
+      "sentencedAt": "2024-09-11",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "DOMESTIC_ABUSE_T3"
+    }
+  ],
+  "adjustments": {
+    "UNLAWFULLY_AT_LARGE": [
+      {
+        "appliesToSentencesFrom": "2024-09-11",
+        "numberOfDays": 5,
+        "fromDate": "2025-09-05",
+        "toDate": "2025-09-09"
+      }
+    ]
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac1-8.json
@@ -1,0 +1,33 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "ST19001"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2024-09-16",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "DOMESTIC_ABUSE_T3"
+    }
+  ],
+  "adjustments": {
+    "ADDITIONAL_DAYS_AWARDED": [
+      {
+        "appliesToSentencesFrom": "2024-09-16",
+        "numberOfDays": 2,
+        "fromDate": "2024-10-10",
+        "toDate": "2024-10-12"
+      }
+    ]
+  },
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-1.json
@@ -1,0 +1,23 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "COML025"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 3
+        }
+      },
+      "sentencedAt": "2024-12-16",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "MURDER_T3"
+    }
+  ],
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-2.json
@@ -1,0 +1,25 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "COML026"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1,
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2025-01-13",
+      "recallType": "FIXED_TERM_RECALL_28",
+      "hasAnSDSEarlyReleaseExclusion": "MURDER_T3"
+    }
+  ],
+  "returnToCustodyDate": "2026-01-05",
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac2-3.json
@@ -1,0 +1,23 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2024-04-03",
+        "offenceCode": "SE20012A"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 3
+        }
+      },
+      "sentencedAt": "2024-12-20",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL_T3"
+    }
+  ],
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/tranches/crs-2202-ac3-1.json
@@ -1,0 +1,24 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2023-04-03",
+        "offenceCode": "ST19001"
+      },
+      "duration": {
+        "durationElements": {
+          "YEARS": 1,
+          "MONTHS": 8
+        }
+      },
+      "sentencedAt": "2023-11-09",
+      "recallType": "STANDARD_RECALL",
+      "hasAnSDSEarlyReleaseExclusion": "DOMESTIC_ABUSE_T3"
+    }
+  ],
+  "calculateErsed": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-2.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SLED": "2027-04-02",
+    "PRRD": "2027-04-02",
+    "ESED": "2027-04-02"
+  },
+  "effectiveSentenceLength": "P4Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-3.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-12-02",
+    "PRRD": "2025-04-06",
+    "TUSED": "2026-02-13",
+    "ESED": "2025-12-02"
+  },
+  "effectiveSentenceLength": "P1Y6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-4.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-01-05",
+    "PRRD": "2025-01-02",
+    "TUSED": "2025-11-11",
+    "ESED": "2025-01-10"
+  },
+  "effectiveSentenceLength": "P3M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-5.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-06-06",
+    "PRRD": "2025-01-19",
+    "TUSED": "2026-01-21",
+    "ESED": "2025-06-11"
+  },
+  "effectiveSentenceLength": "P9M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-6.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SLED": "2029-09-15",
+    "PRRD": "2027-06-28",
+    "ESED": "2029-09-15"
+  },
+  "effectiveSentenceLength": "P5Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-7.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2026-07-15",
+    "PRRD": "2026-07-15",
+    "TUSED": "2026-08-15",
+    "ESED": "2026-07-10"
+  },
+  "effectiveSentenceLength": "P1Y10M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac1-8.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-03-15",
+    "PRRD": "2025-03-15",
+    "TUSED": "2025-11-27",
+    "ESED": "2025-03-15"
+  },
+  "effectiveSentenceLength": "P6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-1.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SLED": "2027-12-15",
+    "PRRD": "2027-12-15",
+    "ESED": "2027-12-15"
+  },
+  "effectiveSentenceLength": "P3Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2026-07-12",
+    "PRRD": "2026-02-01",
+    "TUSED": "2026-10-12",
+    "ESED": "2026-07-12"
+  },
+  "effectiveSentenceLength": "P1Y6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac2-3.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SLED": "2027-12-19",
+    "PRRD": "2027-12-19",
+    "ESED": "2027-12-19"
+  },
+  "effectiveSentenceLength": "P3Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/tranches/crs-2202-ac3-1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-07-08",
+    "PRRD": "2025-07-08",
+    "TUSED": "2025-09-07",
+    "ESED": "2025-07-08"
+  },
+  "effectiveSentenceLength": "P1Y8M"
+}


### PR DESCRIPTION
Produce tests for recall sentences affected by tranche3 offences.

Remove unnecessary MURDER exclusion type.

Remove complex method comments for multiplierFnForDate, which is being replaced in upcoming changes.