### PR TITLE
Crs 2283 removed duplicate consec sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SentenceValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SentenceValidationService.kt
@@ -271,7 +271,7 @@ class SentenceValidationService(
       val firstPart = sentence.sentenceParts().firstOrNull()?.identifier ?: return@filter false
       val duplicateParent = sentencePartsList.contains(firstPart) && sentencePartsList.count { it == firstPart } > 1
       val isReferencedByOthers = otherSentenceParentUUIDs.isNotEmpty() && sentence.sentenceParts().any {
-        part -> part.consecutiveSentenceUUIDs.any { it in otherSentenceParentUUIDs }
+        it.consecutiveSentenceUUIDs.any { uuid -> uuid in otherSentenceParentUUIDs }
       }
       duplicateParent || isReferencedByOthers
     }

--- a/src/test/resources/test_data/calculation-service-examples.csv
+++ b/src/test/resources/test_data/calculation-service-examples.csv
@@ -693,5 +693,6 @@ consecutive-sentences,crs-2283-ac5-1,,,,CONCURRENT_CONSECUTIVE_SENTENCES,2 years
 consecutive-sentences,crs-2283-ac5-2,,,,CONCURRENT_CONSECUTIVE_SENTENCES,2 years 24 months 0 weeks 0 days
 consecutive-sentences,crs-2283-ac5-3,,,,CONCURRENT_CONSECUTIVE_SENTENCES,8 years 24 months 0 weeks 0 days
 consecutive-sentences,crs-2283-ac5-4,,,,CONCURRENT_CONSECUTIVE_SENTENCES,2 years 24 months 2 weeks 0 days
+consecutive-sentences,crs-2283-ac5-5,,,,CONCURRENT_CONSECUTIVE_SENTENCES,2 years 149 months 0 weeks 0 days
 custom-examples,crs-2331-bug,,,,,
 custom-examples,crs-2332-bug,,,,,

--- a/src/test/resources/test_data/overall_calculation/consecutive-sentences/crs-2283-ac5-5.json
+++ b/src/test/resources/test_data/overall_calculation/consecutive-sentences/crs-2283-ac5-5.json
@@ -1,0 +1,310 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "bookingId": 111111,
+  "sentences": [
+    {
+      "type": "SopcSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "sdopcu18": false,
+      "isSDSPlus": false,
+      "identifier": "e9105ebc-cab9-345f-bdc1-cea9a177d19d",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 1,
+      "custodialDuration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 44
+        }
+      },
+      "extensionDuration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 1,
+          "MONTHS": 0
+        }
+      },
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "SopcSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "sdopcu18": false,
+      "isSDSPlus": false,
+      "identifier": "82de2cf8-20f3-3e11-a09b-c23efa7a18de",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 2,
+      "custodialDuration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 40
+        }
+      },
+      "extensionDuration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 1,
+          "MONTHS": 0
+        }
+      },
+      "consecutiveSentenceUUIDs": [
+        "e9105ebc-cab9-345f-bdc1-cea9a177d19d"
+      ],
+      "isSDSPlusOffenceInPeriod": false,
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 3
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "cfd87710-6668-3a9a-bdd6-0e59e991651d",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 3,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 64
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "89f6a1e5-92c6-36fc-b832-86dbc40ad57e",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 4,
+      "consecutiveSentenceUUIDs": [
+        "82de2cf8-20f3-3e11-a09b-c23efa7a18de"
+      ],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": true
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 64
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "63cac35d-9839-3359-850d-52886ca51b47",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 5,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": true
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 3
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "ef04f40d-819f-363c-9790-91ec9692c8d7",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 6,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 8
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "801d298d-097f-306d-a8da-115c1d272bd2",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 7,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 8
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "cdec0b38-a118-3ef0-9c8a-548ecce8a7b7",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 8,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 8
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "f09dcb0e-aec9-30ac-b7f5-c9950dbc7420",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 9,
+      "consecutiveSentenceUUIDs": [],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "86e98cd0-9e5c-3550-85cd-fce4d655829b",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 10,
+      "consecutiveSentenceUUIDs": [
+        "89f6a1e5-92c6-36fc-b832-86dbc40ad57e"
+      ],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    },
+    {
+      "type": "StandardSentence",
+      "offence": {
+        "committedAt": "2000-01-01",
+        "offenceCode": "SX11111"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 0,
+          "WEEKS": 0,
+          "YEARS": 0,
+          "MONTHS": 1
+        }
+      },
+      "isSDSPlus": false,
+      "identifier": "02560329-629d-318b-9a58-e892a1cccba0",
+      "recallType": null,
+      "sentencedAt": "2019-09-18",
+      "caseSequence": 1,
+      "lineSequence": 11,
+      "consecutiveSentenceUUIDs": [
+        "89f6a1e5-92c6-36fc-b832-86dbc40ad57e"
+      ],
+      "isSDSPlusOffenceInPeriod": false,
+      "hasAnSDSEarlyReleaseExclusion": "SEXUAL",
+      "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+    }
+  ],
+  "externalMovements": [],
+  "historicalTusedData": null
+}


### PR DESCRIPTION
Check for none Consecutive sentences with consecutiveSentenceUUIDs.

Such sentences have likely been removed from an earlier consec sentence to avoid duplicates consec chains.

If the UUID is present for any current consec sentence chain, the sentence has more than one child  .