### PR TITLE
crs-2348-historic-sled-from-manual-calc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -305,7 +305,7 @@ class CalculationTransactionalService(
 
     if (featureToggles.historicSled) {
       val sledDate = calculationDates[ReleaseDateType.SLED]
-      val historicDates = historicDatesFromSled(sourceData.prisonerDetails.offenderNo, sledDate)
+      val historicDates = sledDate?.let { historicDatesFromSled(sourceData.prisonerDetails.offenderNo, it) }
       if (sledDate !== null && historicDates !== null) {
         persistCalculationDatesWithHistoricOverrides(
           sledDate,
@@ -350,7 +350,7 @@ class CalculationTransactionalService(
     )
   }
 
-  private fun historicDatesFromSled(
+  fun historicDatesFromSled(
     offenderNo: String,
     sledDate: LocalDate?,
   ): List<CalculationOutcome>? = sledDate?.let {
@@ -378,6 +378,16 @@ class CalculationTransactionalService(
     calculationDates: MutableMap<ReleaseDateType, LocalDate>,
   ) {
     val overridesByType = dominantHistoricDateService.calculateFromSled(sledDate, historicDates)
+
+    /**
+     * Add SLED to calculation dates if historic dates include LED and SED with the same date
+     * We need to combine the two dates to a SLED in such an instance
+     */
+    overridesByType[ReleaseDateType.SLED]?.let { sledOverride ->
+      if (historicDates.none { it.calculationDateType == ReleaseDateType.SLED.name }) {
+        calculationDates[ReleaseDateType.SLED] = sledOverride
+      }
+    }
 
     val historicOverrideIds = historicDates
       .filter { overridesByType.containsKey(ReleaseDateType.valueOf(it.calculationDateType)) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DominantHistoricDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DominantHistoricDateService.kt
@@ -40,10 +40,14 @@ class DominantHistoricDateService {
     sled: LocalDate,
     sed: LocalDate?,
     led: LocalDate?,
-  ): Map<ReleaseDateType, LocalDate> = mapOf(
-    ReleaseDateType.SED to latestDate(sled, sed),
-    ReleaseDateType.LED to latestDate(sled, led),
-  )
+  ): Map<ReleaseDateType, LocalDate> = if (sed is LocalDate && led is LocalDate && sed.isEqual(led)) {
+    mapOf(ReleaseDateType.SLED to sed)
+  } else {
+    mapOf(
+      ReleaseDateType.SED to latestDate(sled, sed),
+      ReleaseDateType.LED to latestDate(sled, led),
+    )
+  }
 
   fun latestDate(currentDate: LocalDate, historicDate: LocalDate?) = when {
     historicDate !== null && historicDate > currentDate -> historicDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DominantHistoricDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/DominantHistoricDateServiceTest.kt
@@ -114,6 +114,30 @@ class DominantHistoricDateServiceTest {
   }
 
   @Test
+  fun `should calculate LED and SED and return SLED if both dates are equal`() {
+    val calculatedSled = LocalDate.of(2020, 1, 1)
+    val historicLed = LocalDate.of(2021, 1, 1)
+    val historicSed = LocalDate.of(2021, 1, 1)
+    val outcomes = listOf(
+      CalculationOutcome(
+        calculationRequestId = 2L,
+        outcomeDate = historicLed,
+        calculationDateType = ReleaseDateType.LED.name,
+      ),
+      CalculationOutcome(
+        calculationRequestId = 3L,
+        outcomeDate = historicSed,
+        calculationDateType = ReleaseDateType.SED.name,
+      ),
+    )
+
+    val overrides = service.calculateFromSled(calculatedSled, outcomes)
+
+    assertEquals(overrides.containsKey(ReleaseDateType.SLED), true)
+    assertEquals(historicLed, overrides[ReleaseDateType.SLED])
+  }
+
+  @Test
   fun `should use SED where no historic SLED exists`() {
     val calculatedSled = LocalDate.of(2022, 1, 1)
     val outcomes = listOf(


### PR DESCRIPTION
Combine calculation outcomes for LED and SED where both dates are equal from a manual calculation.

Add additional test coverage.