### PR TITLE
Improving bulk comparison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/ComparisonStatusValue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/enumerations/ComparisonStatusValue.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations
 
-enum class ComparisonStatusValue() {
-  PROCESSING,
-  ACTIVE,
-  COMPLETED,
-  ARCHIVED,
+enum class ComparisonStatusValue {
+  SETUP, // In setup creating the comparison record, getting prisoners and queuing each message
+  PROCESSING, // Processing each calculation required
+  COMPLETED, // Processing complete
+  ERROR, // Unable to complete due to error in setup
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonEventService.kt
@@ -44,35 +44,54 @@ class BulkComparisonEventService(
   @Transactional
   @Async
   fun processPrisonComparison(comparisonId: Long, token: String) {
-    setAuthToken(token)
-    val comparison = getComparison(comparisonId)
-    val prisoners = prisonService.getCalculablePrisonerByPrison(comparison.prison!!)
-    sendMessages(comparison, prisoners.map { it.prisonerNumber })
-    comparison.numberOfPeopleExpected = prisoners.size.toLong()
+    try {
+      setAuthToken(token)
+      val comparison = getComparison(comparisonId)
+      val prisoners = prisonService.getCalculablePrisonerByPrison(comparison.prison!!)
+      sendMessages(comparison, prisoners.map { it.prisonerNumber })
+      completeSetup(comparison, prisoners.size.toLong())
+    } catch (e: Exception) {
+      handleErrorInBulkSetup(comparisonId, e)
+    }
   }
 
   @Transactional
   @Async
   fun processFullCaseLoadComparison(comparisonId: Long, token: String) {
-    setAuthToken(token)
-    val comparison = getComparison(comparisonId)
-    val currentUserPrisonsList = prisonService.getCurrentUserPrisonsList()
-    var count = 0L
-    for (prison in currentUserPrisonsList) {
-      val prisoners = prisonService.getCalculablePrisonerByPrison(prison)
-      sendMessages(comparison, prisoners.map { it.prisonerNumber }, prison)
-      count += prisoners.size
+    try {
+      setAuthToken(token)
+      val comparison = getComparison(comparisonId)
+      val currentUserPrisonsList = prisonService.getCurrentUserPrisonsList()
+      var count = 0L
+      for (prison in currentUserPrisonsList) {
+        val prisoners = prisonService.getCalculablePrisonerByPrison(prison)
+        sendMessages(comparison, prisoners.map { it.prisonerNumber }, prison)
+        count += prisoners.size
+      }
+      completeSetup(comparison, count)
+    } catch (e: Exception) {
+      handleErrorInBulkSetup(comparisonId, e)
     }
-    comparison.numberOfPeopleExpected = count
   }
 
   @Transactional
   @Async
   fun processManualComparison(comparisonId: Long, prisonerIds: List<String>, token: String) {
-    setAuthToken(token)
+    try {
+      setAuthToken(token)
+      val comparison = getComparison(comparisonId)
+      sendMessages(comparison, prisonerIds)
+      completeSetup(comparison, prisonerIds.size.toLong())
+    } catch (e: Exception) {
+      handleErrorInBulkSetup(comparisonId, e)
+    }
+  }
+
+  private fun handleErrorInBulkSetup(comparisonId: Long, e: Exception) {
+    log.error("Error setting up bulk comparison $comparisonId", e)
     val comparison = getComparison(comparisonId)
-    sendMessages(comparison, prisonerIds)
-    comparison.numberOfPeopleExpected = prisonerIds.size.toLong()
+    comparison.comparisonStatus = ComparisonStatus(comparisonStatusValue = ComparisonStatusValue.ERROR)
+    comparisonRepository.save(comparison)
   }
 
   fun sendMessages(comparison: Comparison, calculations: List<String>, establishment: String? = null) {
@@ -85,6 +104,12 @@ class BulkComparisonEventService(
       establishment = establishment,
       username = serviceUserService.getUsername(),
     )
+  }
+
+  fun completeSetup(comparison: Comparison, total: Long) {
+    comparison.numberOfPeopleExpected = total
+    comparison.comparisonStatus = ComparisonStatus(comparisonStatusValue = ComparisonStatusValue.PROCESSING)
+    comparisonRepository.save(comparison)
   }
 
   fun getComparison(comparisonId: Long): Comparison {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -700,7 +700,7 @@ fun transform(
     prison = comparison.prison,
     calculatedAt = LocalDateTime.now(),
     calculatedByUsername = username,
-    comparisonStatus = ComparisonStatus(ComparisonStatusValue.PROCESSING),
+    comparisonStatus = ComparisonStatus(ComparisonStatusValue.SETUP),
   )
 }
 
@@ -712,7 +712,7 @@ fun transform(
   comparisonType = MANUAL,
   calculatedAt = LocalDateTime.now(),
   calculatedByUsername = username,
-  comparisonStatus = ComparisonStatus(ComparisonStatusValue.PROCESSING),
+  comparisonStatus = ComparisonStatus(ComparisonStatusValue.SETUP),
 )
 
 fun transform(


### PR DESCRIPTION
1. Increase timeout for getting prisoners at establishment.
2. Bulk message request only allows 10 messages at a time
3. Add new state for SETUP.
4. Mark comparison as error if exception happens in the setup