### PR TITLE
Add test to cover list D excluded scenarios

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSPlusCheckResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSPlusCheckResult.kt
@@ -73,7 +73,7 @@ class SDSPlusCheckResult(
     return if (listDExtended) {
       sentencedAfterPcsc()
     } else {
-      sentencedAfterPcsc() || offenceMarkers?.pcscMarkers?.inListA == true  && sentencedWithinOriginalSdsPlusWindow()
+      sentencedAfterPcsc() || offenceMarkers?.pcscMarkers?.inListA == true && sentencedWithinOriginalSdsPlusWindow()
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSPlusCheckResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSPlusCheckResult.kt
@@ -24,20 +24,14 @@ class SDSPlusCheckResult(
 
     val offenceCode = sentenceAndOffence.offence.offenceCode
 
-    // check that things are supported and relevant
     eligibleSentence = SentenceCalculationType.isSupported(sentenceAndOffence.sentenceCalculationType) &&
       SentenceCalculationType.isSDSPlusEligible(sentenceAndOffence.sentenceCalculationType)
     offenceMarkers = sdsPlusMarkersByOffences[offenceCode]
     listDExtended = offenceCode in LEGACY_OFFENCE_CODES_FOR_OFFENCES_ON_LIST_D
 
-    // we determine whether the calculation type is none, SDS or SECTION 250
     eligibilityType = getSentenceEligibilityType(sentenceAndOffence.sentenceCalculationType)
     isSDSPlusOffenceInPeriod = offenceWithinDateRangeForLists()
 
-    // we need to know that the sentence type is supported
-    // that the sentence type is SDS (or Section 25)
-    // and it meets the relevant (4 or 7 year) length requirement,
-    // and it's associated with the relevant list
     isSDSPlusEligibleSentenceTypeLengthAndOffence = eligibleSentence && eligibleSentenceTypeLengthAndOffence()
 
     isSDSPlus = isSDSPlusEligibleSentenceTypeLengthAndOffence && isSDSPlusOffenceInPeriod
@@ -79,7 +73,7 @@ class SDSPlusCheckResult(
     return if (listDExtended) {
       sentencedAfterPcsc()
     } else {
-      sentencedAfterPcsc() || sentencedWithinOriginalSdsPlusWindow()
+      sentencedAfterPcsc() || offenceMarkers?.pcscMarkers?.inListA == true  && sentencedWithinOriginalSdsPlusWindow()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
@@ -83,7 +83,6 @@ class ReleaseArrangementLookupServiceTest {
     assertTrue(returnedResult[0].isSDSPlusEligibleSentenceTypeLengthAndOffence)
   }
 
-
   @Test
   fun `SDS+ is NOT set for ADIMP as sentenced before SDS and not over 7 years in duration`() {
     val returnedResult = underTest.populateReleaseArrangements(sentenceMatchesNoMatchingOffencesDueToSentenceDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
@@ -74,6 +74,17 @@ class ReleaseArrangementLookupServiceTest {
   }
 
   @Test
+  fun `SDS+ is NOT set for SDS+ Over 7 Years, on List D, sentenced prior to PCSC`() {
+    whenever(mockManageOffencesService.getPcscMarkersForOffenceCodes(any())).thenReturn(listOf(pcscListDMarkers))
+
+    val returnedResult = underTest.populateReleaseArrangements(sentencedAfterSDSPlusBeforePCSCLongerThan7Years)
+    assertFalse(returnedResult[0].isSDSPlus)
+    assertFalse(returnedResult[0].isSDSPlusOffenceInPeriod)
+    assertTrue(returnedResult[0].isSDSPlusEligibleSentenceTypeLengthAndOffence)
+  }
+
+
+  @Test
   fun `SDS+ is NOT set for ADIMP as sentenced before SDS and not over 7 years in duration`() {
     val returnedResult = underTest.populateReleaseArrangements(sentenceMatchesNoMatchingOffencesDueToSentenceDate)
     // no call to MO should take place as offences don't match filter.
@@ -654,7 +665,7 @@ class ReleaseArrangementLookupServiceTest {
         null,
         "TEST",
         "TEST",
-        SentenceCalculationType.YOI.toString(),
+        SentenceCalculationType.ADIMP.toString(),
         "TEST",
         LocalDate.of(2021, 4, 2),
         listOf(SentenceTerms(12, 4, 1, 1)),


### PR DESCRIPTION
Fix issue where items on List D (over 7 years) use the SDS+ date, rather than the PCSC date 
Note: this, sadly, introduces a dependency between lists and date ranges we have tried to seperate as much as possible within code. There doesn't seem to be an obvious way around that :(