### PR TITLE
Set the CPU request limit to 1 so CPU isn't overly throttled

### DIFF
--- a/helm_deploy/calculate-release-dates-api/values.yaml
+++ b/helm_deploy/calculate-release-dates-api/values.yaml
@@ -71,5 +71,6 @@ generic-data-analytics-extractor:
   resources:
     requests:
       memory: 2G
+      cpu: 1
     limits:
       memory: 4G


### PR DESCRIPTION
* Extract failed on Wed morning due to CPU limits, it did pass again the following day however the CPU was throttled due to the initial request being fairly low but within limits