### PR TITLE
crs-2317-missing-historic-tused-for-breakdown

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationBreakdownService.kt
@@ -27,10 +27,17 @@ open class CalculationBreakdownService(
     val bookingAndSentenceAdjustments = calculationRequest.adjustments?.let { prisonApiDataMapper.mapBookingAndSentenceAdjustments(calculationRequest) }
     val returnToCustodyDate = calculationRequest.returnToCustodyDate?.let { prisonApiDataMapper.mapReturnToCustodyDate(calculationRequest) }
     val calculation = transform(calculationRequest)
+    val historicalTusedData = prisonApiDataMapper.mapHistoricalTusedData(calculationRequest)
     return if (sentenceAndOffences != null && prisonerDetails != null && bookingAndSentenceAdjustments != null) {
       val booking = Booking(
         offender = transform(prisonerDetails),
-        sentences = sentenceAndOffences.map { transform(it, calculationUserInputs) },
+        sentences = sentenceAndOffences.map {
+          transform(
+            sentence = it,
+            calculationUserInputs = calculationUserInputs,
+            historicalTusedData = historicalTusedData,
+          )
+        },
         adjustments = transform(bookingAndSentenceAdjustments, sentenceAndOffences),
         bookingId = prisonerDetails.bookingId,
         returnToCustodyDate = returnToCustodyDate?.returnToCustodyDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiDataMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/PrisonApiDataMapper.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.HistoricalTusedData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffencesWithSDSPlus
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderFinePayment
@@ -55,5 +57,13 @@ class PrisonApiDataMapper(private val objectMapper: ObjectMapper) {
   fun mapOffenderFinePayment(calculationRequest: CalculationRequest): List<OffenderFinePayment> {
     val reader = objectMapper.readerFor(object : TypeReference<List<OffenderFinePayment>>() {})
     return reader.readValue(calculationRequest.offenderFinePayments)
+  }
+
+  fun mapHistoricalTusedData(calculationRequest: CalculationRequest): HistoricalTusedData? {
+    val historicalTusedDataNode = calculationRequest.inputData.findPath("historicalTusedData")
+    if (historicalTusedDataNode.isMissingNode) {
+      return null
+    }
+    return objectMapper.convertValue(historicalTusedDataNode, HistoricalTusedData::class.java)
   }
 }

--- a/src/test/resources/test_data/hint-text.csv
+++ b/src/test/resources/test_data/hint-text.csv
@@ -29,3 +29,4 @@ crs-2212-ac7
 crs-2263-ac8
 crs-2259-botus-bug-ac1
 crs-2259-botus-bug-ac2
+crs-2317-single-botus

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2317-single-botus.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2317-single-botus.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "SED",
+    "date": "2025-03-17",
+    "hints": []
+  },
+  {
+    "type": "ARD",
+    "date": "2025-03-17",
+    "hints": []
+  },
+  {
+    "type": "TUSED",
+    "date": "2025-10-02",
+    "hints": ["TUSED from last calculation saved to NOMIS"]
+  }
+]

--- a/src/test/resources/test_data/hint-text/input-data/crs-2317-single-botus.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2317-single-botus.json
@@ -1,0 +1,42 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "2000-01-26",
+    "isActiveSexOffender": false
+  },
+  "bookingId": 1234567,
+  "sentences": [
+    {
+      "type": "BotusSentence",
+      "offence": {
+        "committedAt": "2025-02-03",
+        "offenceCode": "CJ03524"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 14,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 0
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "287f14dd-d522-30ac-8e23-1cf9f857b36c",
+      "recallType": null,
+      "sentencedAt": "2025-03-04",
+      "latestTusedDate": "2025-10-02",
+      "latestTusedSource": "NOMIS",
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    }
+  ],
+  "adjustments": {},
+  "externalMovements": [],
+  "historicalTusedData": {
+    "tused": "2025-10-02",
+    "historicalTusedSource": "NOMIS"
+  },
+  "returnToCustodyDate": null,
+  "fixedTermRecallDetails": null
+}


### PR DESCRIPTION
Provide historic TUSED data to sentence mapper before performing calculationWithBreakdown.