### PR TITLE
CRS-2260 Add null check for TUSED breakdown - could be null via the full-validation route when a BOTUS exists

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -589,14 +589,16 @@ class BookingExtractionService(
       .filter { it.sentenceCalculation.topUpSupervisionDate != null }
       .maxByOrNull { it.sentenceCalculation.topUpSupervisionDate!! }
 
-    return if (latestTUSEDSentence != null &&
-      latestTUSEDSentence.sentenceCalculation.topUpSupervisionDate!!.isAfter(
-        latestLicenseExpiryDate,
-      )
-    ) {
-      latestTUSEDSentence.sentenceCalculation.topUpSupervisionDate!! to latestTUSEDSentence.sentenceCalculation.breakdownByReleaseDateType[TUSED]!!
-    } else {
-      null
+    return latestTUSEDSentence?.let { sentence ->
+      val topUpDate = sentence.sentenceCalculation.topUpSupervisionDate
+      val breakdown = sentence.sentenceCalculation.breakdownByReleaseDateType[TUSED]
+
+      // CRS-2260 Added breakdown != null check - this can be null in this BOTUS scenario via the full-validation endpoint (fullValidationFromBookingData)
+      if (topUpDate != null && breakdown != null && topUpDate.isAfter(latestLicenseExpiryDate)) {
+         topUpDate to breakdown
+      } else {
+        null
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -595,7 +595,7 @@ class BookingExtractionService(
 
       // CRS-2260 Added breakdown != null check - this can be null in this BOTUS scenario via the full-validation endpoint (fullValidationFromBookingData)
       if (topUpDate != null && breakdown != null && topUpDate.isAfter(latestLicenseExpiryDate)) {
-         topUpDate to breakdown
+        topUpDate to breakdown
       } else {
         null
       }


### PR DESCRIPTION
Possibly some tech debt here because there are no integration/TDD tests that test this functionality via the full-validation route