### PR TITLE
crs-2262-concurrent-botus-feature-toggle

### DIFF
--- a/helm_deploy/calculate-release-dates-api/values.yaml
+++ b/helm_deploy/calculate-release-dates-api/values.yaml
@@ -23,6 +23,7 @@ generic-service:
     HMPPS_SQS_USE_WEB_TOKEN: "true"
     HDC_365_FEATURE_TOGGLE: "true"
     BOTUS_CONSECUTIVE_JOURNEY_FEATURE_TOGGLE: "true"
+    BOTUS_CONCURRENT_JOURNEY_FEATURE_TOGGLE: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ generic-service:
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     ADJUSTMENTS_API_URL: https://adjustments-api-dev.hmpps.service.justice.gov.uk
     MANAGE-OFFENCES_API_URL: https://manage-offences-api-dev.hmpps.service.justice.gov.uk
+    BOTUS_CONCURRENT_JOURNEY_FEATURE_TOGGLE: "true"
     SDS_EARLY_RELEASE_FEATURE_TOGGLE: "true"
     SDS_EARLY_RELEASE_HINTS_FEATURE_TOGGLE: "true"
     SUPPORT_INACTIVE_SENTENCES_AND_ADJUSTMENTS: "false"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISON_API_URL: https://prison-api-preprod.prison.service.justice.gov.uk
     ADJUSTMENTS_API_URL: https://adjustments-api-preprod.hmpps.service.justice.gov.uk
     MANAGE-OFFENCES_API_URL: https://manage-offences-api-preprod.hmpps.service.justice.gov.uk
+    BOTUS_CONCURRENT_JOURNEY_FEATURE_TOGGLE: "true"
     SDS_EARLY_RELEASE_FEATURE_TOGGLE: "true"
     SDS_EARLY_RELEASE_HINTS_FEATURE_TOGGLE: "true"
     SUPPORT_INACTIVE_SENTENCES_AND_ADJUSTMENTS: "false"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/FeatureToggles.kt
@@ -9,6 +9,7 @@ data class FeatureToggles(
   var supportInactiveSentencesAndAdjustments: Boolean = false,
   var toreraOffenceToManualJourney: Boolean = false,
   var botusConsecutiveJourney: Boolean = false,
+  var botusConcurrentJourney: Boolean = false,
   var hdc365: Boolean = false,
   var externalMovementsEnabled: Boolean = false,
   var revisedFixedTermRecallsRules: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/BotusValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/BotusValidationService.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation
 
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType.BOTUS
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE
 
 @Service
 class BotusValidationService(
@@ -15,19 +16,32 @@ class BotusValidationService(
 ) {
 
   internal fun validate(sourceData: PrisonApiSourceData): List<ValidationMessage> {
-    if (featureToggles.botusConsecutiveJourney) {
-      log.info("BOTUS consecutive and concurrent journeys are feature enabled - therefore the 'unsupported' validation for BOTUS will not run")
-      return emptyList()
+    if (featureToggles.botusConcurrentJourney) {
+      val consecutiveSentences = sourceData.sentenceAndOffences
+        .filter { it.consecutiveToSequence != null }
+
+      if (consecutiveSentences.any { isBotusSentence(it) }) {
+        return listOf(ValidationMessage(code = BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE))
+      }
+
+      getConsecutiveChains(consecutiveSentences).forEach { chain ->
+        if (isBotusAdjacentSentence(sourceData, chain.first())) {
+          return listOf(ValidationMessage(code = BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE))
+        }
+      }
     }
-    log.info("BOTUS consecutive and concurrent journeys are unsupported, running unsupported validation")
 
-    val botusSentences = getBotusSentences(sourceData)
+    if (!featureToggles.botusConsecutiveJourney) {
+      val botusSentences = getBotusSentences(sourceData)
 
-    if (botusSentences.isEmpty() || botusSentences.size == sourceData.sentenceAndOffences.size) {
-      return emptyList()
+      if (botusSentences.isEmpty() || botusSentences.size == sourceData.sentenceAndOffences.size) {
+        return emptyList()
+      }
+
+      return listOf(ValidationMessage(code = BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE))
     }
 
-    return listOf(ValidationMessage(code = BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE))
+    return emptyList()
   }
 
   private fun getBotusSentences(sourceData: PrisonApiSourceData): List<SentenceAndOffence> {
@@ -36,7 +50,29 @@ class BotusValidationService(
     }
   }
 
-  companion object {
-    private val log = LoggerFactory.getLogger(BotusValidationService::class.java)
+  private fun isBotusSentence(sentence: SentenceAndOffenceWithReleaseArrangements): Boolean {
+    return SentenceCalculationType.from(sentence.sentenceCalculationType) == BOTUS
+  }
+
+  private fun isBotusAdjacentSentence(sourceData: PrisonApiSourceData, index: Int): Boolean {
+    val sentence = sourceData.sentenceAndOffences.firstOrNull { it.sentenceSequence == index }
+    return sentence?.let { isBotusSentence(it) } == true
+  }
+
+  private fun getConsecutiveChains(
+    consecutiveSentences: List<SentenceAndOffenceWithReleaseArrangements>,
+  ): List<List<Int>> {
+    val sentenceChains = mutableListOf<MutableList<Int>>()
+
+    for (sentence in consecutiveSentences) {
+      val sequence = sentence.consecutiveToSequence ?: continue
+      if (sentenceChains.isEmpty() || sentenceChains.last().last() != sequence - 1) {
+        sentenceChains.add(mutableListOf(sequence))
+      } else {
+        sentenceChains.last().add(sequence)
+      }
+    }
+
+    return sentenceChains
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
@@ -85,6 +85,7 @@ enum class ValidationCode(val message: String, val validationType: ValidationTyp
   ZERO_IMPRISONMENT_TERM("Court case %s count %s must include an imprisonment term greater than zero."),
   UNSUPPORTED_CALCULATION_DTO_WITH_RECALL("Unsupported calculation - DTO and recall", UNSUPPORTED_CALCULATION),
   PRE_PCSC_DTO_WITH_ADJUSTMENT("If a Detention and training order (DTO) has a sentence date before 28 June 2022, %s cannot be applied."),
+  BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE("BOTUS consecutive with other sentence type", UNSUPPORTED_CALCULATION),
   BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE("BOTUS concurrent/consecutive with other sentence type", UNSUPPORTED_CALCULATION),
   UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE("Unsupported recalls for SDS40", MANUAL_ENTRY_JOURNEY_REQUIRED),
   UNSUPPORTED_SDS40_CONSECUTIVE_SDS_BETWEEN_TRANCHE_COMMENCEMENTS(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,6 +146,7 @@ domain-events-sns:
 
 feature-toggles:
   botus-consecutive-journey: ${BOTUS_CONSECUTIVE_JOURNEY_FEATURE_TOGGLE:false}
+  botus-concurrent-journey: ${BOTUS_CONCURRENT_JOURNEY_FEATURE_TOGGLE:false}
   sds-early-release: ${SDS_EARLY_RELEASE_FEATURE_TOGGLE:false}
   sds-early-release-hints: ${SDS_EARLY_RELEASE_HINTS_FEATURE_TOGGLE:false}
   support-inactive-sentences-and-adjustments: ${SUPPORT_INACTIVE_SENTENCES_AND_ADJUSTMENTS:false}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
@@ -567,7 +567,7 @@ class ManualCalculationServiceTest {
     whenever(validationService.validateSupportedSentencesAndCalculations(any())).thenReturn(
       listOf(
         ValidationMessage(ValidationCode.UNSUPPORTED_CALCULATION_DTO_WITH_RECALL),
-        ValidationMessage(ValidationCode.BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE),
+        ValidationMessage(ValidationCode.BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/BotusValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/BotusValidationServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.BookingAndSentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE
 import java.time.LocalDate
 
 class BotusValidationServiceTest {
@@ -24,6 +25,7 @@ class BotusValidationServiceTest {
   @Test
   fun `should skip validation when botusConsecutiveJourney feature toggle is enabled`() {
     whenever(featureToggles.botusConsecutiveJourney).thenReturn(true)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(false)
 
     val messages = botusValidationService.validate(SOURCE_DATA)
 
@@ -33,10 +35,61 @@ class BotusValidationServiceTest {
   @Test
   fun `should perform validation when botusConsecutiveJourney feature toggle is disabled`() {
     whenever(featureToggles.botusConsecutiveJourney).thenReturn(false)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(false)
 
     val messages = botusValidationService.validate(SOURCE_DATA)
 
     assertThat(messages).containsExactly(ValidationMessage(BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE))
+  }
+
+  @Test
+  fun `should perform validation when error when Consecutive chain includes BOTUS sentence as the first sentence in a chain`() {
+    whenever(featureToggles.botusConsecutiveJourney).thenReturn(false)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(false)
+
+    val messages = botusValidationService.validate(SOURCE_DATA_FIRST_CHAIN_IS_BOTUS)
+
+    assertThat(messages).containsExactly(ValidationMessage(BOTUS_CONSECUTIVE_OR_CONCURRENT_TO_OTHER_SENTENCE))
+  }
+
+  @Test
+  fun `should skip validation when botusConcurrentJourney feature toggle is disabled`() {
+    whenever(featureToggles.botusConsecutiveJourney).thenReturn(true)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(false)
+
+    val messages = botusValidationService.validate(SOURCE_DATA)
+
+    assertThat(messages).isEmpty()
+  }
+
+  @Test
+  fun `should perform validation when botusConcurrentJourney feature toggle is enabled`() {
+    whenever(featureToggles.botusConsecutiveJourney).thenReturn(true)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(true)
+
+    val messages = botusValidationService.validate(SOURCE_DATA)
+
+    assertThat(messages).containsExactly(ValidationMessage(BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE))
+  }
+
+  @Test
+  fun `should perform validation with error when botusConcurrentJourney chain includes BOTUS sentence as the first sentence in a chain`() {
+    whenever(featureToggles.botusConsecutiveJourney).thenReturn(true)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(true)
+
+    val messages = botusValidationService.validate(SOURCE_DATA_FIRST_CHAIN_IS_BOTUS)
+
+    assertThat(messages).containsExactly(ValidationMessage(BOTUS_CONSECUTIVE_TO_OTHER_SENTENCE))
+  }
+
+  @Test
+  fun `should perform validation with no error when botusConcurrentJourney chain includes no BOTUS sentence`() {
+    whenever(featureToggles.botusConsecutiveJourney).thenReturn(true)
+    whenever(featureToggles.botusConcurrentJourney).thenReturn(true)
+
+    val messages = botusValidationService.validate(SOURCE_DATE_NO_CONSECUTIVE_BOTUS)
+
+    assertThat(messages).isEmpty()
   }
 
   companion object {
@@ -82,8 +135,78 @@ class BotusValidationServiceTest {
       ),
     )
 
+    private val CONSECUTIVE_NONE_BOTUS_SENTENCES = listOf(
+      BASE_SENTENCE.copy(
+        sentenceSequence = 1,
+      ),
+      BASE_SENTENCE.copy(
+        sentenceSequence = 2,
+        consecutiveToSequence = 1,
+        sentenceCalculationType = SentenceCalculationType.FTR.name,
+        terms = listOf(SentenceTerms(days = 7, code = "IMP")),
+      ),
+      BASE_SENTENCE.copy(
+        lineSequence = 3,
+        sentenceCalculationType = SentenceCalculationType.BOTUS.name,
+      ),
+    )
+
+    private val CONSECUTIVE_BOTUS_SENTENCES_ADJACENT_FIRST = listOf(
+      BASE_SENTENCE.copy(
+        sentenceSequence = 1,
+      ),
+      BASE_SENTENCE.copy(
+        sentenceSequence = 2,
+        sentenceCalculationType = SentenceCalculationType.BOTUS.name,
+      ),
+      BASE_SENTENCE.copy(
+        sentenceSequence = 3,
+        consecutiveToSequence = 2,
+        sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+        terms = listOf(SentenceTerms(days = 7, code = "IMP")),
+      ),
+      BASE_SENTENCE.copy(
+        sentenceSequence = 4,
+        consecutiveToSequence = 3,
+        sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+        terms = listOf(SentenceTerms(days = 3, code = "IMP")),
+      ),
+    )
+
     val SOURCE_DATA = PrisonApiSourceData(
       sentenceAndOffences = CONSECUTIVE_BOTUS_SENTENCES.map {
+        SentenceAndOffenceWithReleaseArrangements(
+          source = it,
+          isSdsPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+          isSDSPlusOffenceInPeriod = false,
+          hasAnSDSExclusion = SDSEarlyReleaseExclusionType.NO,
+        )
+      },
+      prisonerDetails = VALID_PRISONER,
+      bookingAndSentenceAdjustments = VALID_ADJUSTMENTS,
+      offenderFinePayments = listOf(),
+      returnToCustodyDate = null,
+    )
+
+    val SOURCE_DATE_NO_CONSECUTIVE_BOTUS = PrisonApiSourceData(
+      sentenceAndOffences = CONSECUTIVE_NONE_BOTUS_SENTENCES.map {
+        SentenceAndOffenceWithReleaseArrangements(
+          source = it,
+          isSdsPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+          isSDSPlusOffenceInPeriod = false,
+          hasAnSDSExclusion = SDSEarlyReleaseExclusionType.NO,
+        )
+      },
+      prisonerDetails = VALID_PRISONER,
+      bookingAndSentenceAdjustments = VALID_ADJUSTMENTS,
+      offenderFinePayments = listOf(),
+      returnToCustodyDate = null,
+    )
+
+    val SOURCE_DATA_FIRST_CHAIN_IS_BOTUS = PrisonApiSourceData(
+      sentenceAndOffences = CONSECUTIVE_BOTUS_SENTENCES_ADJACENT_FIRST.map {
         SentenceAndOffenceWithReleaseArrangements(
           source = it,
           isSdsPlus = false,


### PR DESCRIPTION
Add FeatureToggle to calculate sentences where there is 1 or more active BOTUS Concurrent with other supported sentences / sentence chains.

Check Nomis sentence chains where the first element in the chain may be Botus but has no consecutiveToSequence value.