### PR TITLE
Suppress HDCED if equal to or later than CRD

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -88,7 +88,9 @@ class BookingExtractionService(
     }
 
     if (sentenceCalculation.homeDetentionCurfewEligibilityDate != null && !sentence.releaseDateTypes.contains(PED)) {
-      dates[HDCED] = sentenceCalculation.homeDetentionCurfewEligibilityDate!!
+      if (hdcedExtractionService.releaseDateIsAfterHdced(sentenceCalculation)) {
+        dates[HDCED] = sentenceCalculation.homeDetentionCurfewEligibilityDate!!
+      }
     }
 
     if (sentenceCalculation.notionalConditionalReleaseDate != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HdcedExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HdcedExtractionService.kt
@@ -34,11 +34,24 @@ class HdcedExtractionService(
         )
 
         if (hdcedSentence != null) {
-          return resolveEligibilityDate(hdcedSentence, conflictingSentence)
+          if (latestAdjustedReleaseDateIsAfterHdced(hdcedSentence.sentenceCalculation, latestAdjustedReleaseDate)) {
+            return resolveEligibilityDate(hdcedSentence, conflictingSentence)
+          }
         }
       }
     }
     return null
+  }
+
+  fun latestAdjustedReleaseDateIsAfterHdced(sentenceCalculation: SentenceCalculation, latestReleaseDate: LocalDate): Boolean {
+    val hdcedDate = sentenceCalculation.homeDetentionCurfewEligibilityDate
+    return hdcedDate?.let { latestReleaseDate.isAfter(it) } ?: false
+  }
+
+  fun releaseDateIsAfterHdced(sentenceCalculation: SentenceCalculation): Boolean {
+    val releaseDate = sentenceCalculation.releaseDate
+    val hdcedDate = sentenceCalculation.homeDetentionCurfewEligibilityDate
+    return hdcedDate?.let { releaseDate.isAfter(it) } ?: false
   }
 
   private fun getLatestConflictingSentence(

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -658,4 +658,6 @@ custom-examples,crs-2162-2,,,
 
 validation,CRS-2207,,,
 custom-examples,crs-2210-concurrent-recall-ual-timeline-bug,,,
+custom-examples,crs-2211,,,
+custom-examples,crs-2211-non-ora,,,
 

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2211-non-ora.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2211-non-ora.json
@@ -1,0 +1,39 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2015-01-12",
+        "offenceCode": "OF61102"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 6
+        }
+      },
+      "sentencedAt": "2024-07-12",
+      "identifier": "f3a6566c-f724-3ed5-b263-35c3f8090d71"
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "appliesToSentencesFrom": "2024-07-12",
+        "numberOfDays": 80,
+        "fromDate": "2024-04-23",
+        "toDate": " 2024-07-11"
+      }
+    ],
+    "ADDITIONAL_DAYS_AWARDED": [
+      {
+        "appliesToSentencesFrom": "2024-07-12",
+        "numberOfDays": 35,
+        "fromDate": "2024-07-05",
+        "toDate": "2024-08-09"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2211.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2211.json
@@ -1,0 +1,60 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2023-06-23",
+        "offenceCode": "OF61102"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 12
+        }
+      },
+      "sentencedAt": "2024-09-06",
+      "identifier": "f3a6566c-f724-3ed5-b263-35c3f8090d71"
+    },
+    {
+      "offence": {
+        "committedAt": "2023-12-19",
+        "offenceCode": "CJ88160"
+      },
+      "duration": {
+        "durationElements": {
+          "MONTHS": 4
+        }
+      },
+      "sentencedAt": "2024-09-06",
+      "consecutiveSentenceUUIDs": [
+        "f3a6566c-f724-3ed5-b263-35c3f8090d71"
+      ]
+    }
+  ],
+  "adjustments": {
+    "REMAND": [
+      {
+        "appliesToSentencesFrom": "2024-09-06",
+        "numberOfDays": 213,
+        "fromDate": "2024-02-06",
+        "toDate": "2024-09-05"
+      }
+    ],
+    "ADDITIONAL_DAYS_AWARDED": [
+      {
+        "appliesToSentencesFrom": "2024-03-15",
+        "numberOfDays": 35,
+        "fromDate": "2024-03-15",
+        "toDate": "2024-04-18"
+      },
+      {
+        "appliesToSentencesFrom": "2024-10-03",
+        "numberOfDays": 28,
+        "fromDate": "2024-10-03",
+        "toDate": "2024-10-30"
+      }
+    ]
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2211-non-ora.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2211-non-ora.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "SED": "2024-10-23",
+    "ARD": "2024-08-27",
+    "ESED": "2025-01-11"
+  },
+  "effectiveSentenceLength": "P6M"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2211.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2211.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2025-06-06",
+    "CRD": "2024-09-22",
+    "TUSED": "2025-08-18",
+    "ESED": "2026-01-05"
+  },
+  "effectiveSentenceLength": "P1Y4M"
+}


### PR DESCRIPTION
- Updated `HdcedExtractionService` to suppress HDCED when it is equal to or later than CRD/ARD, ensuring compliance with AC1.
- Added utility methods `latestAdjustedReleaseDateIsAfterHdced` and `releaseDateIsAfterHdced` for precise HDCED handling.
- Modified `BookingExtractionService` to prevent HDCED display or submission under the specified conditions.
- Added test cases for CRS-2211 and CRS-2211-non-ora to validate the suppression logic.
- Included relevant test data reflecting adjustments and expected outcomes, ensuring scenarios like ADAs are correctly processed.