### PR TITLE
crs-2333-add-post-calc-manual-journey-reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
@@ -112,7 +112,7 @@ class ManualCalculationService(
 
         val postCalcManualJourneyErrors = validationService
           .validateBookingAfterCalculation(calculationOutput, booking)
-          .filter { it.type == MANUAL_ENTRY_JOURNEY_REQUIRED  }
+          .filter { it.type == MANUAL_ENTRY_JOURNEY_REQUIRED }
 
         if (postCalcManualJourneyErrors.isNotEmpty()) {
           savedCalculationRequest.manualCalculationReason = postCalcManualJourneyErrors.map { transform(savedCalculationRequest, it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationService.kt
@@ -22,8 +22,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Upda
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationOutcomeRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationType.MANUAL_ENTRY_JOURNEY_REQUIRED
 import java.time.LocalDate
 import java.time.Period
 
@@ -110,15 +110,9 @@ class ManualCalculationService(
           calculationUserInputs,
         )
 
-        val postCalcManualJourneyErrorTypes = listOf(
-          ValidationCode.UNSUPPORTED_SDS40_RECALL_SENTENCE_TYPE,
-          ValidationCode.UNSUPPORTED_SDS40_CONSECUTIVE_SDS_BETWEEN_TRANCHE_COMMENCEMENTS,
-          ValidationCode.UNABLE_TO_DETERMINE_SHPO_RELEASE_PROVISIONS,
-        )
-
         val postCalcManualJourneyErrors = validationService
           .validateBookingAfterCalculation(calculationOutput, booking)
-          .filter { postCalcManualJourneyErrorTypes.contains(it.code) }
+          .filter { it.type == MANUAL_ENTRY_JOURNEY_REQUIRED  }
 
         if (postCalcManualJourneyErrors.isNotEmpty()) {
           savedCalculationRequest.manualCalculationReason = postCalcManualJourneyErrors.map { transform(savedCalculationRequest, it) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
@@ -56,7 +56,8 @@ class ManualCalculationIntTest : IntegrationTestBase() {
               SubmittedDate(1, 1, LocalDate.now().year + 1),
             ),
           ),
-          1L, "",
+          1L,
+          "",
         ),
       )
       .accept(MediaType.APPLICATION_JSON)
@@ -82,7 +83,8 @@ class ManualCalculationIntTest : IntegrationTestBase() {
               SubmittedDate(1, 1, LocalDate.now().year + 1),
             ),
           ),
-          1L, "",
+          1L,
+          "",
         ),
       )
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/resources/test_data/api_integration/sentences/CRS-2333-1.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-2333-1.json
@@ -1,0 +1,26 @@
+[
+  {
+    "bookingId": 1,
+    "sentenceSequence": 1,
+    "sentenceStatus": "A",
+    "sentenceCategory": "2003",
+    "sentenceCalculationType": "DTO_ORA",
+    "sentenceTypeDescription": "ORA Detention and Training Order",
+    "sentenceDate": "2015-03-17",
+    "terms": [{
+      "years": 0,
+      "months": 20,
+      "weeks": 0,
+      "days": 0,
+      "code": "SEC104"
+    }],
+    "offences": [
+      {
+        "offenderChargeId": 9991,
+        "offenceStartDate": "2015-03-17",
+        "offenceCode": "GBH",
+        "offenceDescription": "Grievous bodily harm"
+      }
+    ]
+  }
+]

--- a/src/test/resources/test_data/api_integration/sentences/CRS-2333-2.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-2333-2.json
@@ -1,0 +1,27 @@
+[
+  {
+    "bookingId": 1,
+    "sentenceSequence": 1,
+    "sentenceStatus": "A",
+    "sentenceCategory": "2003",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "CJA03 Standard Determinate Sentence",
+    "sentenceDate": "2024-09-30",
+    "committedAt": "2024-09-30",
+    "terms": [{
+      "years": 0,
+      "months": 5,
+      "weeks": 0,
+      "days": 0,
+      "code": "IMP"
+    }],
+    "offences": [
+      {
+        "offenderChargeId": 9991,
+        "offenceStartDate": "2020-12-10",
+        "offenceCode": "SX03220",
+        "offenceDescription": "Sexual assault"
+      }
+    ]
+  }
+]

--- a/src/test/resources/test_data/reset-base-data.sql
+++ b/src/test/resources/test_data/reset-base-data.sql
@@ -10,5 +10,6 @@ DELETE FROM calculation_outcome;
 DELETE FROM calculation_request_sentence_user_input;
 DELETE FROM calculation_request_user_input;
 DELETE FROM tranche_outcome;
+DELETE FROM calculation_request_manual_reason;
 DELETE FROM calculation_request;
 DELETE FROM bank_holiday_cache;


### PR DESCRIPTION
Store post calculation validation errors resulting in manual journey.

Errors can be from pre-calculation or post-calculation.