### PR TITLE
CRS-2254 Mock call to nonFridayReleaseService to avoid hint texts changing over time in the tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -29,6 +30,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBr
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.DetailedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NonFridayReleaseDay
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BankHoliday
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.BankHolidays
@@ -74,6 +76,10 @@ class HintTextTest {
   @BeforeEach
   fun beforeAll() {
     Mockito.`when`(bankHolidayService.getBankHolidays()).thenReturn(BANK_HOLIDAYS)
+    Mockito.`when`(nonFridayReleaseService.getDate(any<ReleaseDate>())).thenAnswer { invocation ->
+      val releaseDate = invocation.getArgument<ReleaseDate>(0)
+      NonFridayReleaseDay(releaseDate.date)
+    }
   }
 
   @ParameterizedTest
@@ -227,7 +233,8 @@ class HintTextTest {
   private val clock = Clock.fixed(today.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())
   private val featureToggles = FeatureToggles(sdsEarlyReleaseHints = true, hdc365 = true)
 
-  private val nonFridayReleaseService = NonFridayReleaseService(bankHolidayService, clock)
+//  private val nonFridayReleaseService = NonFridayReleaseService(bankHolidayService, clock)
+  private val nonFridayReleaseService = mock<NonFridayReleaseService>()
 
   private val calculationResultEnrichmentService = CalculationResultEnrichmentService(nonFridayReleaseService, workingDayService, clock, featureToggles)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
@@ -233,7 +233,6 @@ class HintTextTest {
   private val clock = Clock.fixed(today.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())
   private val featureToggles = FeatureToggles(sdsEarlyReleaseHints = true, hdc365 = true)
 
-//  private val nonFridayReleaseService = NonFridayReleaseService(bankHolidayService, clock)
   private val nonFridayReleaseService = mock<NonFridayReleaseService>()
 
   private val calculationResultEnrichmentService = CalculationResultEnrichmentService(nonFridayReleaseService, workingDayService, clock, featureToggles)

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2164-ac3.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2164-ac3.json
@@ -8,7 +8,6 @@
     "type": "CRD",
     "date": "2025-01-18",
     "hints": [
-      "The Discretionary Friday/Pre-Bank Holiday Release Scheme Policy applies to this release date.",
       "40% date has been applied"
     ]
   },

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac01.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac01.json
@@ -7,7 +7,7 @@
   {
     "type": "CRD",
     "date": "2025-11-28",
-    "hints": ["The Discretionary Friday/Pre-Bank Holiday Release Scheme Policy applies to this release date."]
+    "hints": []
   },
   {
     "type": "HDCED",

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac02-1.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac02-1.json
@@ -7,7 +7,10 @@
   {
     "type": "CRD",
     "date": "2025-11-29",
-    "hints": ["The Discretionary Friday/Pre-Bank Holiday Release Scheme Policy applies to this release date.", "40% date has been applied"]
+    "hints": [
+      "Friday, 28 November 2025 when adjusted to a working day",
+      "40% date has been applied"
+    ]
   },
   {
     "type": "HDCED",

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac03-1.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2218-ac03-1.json
@@ -7,7 +7,10 @@
   {
     "type": "CRD",
     "date": "2025-11-30",
-    "hints": ["The Discretionary Friday/Pre-Bank Holiday Release Scheme Policy applies to this release date.", "40% date has been applied"]
+    "hints": [
+      "Friday, 28 November 2025 when adjusted to a working day",
+      "40% date has been applied"
+    ]
   },
   {
     "type": "HDCED",


### PR DESCRIPTION
this changes some of the hints because the variable one 'The Discretionary..' will no longer show (the condition has been mocked to return false every time)