### PR TITLE
Make ERSED release point configurable via ersed.releasePoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/ErsedConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/config/ErsedConfiguration.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("ersed")
 data class ErsedConfiguration(
   val maxPeriodDays: Int,
+  val releasePoint: Double,
 )

--- a/src/main/resources/application-calculation-params.yml
+++ b/src/main/resources/application-calculation-params.yml
@@ -10,9 +10,10 @@ hdced:
 
 ersed:
   max-period-days: 544
+  release-point: 0.5
 
 release-point-multipliers:
-  earlyReleasePoint: 0.4
+  early-release-point: 0.4
 sds-early-release-tranches:
   tranche-one-date: 2024-09-10
   tranche-two-date: 2024-10-22


### PR DESCRIPTION
Replaces hardcoded 50% threshold with configurable `releasePoint` value in ErsedConfiguration. This supports future changes in policy without code changes.

(With a little bit of a refactor.)