### PR TITLE
CRS-2240-data-analytics-extractor-memory-limit

### DIFF
--- a/helm_deploy/calculate-release-dates-api/values.yaml
+++ b/helm_deploy/calculate-release-dates-api/values.yaml
@@ -60,6 +60,6 @@ generic-data-analytics-extractor:
   args: "extract_table_names.py && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"
   resources:
     requests:
-      memory: 1G
-    limits:
       memory: 2G
+    limits:
+      memory: 4G


### PR DESCRIPTION
Increase memory limit to 4Gb in light of larger DB size.

A more optimised solution will be added in due course to prevent future memory issues.