### PR TITLE
Crs 2367 ftr48 aggregate check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AFineSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AFineSentence.kt
@@ -33,5 +33,7 @@ data class AFineSentence(
 
   override fun getLengthInDays(): Int = duration.getLengthInDays(this.sentencedAt)
 
+  override fun getLengthInMonths(): Int = duration.getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/BotusSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/BotusSentence.kt
@@ -30,6 +30,8 @@ data class BotusSentence(
 
   override fun getLengthInDays(): Int = duration.getLengthInDays(this.sentencedAt)
 
+  override fun getLengthInMonths(): Int = duration.getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 
   override fun isOrExclusivelyBotus(): Boolean = true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
@@ -61,6 +61,9 @@ interface CalculableSentence {
   fun getLengthInDays(): Int
 
   @JsonIgnore
+  fun getLengthInMonths(): Int
+
+  @JsonIgnore
   fun isRecall(): Boolean = recallType != null
 
   @JsonIgnore

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ConsecutiveSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ConsecutiveSentence.kt
@@ -76,6 +76,8 @@ class ConsecutiveSentence(val orderedSentences: List<AbstractSentence>) : Calcul
     return duration.getLengthInDays(sentencedAt)
   }
 
+  override fun getLengthInMonths(): Int = getCombinedDuration().getLengthInMonths(sentencedAt)
+
   private fun isMoreThanTwoYears(duration: Duration) = duration.getLengthInDays(sentencedAt) > ChronoUnit.DAYS.between(this.sentencedAt, this.sentencedAt.plus(24, ChronoUnit.MONTHS))
 
   override fun hasAnyEdsOrSopcSentence(): Boolean = hasExtendedSentence() || hasSopcSentence()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DetentionAndTrainingOrderSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DetentionAndTrainingOrderSentence.kt
@@ -19,6 +19,7 @@ data class DetentionAndTrainingOrderSentence(
   override val isSDSPlusEligibleSentenceTypeLengthAndOffence: Boolean = false
   override val isSDSPlusOffenceInPeriod: Boolean = false
   override fun getLengthInDays(): Int = duration.getLengthInDays(this.sentencedAt)
+  override fun getLengthInMonths(): Int = duration.getLengthInMonths(sentencedAt)
 
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DtoSingleTermSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/DtoSingleTermSentence.kt
@@ -67,6 +67,8 @@ class DtoSingleTermSentence(
 
   override fun getLengthInDays(): Int = combinedDuration().getLengthInDays(sentencedAt)
 
+  override fun getLengthInMonths(): Int = combinedDuration().getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 
   private fun earliestSentencedAt(firstStandardSentence: AbstractSentence, secondStandardSentence: AbstractSentence): LocalDate = if (firstStandardSentence.sentencedAt.isBefore(secondStandardSentence.sentencedAt)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Duration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/Duration.kt
@@ -30,6 +30,8 @@ data class Duration(
   // PSI 5.5 Converting a Sentence in to Days
   fun getLengthInDays(startDate: LocalDate): Int = (DAYS.between(startDate, getEndDate(startDate)) + 1).toInt()
 
+  fun getLengthInMonths(startDate: LocalDate): Int = (MONTHS.between(startDate, getEndDate(startDate)) + 1).toInt()
+
   // PSI 5.5 Converting a Sentence in to Days
   fun getEndDate(startDate: LocalDate): LocalDate {
     val years = durationElements.getOrDefault(YEARS, 0L)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ExtendedDeterminateSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ExtendedDeterminateSentence.kt
@@ -39,6 +39,6 @@ data class ExtendedDeterminateSentence(
 
   fun combinedDuration(): Duration = custodialDuration.appendAll(extensionDuration.durationElements)
   override fun getLengthInDays(): Int = combinedDuration().getLengthInDays(sentencedAt)
-
+  override fun getLengthInMonths(): Int = combinedDuration().getLengthInMonths(sentencedAt)
   override fun hasAnyEdsOrSopcSentence(): Boolean = true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SingleTermSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SingleTermSentence.kt
@@ -56,6 +56,8 @@ class SingleTermSentence(
 
   override fun getLengthInDays(): Int = combinedDuration().getLengthInDays(sentencedAt)
 
+  override fun getLengthInMonths(): Int = combinedDuration().getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 
   private fun earliestSentencedAt(firstStandardSentence: AbstractSentence, secondStandardSentence: AbstractSentence): LocalDate = if (firstStandardSentence.sentencedAt.isBefore(secondStandardSentence.sentencedAt)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SopcSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SopcSentence.kt
@@ -39,5 +39,7 @@ data class SopcSentence(
   fun combinedDuration(): Duration = custodialDuration.appendAll(extensionDuration.durationElements)
   override fun getLengthInDays(): Int = combinedDuration().getLengthInDays(sentencedAt)
 
+  override fun getLengthInMonths(): Int = combinedDuration().getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/StandardDeterminateSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/StandardDeterminateSentence.kt
@@ -35,6 +35,8 @@ data class StandardDeterminateSentence(
 
   override fun getLengthInDays(): Int = duration.getLengthInDays(this.sentencedAt)
 
+  override fun getLengthInMonths(): Int = duration.getLengthInMonths(sentencedAt)
+
   override fun hasAnyEdsOrSopcSentence(): Boolean = false
 
   @JsonIgnore

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationService.kt
@@ -276,18 +276,17 @@ class RecallValidationService(
     return messages
   }
 
-  internal fun validateFtrFortyOverlap(sentences: List<AbstractSentence>): List<ValidationMessage> = if (
-    featureToggles.ftr48ManualJourney &&
-    sentences.any {
-      it.recallType == FIXED_TERM_RECALL_28 &&
-        it.sentencedAt.isBefore(FTR_48_COMMENCEMENT_DATE) &&
-        it.durationIsGreaterThanOrEqualTo(12, MONTHS) &&
-        it.durationIsLessThan(48, MONTHS)
+  internal fun validateFtrFortyOverlap(sentences: List<AbstractSentence>): List<ValidationMessage> {
+    if (featureToggles.ftr48ManualJourney && sentences.any(::ftr48AffectedSentence)) {
+      return listOf(ValidationMessage(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE))
     }
-  ) {
-    listOf(ValidationMessage(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE))
-  } else {
-    emptyList()
+    return emptyList()
+  }
+
+  private fun ftr48AffectedSentence(sentence: AbstractSentence): Boolean {
+    if (sentence.recallType != FIXED_TERM_RECALL_28 || sentence.sentencedAt.isAfter(FTR_48_COMMENCEMENT_DATE)) return false
+    val totalDurationInMonths = sentence.sentenceParts().sumOf { s -> s.totalDuration().getLengthInMonths(s.sentencedAt) }
+    return totalDurationInMonths >= 12 && totalDurationInMonths < 48
   }
 
   private fun validateMixedDurations(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,10 @@ info.app:
 spring:
   application:
     name: calculate-release-dates-api
-  codec:
-    max-in-memory-size: 200MB
+
+  http:
+    codecs:
+      max-in-memory-size: 200MB
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
@@ -157,5 +159,5 @@ feature-toggles:
   externalMovementsAdjustmentSharing: ${EXTERNAL_MOVEMENTS_ADJUSTMENTS_FEATURE_TOGGLE:false}
   useAdjustmentsApi: ${USE_ADJUSTMENTS_API:false}
   concurrentConsecutiveSentencesEnabled: ${CONCURRENT_CONSECUTIVE_SENTENCES_ENABLED:false}
-  historic-sled: ${HISTORIC_SLED_ENABLED:false}
+  historicSled: ${HISTORIC_SLED_ENABLED:false}
   ftr48ManualJourney: ${FTR_48_MANUAL_JOURNEY:false}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationParamsTestConfigHelper.sdsEarlyReleaseTrancheOneDate
@@ -14,10 +15,10 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.CalculationP
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.SDS40TrancheConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AbstractSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecallType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.FTR_48_COMMENCEMENT_DATE
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 @ExtendWith(MockitoExtension::class)
 class RecallValidationServiceTest {
@@ -35,13 +36,60 @@ class RecallValidationServiceTest {
   @Nested
   @DisplayName("validateFtrFortyOverlap")
   inner class ValidateFtrFortyOverlapTests {
+    fun mockSentencePartWithMonths(months: Int): AbstractSentence {
+      val duration = mock<Duration> {
+        on { getLengthInMonths(anyOrNull()) } doReturn months
+      }
+      return mock {
+        on { totalDuration() } doReturn duration
+      }
+    }
+
     @Test()
     fun `returns validation message when sentence matches all conditions`() {
+      val sentenceParts = listOf(mockSentencePartWithMonths(24))
       val sentence = mock<AbstractSentence> {
         on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
         on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
-        on { durationIsGreaterThanOrEqualTo(12, ChronoUnit.MONTHS) } doReturn true
-        on { durationIsLessThan(48, ChronoUnit.MONTHS) } doReturn true
+        on { sentenceParts() } doReturn sentenceParts
+      }
+
+      val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))
+
+      assertEquals(1, result.size)
+      assertEquals(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE, result.first().code)
+    }
+
+    @Test
+    fun `returns validation message when aggregate sentence matches all conditions`() {
+      val sentenceParts = listOf(
+        mockSentencePartWithMonths(24),
+        mockSentencePartWithMonths(23),
+      )
+
+      val sentence = mock<AbstractSentence> {
+        on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
+        on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
+        on { sentenceParts() } doReturn sentenceParts
+      }
+
+      val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))
+
+      assertEquals(1, result.size)
+      assertEquals(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE, result.first().code)
+    }
+
+    @Test
+    fun `returns validation message when aggregate duration is 12 months or more`() {
+      val sentenceParts = listOf(
+        mockSentencePartWithMonths(6),
+        mockSentencePartWithMonths(6),
+      )
+
+      val sentence = mock<AbstractSentence> {
+        on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
+        on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
+        on { sentenceParts() } doReturn sentenceParts
       }
 
       val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))
@@ -53,9 +101,10 @@ class RecallValidationServiceTest {
     @Test
     fun `returns empty list when duration is less than 12 months`() {
       val sentence = mock<AbstractSentence> {
+        val sentenceParts = listOf(mockSentencePartWithMonths(11))
         on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
         on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
-        on { durationIsGreaterThanOrEqualTo(12, ChronoUnit.MONTHS) } doReturn false
+        on { sentenceParts() } doReturn sentenceParts
       }
 
       val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))
@@ -64,12 +113,33 @@ class RecallValidationServiceTest {
     }
 
     @Test
-    fun `returns empty list when duration is 48 months or more`() {
+    fun `returns empty list when aggregate duration is less than 12 months`() {
+      val sentence = mock<AbstractSentence> {
+        val sentenceParts = listOf(
+          mockSentencePartWithMonths(6),
+          mockSentencePartWithMonths(5)
+        )
+        on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
+        on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
+        on { sentenceParts() } doReturn sentenceParts
+      }
+
+      val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))
+
+      assert(result.isEmpty())
+    }
+
+    @Test
+    fun `returns empty list when aggregate duration is 48 months or more`() {
+      val sentenceParts = listOf(
+        mockSentencePartWithMonths(24),
+        mockSentencePartWithMonths(24),
+      )
+
       val sentence = mock<AbstractSentence> {
         on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
         on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)
-        on { durationIsGreaterThanOrEqualTo(12, ChronoUnit.MONTHS) } doReturn true
-        on { durationIsLessThan(48, ChronoUnit.MONTHS) } doReturn false
+        on { sentenceParts() } doReturn sentenceParts
       }
 
       val result = recallValidationService.validateFtrFortyOverlap(listOf(sentence))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/RecallValidationServiceTest.kt
@@ -117,7 +117,7 @@ class RecallValidationServiceTest {
       val sentence = mock<AbstractSentence> {
         val sentenceParts = listOf(
           mockSentencePartWithMonths(6),
-          mockSentencePartWithMonths(5)
+          mockSentencePartWithMonths(5),
         )
         on { recallType } doReturn RecallType.FIXED_TERM_RECALL_28
         on { sentencedAt } doReturn LocalDate.of(2020, 1, 1)


### PR DESCRIPTION
Check aggregate duration using months.
Add getLengthInMonths base method to CalculableSentence. 
Update http codec memory allocation to updated none deprecated Spring format.