### PR TITLE
Crs 2066 block conspiracy offence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/PreCalculationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/PreCalculationValidationService.kt
@@ -98,6 +98,7 @@ class PreCalculationValidationService(
   internal fun validateUnsupportedOffences(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
     val messages =
       unsupportedValidationService.validateUnsupportedEncouragingOffences(sentencesAndOffence).toMutableList()
+    messages += unsupportedValidationService.validateUnsupportedGenericConspiracyOffence(sentencesAndOffence)
     messages += unsupportedValidationService.validateUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence)
     messages += unsupportedValidationService.validateUnsupportedSuspendedOffences(sentencesAndOffence)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/PreCalculationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/PreCalculationValidationService.kt
@@ -42,7 +42,7 @@ class PreCalculationValidationService(
     }
 
     if (adjustments.size > 0) {
-      val adjustmentString = adjustments.joinToString(separator = " and ") { it.toString().lowercase() }
+      val adjustmentString = adjustments.joinToString(separator = " and ") { it.lowercase() }
       messages.add(
         ValidationMessage(
           ValidationCode.PRE_PCSC_DTO_WITH_ADJUSTMENT,
@@ -95,15 +95,7 @@ class PreCalculationValidationService(
     return messages
   }
 
-  internal fun validateUnsupportedOffences(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
-    val messages =
-      unsupportedValidationService.validateUnsupportedEncouragingOffences(sentencesAndOffence).toMutableList()
-    messages += unsupportedValidationService.validateUnsupportedGenericConspiracyOffence(sentencesAndOffence)
-    messages += unsupportedValidationService.validateUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence)
-    messages += unsupportedValidationService.validateUnsupportedSuspendedOffences(sentencesAndOffence)
-
-    return messages
-  }
+  internal fun validateUnsupportedOffences(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> = unsupportedValidationService.validateUnsupportedOffenceCodes(sentencesAndOffence)
 
   fun validateSe20Offences(data: CalculationSourceData): List<ValidationMessage> {
     val invalidOffences = data.sentenceAndOffences.filter {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/UnsupportedValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/UnsupportedValidationService.kt
@@ -2,59 +2,46 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
 
 @Service
 class UnsupportedValidationService {
 
-  internal fun validateUnsupportedSuspendedOffences(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
-    val unSupportedEncouragingOffenceCodes = findUnsupportedSuspendedOffenceCodes(sentencesAndOffence)
-    if (unSupportedEncouragingOffenceCodes.isNotEmpty()) {
-      return listOf(ValidationMessage(ValidationCode.UNSUPPORTED_SUSPENDED_OFFENCE))
+  fun validateUnsupportedOffenceCodes(
+    sentences: List<SentenceAndOffenceWithReleaseArrangements>,
+  ): List<ValidationMessage> {
+    val messages = mutableListOf<ValidationMessage>()
+
+    unsupportedOffenceCodeValidationMap.forEach { (predicate, code) ->
+      if (sentences.any(predicate)) {
+        messages += ValidationMessage(code)
+      }
     }
-    return emptyList()
-  }
 
-  internal fun validateUnsupportedEncouragingOffences(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
-    val unSupportedEncouragingOffenceCodes = findUnsupportedEncouragingOffenceCodes(sentencesAndOffence)
-    if (unSupportedEncouragingOffenceCodes.isNotEmpty()) {
-      return listOf(ValidationMessage(ValidationCode.UNSUPPORTED_OFFENCE_ENCOURAGING_OR_ASSISTING))
-    }
-    return emptyList()
-  }
-  fun validateUnsupportedGenericConspiracyOffence(
-    sentencesAndOffences: List<SentenceAndOffenceWithReleaseArrangements>,
-  ): List<ValidationMessage> = sentencesAndOffences.filter { it.offence.offenceCode == "CL77036" }.map {
-    ValidationMessage(ValidationCode.UNSUPPORTED_GENERIC_CONSPIRACY_OFFENCE)
-  }
-
-  internal fun validateUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
-    val unSupportedEncouragingOffenceCodes = findUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence)
-    if (unSupportedEncouragingOffenceCodes.isNotEmpty()) {
-      return listOf(ValidationMessage(ValidationCode.UNSUPPORTED_BREACH_97))
-    }
-    return emptyList()
-  }
-
-  private fun findUnsupportedEncouragingOffenceCodes(sentenceAndOffences: List<SentenceAndOffenceWithReleaseArrangements>): List<SentenceAndOffence> {
-    val offenceCodesToFilter = (2..13).map { "SC070${"%02d".format(it)}" }
-    return sentenceAndOffences.filter { it.offence.offenceCode in offenceCodesToFilter }
-  }
-
-  private fun findUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<SentenceAndOffence> = sentencesAndOffence.filter {
-    it.offence.offenceCode.startsWith("PH97003") &&
-      it.offence.offenceStartDate != null &&
-      it.offence.offenceStartDate.isAfterOrEqualTo(AFTER_97_BREACH_PROVISION_INVALID)
-  }
-
-  private fun findUnsupportedSuspendedOffenceCodes(sentenceAndOffences: List<SentenceAndOffenceWithReleaseArrangements>): List<SentenceAndOffence> {
-    val offenceCodesToFilter = listOf("SE20512", "CJ03523")
-    return sentenceAndOffences.filter { it.offence.offenceCode in offenceCodesToFilter }
+    return messages
   }
 
   companion object {
     private val AFTER_97_BREACH_PROVISION_INVALID = LocalDate.of(2020, 12, 1)
+
+    private val unsupportedOffenceCodeValidationMap: Map<(SentenceAndOffenceWithReleaseArrangements) -> Boolean, ValidationCode> =
+      mapOf(
+        { it: SentenceAndOffenceWithReleaseArrangements -> it.offence.offenceCode == "CL77036" } to
+          ValidationCode.UNSUPPORTED_GENERIC_CONSPIRACY_OFFENCE,
+
+        { it: SentenceAndOffenceWithReleaseArrangements ->
+          it.offence.offenceCode in (2..13).map { i -> "SC070${"%02d".format(i)}" }
+        } to ValidationCode.UNSUPPORTED_OFFENCE_ENCOURAGING_OR_ASSISTING,
+
+        { it: SentenceAndOffenceWithReleaseArrangements ->
+          it.offence.offenceCode.startsWith("PH97003") &&
+            it.offence.offenceStartDate?.isAfterOrEqualTo(AFTER_97_BREACH_PROVISION_INVALID) == true
+        } to ValidationCode.UNSUPPORTED_BREACH_97,
+
+        { it: SentenceAndOffenceWithReleaseArrangements ->
+          it.offence.offenceCode in listOf("SE20512", "CJ03523")
+        } to ValidationCode.UNSUPPORTED_SUSPENDED_OFFENCE,
+      )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/UnsupportedValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/UnsupportedValidationService.kt
@@ -24,6 +24,11 @@ class UnsupportedValidationService {
     }
     return emptyList()
   }
+  fun validateUnsupportedGenericConspiracyOffence(
+    sentencesAndOffences: List<SentenceAndOffenceWithReleaseArrangements>,
+  ): List<ValidationMessage> = sentencesAndOffences.filter { it.offence.offenceCode == "CL77036" }.map {
+    ValidationMessage(ValidationCode.UNSUPPORTED_GENERIC_CONSPIRACY_OFFENCE)
+  }
 
   internal fun validateUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence: List<SentenceAndOffenceWithReleaseArrangements>): List<ValidationMessage> {
     val unSupportedEncouragingOffenceCodes = findUnsupported97BreachOffencesAfter1Dec2020(sentencesAndOffence)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationCode.kt
@@ -98,11 +98,19 @@ enum class ValidationCode(val message: String, val validationType: ValidationTyp
       "For example, ‘Encouraging/Assisting’ a Rape SX03001 would be SX03001E.",
     UNSUPPORTED_OFFENCE,
   ),
+  UNSUPPORTED_GENERIC_CONSPIRACY_OFFENCE(
+    "The offence code CL77036 is a generic conspiracy offence and should not be used.\n" +
+      "Any offences that include the inchoate 'Conspiracy' must be recorded as the underlying act, ending in the letter 'C'\n" +
+      "For example, Conspiracy to Bribe BA10010 would be BA10010C.",
+    UNSUPPORTED_OFFENCE,
+  ),
+
   UNSUPPORTED_BREACH_97(
     "Breaches of restraining orders committed on or after 01 December 2020 must be sentenced under the 2020 Sentencing Act.\n" +
       "Go to NOMIS and change the offence code from PH97003 to SE20002.",
     UNSUPPORTED_OFFENCE,
   ),
+
   UNSUPPORTED_SUSPENDED_OFFENCE("Replace this offence in NOMIS with the original offence they were sentenced for, then reload this page.", SUSPENDED_OFFENCE),
   FTR_NO_RETURN_TO_CUSTODY_DATE("The Fixed term recall must have a 'return to custody' date"),
   NO_SENTENCES("Prisoner has no sentences"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationServiceTest.kt
@@ -347,6 +347,40 @@ class ValidationServiceTest {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = ["CL77036"])
+  fun `Test Sentences with unsupported offenceCode CL77036 returns validation message`(offenceCode: String) {
+    // Arrange
+    val invalidSentence = validSdsSentence.copy(
+      offence = validSdsSentence.offence.copy(offenceCode = offenceCode),
+    )
+
+    // Act
+    val result =
+      validationService.validateBeforeCalculation(
+        CalculationSourceData(
+          sentenceAndOffences = listOf(
+            SentenceAndOffenceWithReleaseArrangements(
+              source = invalidSentence,
+              isSdsPlus = false,
+              isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+              isSDSPlusOffenceInPeriod = false,
+              hasAnSDSExclusion = SDSEarlyReleaseExclusionType.NO,
+            ),
+          ),
+          prisonerDetails = VALID_PRISONER,
+          bookingAndSentenceAdjustments = VALID_ADJUSTMENTS,
+          offenderFinePayments = listOf(),
+          returnToCustodyDate = null,
+        ),
+        USER_INPUTS,
+      )
+
+    // Assert
+    assertThat(result).isNotEmpty
+    assertThat(result[0].code).isEqualTo(ValidationCode.UNSUPPORTED_GENERIC_CONSPIRACY_OFFENCE)
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = ["SC07002", "SC07003", "SC07004", "SC07005", "SC07006", "SC07007", "SC07008", "SC07009", "SC07010", "SC07011", "SC07012", "SC07013"])
   fun `Test Sentences with unsupported offenceCodes SC07002 to SC07013 returns validation message`(offenceCode: String) {
     // Arrange


### PR DESCRIPTION
Displays a validation message when offence code CL77036 is used in a sentence,
instructing the user to replace it with the appropriate underlying offence code
ending in 'C'. This prevents national security and other excluded offences from
being miscategorised and incorrectly included in SDS-40 eligibility.

followed by a small refactor:

Replaces individual validation methods for unsupported offence codes with a
single map-driven approach. This simplifies future additions and reduces
duplication. Logic for SC070xx, PH97003, CL77036, and suspended offences is
now configured via a predicate-to-ValidationCode map.

Also updates PreCalculationValidationService to use the unified method.
