### PR TITLE
Crs 2339 one day sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
@@ -90,7 +90,7 @@ interface CalculableSentence {
       releaseDateTypes.getReleaseDateTypes().contains(ReleaseDateType.PED) && this.sentenceCalculation.extendedDeterminateParoleEligibilityDate == null -> {
         ReleaseDateType.PED
       }
-      sentenceCalculation.isReleaseDateConditional -> {
+      sentenceCalculation.isReleaseDateConditional && durationIsGreaterThan(1, ChronoUnit.DAYS) -> {
         ReleaseDateType.CRD
       }
       releaseDateTypes.contains(ReleaseDateType.MTD) -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationService.kt
@@ -321,8 +321,12 @@ class SentenceIdentificationService(
       else -> sdsStandardOrEarlyRelease(sentence)
     }
 
-    if (sentence.durationIsLessThan(TWELVE, ChronoUnit.MONTHS) &&
-      sentence.offence.committedAt.isBefore(ImportantDates.ORA_DATE)
+    if (
+      sentence.getLengthInDays() == 1 ||
+      (
+        sentence.durationIsLessThan(TWELVE, ChronoUnit.MONTHS) &&
+          sentence.offence.committedAt.isBefore(ImportantDates.ORA_DATE)
+        )
     ) {
       releaseDateTypes.addAll(
         listOf(
@@ -346,7 +350,7 @@ class SentenceIdentificationService(
   ) {
     sentence.identificationTrack = sdsStandardOrEarlyRelease(sentence)
 
-    if (sentence.durationIsGreaterThanOrEqualTo(FOUR, ChronoUnit.YEARS)) {
+    if (sentence.getLengthInDays() > 1 && sentence.durationIsGreaterThanOrEqualTo(FOUR, ChronoUnit.YEARS)) {
       releaseDateTypes.addAll(
         listOf(
           CRD,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceIdentificationServiceTest.kt
@@ -177,7 +177,17 @@ class SentenceIdentificationServiceTest {
       sentence,
       offender,
     )
-    assertEquals("[SLED, CRD, HDCED]", sentence.releaseDateTypes.getReleaseDateTypes().toString())
+    assertEquals("[ARD, SED, HDCED]", sentence.releaseDateTypes.getReleaseDateTypes().toString())
+  }
+
+  @Test
+  fun `Identify After 2015 2 day`() {
+    val sentence = jsonTransformation.loadSentence("two_day_2018_mar")
+    sentenceIdentificationService.identify(
+      sentence,
+      offender,
+    )
+    assertEquals("[SLED, CRD, TUSED, HDCED]", sentence.releaseDateTypes.getReleaseDateTypes().toString())
   }
 
   // sentenced after: 03/12/2012

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2339-1.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2339-1.json
@@ -1,0 +1,19 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2025-03-20"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 1
+        }
+      },
+      "sentencedAt": "2025-03-20"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2339-2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2339-2.json
@@ -1,0 +1,30 @@
+{
+  "offender": {
+    "reference": "ABC123",
+    "dateOfBirth": "1990-01-01"
+  },
+  "sentences": [
+    {
+      "offence": {
+        "committedAt": "2025-03-22"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 1
+        }
+      },
+      "sentencedAt": "2025-03-22"
+    },
+    {
+      "offence": {
+        "committedAt": "2025-03-22"
+      },
+      "duration": {
+        "durationElements": {
+          "DAYS": 1
+        }
+      },
+      "sentencedAt": "2025-03-22"
+    }
+  ]
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2339-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2339-1.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "ARD": "2025-03-20",
+    "SED": "2025-03-20",
+    "ESED": "2025-03-20"
+  },
+  "effectiveSentenceLength": "P1D"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2339-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2339-2.json
@@ -1,0 +1,8 @@
+{
+  "dates": {
+    "ARD": "2025-03-22",
+    "SED": "2025-03-22",
+    "ESED": "2025-03-22"
+  },
+  "effectiveSentenceLength": "P1D"
+}

--- a/src/test/resources/test_data/sentence/two_day_2018_mar.json
+++ b/src/test/resources/test_data/sentence/two_day_2018_mar.json
@@ -1,0 +1,11 @@
+{
+  "offence": {
+    "committedAt": "2018-03-09"
+  },
+  "duration": {
+    "durationElements": {
+      "DAYS": 2
+    }
+  },
+  "sentencedAt": "2018-03-09"
+}


### PR DESCRIPTION
One day standard determinate sentences should only have SED and ARD in place of SLED and CRD.