### PR TITLE
crs-2338-inactive-consec-chain

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
@@ -119,4 +119,5 @@ enum class ValidationCode(val message: String, val validationType: ValidationTyp
   DATES_MISSING_REQUIRED_TYPE("You cannot select a %s and a %s without a %s"),
   DATES_PAIRINGS_INVALID("%s and %s cannot be selected together"),
   CONCURRENT_CONSECUTIVE_SENTENCES("%s years %s months %s weeks %s days", CONCURRENT_CONSECUTIVE),
+  BROKEN_CONSECUTIVE_CHAINS("You cannot have a sentence consecutive to an inactive sentence.")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
@@ -119,5 +119,5 @@ enum class ValidationCode(val message: String, val validationType: ValidationTyp
   DATES_MISSING_REQUIRED_TYPE("You cannot select a %s and a %s without a %s"),
   DATES_PAIRINGS_INVALID("%s and %s cannot be selected together"),
   CONCURRENT_CONSECUTIVE_SENTENCES("%s years %s months %s weeks %s days", CONCURRENT_CONSECUTIVE),
-  BROKEN_CONSECUTIVE_CHAINS("You cannot have a sentence consecutive to an inactive sentence.")
+  BROKEN_CONSECUTIVE_CHAINS("You cannot have a sentence consecutive to an inactive sentence."),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.Validati
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.UNSUPPORTED_DTO_RECALL_SEC104_SEC105
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.UNSUPPORTED_SENTENCE_TYPE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ZERO_IMPRISONMENT_TERM
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BROKEN_CONSECUTIVE_CHAINS
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 
 class ValidationIntTest(private val mockManageOffencesClient: MockManageOffencesClient) : IntegrationTestBase() {
@@ -203,6 +204,14 @@ class ValidationIntTest(private val mockManageOffencesClient: MockManageOffences
   }
 
   @Test
+  fun `Run validate for broken consecutive chain`() {
+    runValidationAndCheckMessages(
+      BROKEN_CONSECUTIVE_CHAIN_SENTENCE,
+      listOf(ValidationMessage(BROKEN_CONSECUTIVE_CHAINS)),
+    )
+  }
+
+  @Test
   fun `Run validate for manual entry missing offence start date`() {
     runValidateForManualEntry(
       MISSING_OFFENCE_START_DATE_SENTENCE,
@@ -265,5 +274,6 @@ class ValidationIntTest(private val mockManageOffencesClient: MockManageOffences
     const val UNSUPPORTED_PRISONER_PRISONER_ID = "UNSUPP_PRIS"
     const val INACTIVE_PRISONER_ID = "INACTIVE"
     const val MISSING_OFFENCE_START_DATE_SENTENCE = "CRS-1634-no-offence-start-date"
+    const val BROKEN_CONSECUTIVE_CHAIN_SENTENCE = "CRS-2338"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ValidationIntTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.Validati
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ADJUSTMENT_FUTURE_DATED_RADA
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ADJUSTMENT_FUTURE_DATED_UAL
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.A_FINE_SENTENCE_WITH_PAYMENTS
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BROKEN_CONSECUTIVE_CHAINS
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.MULTIPLE_SENTENCES_CONSECUTIVE_TO
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.OFFENCE_DATE_AFTER_SENTENCE_RANGE_DATE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.OFFENCE_DATE_AFTER_SENTENCE_START_DATE
@@ -27,7 +28,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.Validati
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.UNSUPPORTED_DTO_RECALL_SEC104_SEC105
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.UNSUPPORTED_SENTENCE_TYPE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.ZERO_IMPRISONMENT_TERM
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode.BROKEN_CONSECUTIVE_CHAINS
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 
 class ValidationIntTest(private val mockManageOffencesClient: MockManageOffencesClient) : IntegrationTestBase() {

--- a/src/test/resources/test_data/api_integration/prisonapiadjustments/CRS-2338.json
+++ b/src/test/resources/test_data/api_integration/prisonapiadjustments/CRS-2338.json
@@ -1,0 +1,4 @@
+{
+  "sentenceAdjustments":[],
+  "bookingAdjustments":[]
+}

--- a/src/test/resources/test_data/api_integration/sentences/CRS-2338.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-2338.json
@@ -1,0 +1,100 @@
+[
+  {
+    "bookingId": 1,
+    "sentenceSequence": 1,
+    "lineSequence": 1,
+    "caseSequence": 1,
+    "caseReference": "1",
+    "courtDescription": "ABC",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-08-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 0,
+        "weeks": 12,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 1,
+        "offenceStartDate": "2021-12-25",
+        "offenceCode": "1",
+        "offenceDescription": "AVC",
+        "indicators": [
+        ]
+      }
+    ]
+  },
+  {
+    "bookingId": 1,
+    "sentenceSequence": 2,
+    "lineSequence": 2,
+    "caseSequence": 2,
+    "consecutiveToSequence": 1,
+    "caseReference": "2",
+    "courtDescription": "ABCD",
+    "sentenceStatus": "I",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-08-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 0,
+        "weeks": 12,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 1,
+        "offenceStartDate": "2021-12-25",
+        "offenceCode": "1",
+        "offenceDescription": "AVC",
+        "indicators": [
+        ]
+      }
+    ]
+  },
+  {
+    "bookingId": 1,
+    "sentenceSequence": 3,
+    "lineSequence": 3,
+    "caseSequence": 3,
+    "consecutiveToSequence": 2,
+    "caseReference": "2",
+    "courtDescription": "ABCDE",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-08-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 0,
+        "weeks": 12,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 1,
+        "offenceStartDate": "2021-12-25",
+        "offenceCode": "1",
+        "offenceDescription": "AVC",
+        "indicators": [
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Add validation where a consecutive chain contains an inactive sentence.