### PR TITLE
Crs 2110 disable ersed eds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/manageoffencesapi/SDSEarlyReleaseExclusionForOffenceCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/manageoffencesapi/SDSEarlyReleaseExclusionForOffenceCode.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.manageoffencesapi
 
 data class SDSEarlyReleaseExclusionForOffenceCode(val offenceCode: String, val schedulePart: SDSEarlyReleaseExclusionSchedulePart)
+data class ToreraSchedulePartCodes(val parts: Map<Int, List<String>>)
 enum class SDSEarlyReleaseExclusionSchedulePart {
   SEXUAL,
   VIOLENT,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityController.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
+
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.eligibility.ErsedEligibilityService
+
+@RestController
+@RequestMapping("/eligibility", produces = [MediaType.APPLICATION_JSON_VALUE])
+class EligibilityController(private val ersedEligibilityService: ErsedEligibilityService) {
+
+  @GetMapping(value = ["/{bookingId}/ersed"])
+  fun ersedEligibility(
+    @Parameter(required = true, example = "100001", description = "The booking ID to check against")
+    @PathVariable("bookingId")
+    bookingId: Long,
+  ): ErsedEligibilityService.ErsedEligibility = ersedEligibilityService.sentenceIsEligible(bookingId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManageOffencesService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.manageoffencesapi.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.manageoffencesapi.SDSEarlyReleaseExclusionForOffenceCode
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.manageoffencesapi.ToreraSchedulePartCodes
 
 @Service
 class ManageOffencesService(
@@ -14,4 +15,6 @@ class ManageOffencesService(
   fun getSdsExclusionsForOffenceCodes(offenceCodes: List<String>): List<SDSEarlyReleaseExclusionForOffenceCode> = manageOffencesApiClient.getSdsExclusionsForOffenceCodes(offenceCodes)
 
   fun getToreraOffenceCodes(): List<String> = manageOffencesApiClient.getToreraOffenceCodes()
+
+  fun getToreraCodesByParts(): ToreraSchedulePartCodes = manageOffencesApiClient.getToreraCodesByParts()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityService.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.eligibility
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.SentenceType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ManageOffencesService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.PrisonService
+
+@Service
+class ErsedEligibilityService(
+  private val manageOffencesService: ManageOffencesService,
+  private val prisonService: PrisonService,
+) {
+
+  data class ErsedEligibility(val isValid: Boolean, val reason: String? = null)
+
+  private val edsCalculationTypes = setOf(
+    SentenceCalculationType.EDS18.name,
+    SentenceCalculationType.EDS21.name,
+    SentenceCalculationType.EDSU18.name,
+    SentenceCalculationType.LASPO_AR.name,
+    SentenceCalculationType.LASPO_DR.name,
+  )
+
+  fun sentenceIsEligible(bookingId: Long): ErsedEligibility {
+    val sentenceData = prisonService.getSentencesAndOffences(bookingId)
+
+    if (sentenceData.all(::exemptSentenceType)) {
+      return ErsedEligibility(false, "No valid ersed sentence types")
+    }
+
+    val edsOffenceCodes = getToreraEdsOffenceCodes(sentenceData)
+    val part1Codes = manageOffencesService.getToreraCodesByParts().parts[1].orEmpty()
+
+    val hasPart1EdsOffence = part1Codes.any { it in edsOffenceCodes }
+
+    return if (hasPart1EdsOffence) {
+      ErsedEligibility(false, "EDS sentence with 19ZA part 1 offence")
+    } else {
+      ErsedEligibility(true)
+    }
+  }
+
+  private fun getToreraEdsOffenceCodes(sourceData: List<SentenceAndOffenceWithReleaseArrangements>): List<String> = sourceData
+    .asSequence()
+    .filter { it.sentenceCalculationType in edsCalculationTypes }
+    .map { it.offence.offenceCode }
+    .toList()
+
+  private fun exemptSentenceType(sentenceAndOffence: SentenceAndOffenceWithReleaseArrangements): Boolean {
+    val type = runCatching {
+      SentenceCalculationType.valueOf(sentenceAndOffence.sentenceCalculationType)
+    }.getOrElse { return true }
+
+    return type.sentenceType == SentenceType.AFine ||
+      type in listOf(SentenceCalculationType.DTO, SentenceCalculationType.DTO_ORA) ||
+      type.recallType !== null
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -239,6 +239,23 @@ class ManageOffencesMockServer : WireMockServer(WIREMOCK_PORT) {
           .withTransformers("response-template"),
       ),
   )
+
+  fun stubToreraOffenceCodesByPart(part1: List<String>, part2: List<String>): StubMapping = stubFor(
+    get(urlMatching("/schedule/torera-offence-codes-by-schedule-part"))
+      .atPriority(Int.MAX_VALUE)
+      .willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody("""{
+            "parts":{
+              "1":[${part1.joinToString(","){ "\"$it\"" }}],
+              "2":[${part2.joinToString(","){ "\"$it\"" }}]
+            }
+          }""".trimIndent())
+          .withStatus(200)
+          .withTransformers("response-template"),
+      ),
+  )
 }
 
 class MockManageOffencesClient(
@@ -263,5 +280,8 @@ class MockManageOffencesClient(
       objectMapper.writeValueAsString(defaultMarkers),
     )
     return this
+  }
+  fun stubToreraOffenceCodesByPart(part1: List<String>, part2: List<String>) {
+    manageOffencesApi.stubToreraOffenceCodesByPart(part1, part2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/wiremock/ManageOffencesMockServer.kt
@@ -246,12 +246,15 @@ class ManageOffencesMockServer : WireMockServer(WIREMOCK_PORT) {
       .willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withBody("""{
+          .withBody(
+            """{
             "parts":{
               "1":[${part1.joinToString(","){ "\"$it\"" }}],
               "2":[${part2.joinToString(","){ "\"$it\"" }}]
             }
-          }""".trimIndent())
+          }
+            """.trimIndent(),
+          )
           .withStatus(200)
           .withTransformers("response-template"),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityControllerTest.kt
@@ -8,8 +8,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.eligibility
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class EligibilityControllerTest(private val mockManageOffencesClient: MockManageOffencesClient) :
-  IntegrationTestBase() {
+class EligibilityControllerTest(private val mockManageOffencesClient: MockManageOffencesClient) : IntegrationTestBase() {
 
   @Test
   fun `Ersed Eligibility should return true`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/EligibilityControllerTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremock.MockManageOffencesClient
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.eligibility.ErsedEligibilityService
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EligibilityControllerTest(private val mockManageOffencesClient: MockManageOffencesClient) :
+  IntegrationTestBase() {
+
+  @Test
+  fun `Ersed Eligibility should return true`() {
+    mockManageOffencesClient.stubToreraOffenceCodesByPart(listOf("ABC"), listOf("XYZ"))
+    val bookingID = "default".hashCode().toLong()
+    val eligibility = webTestClient.get()
+      .uri("/eligibility/$bookingID/ersed")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErsedEligibilityService.ErsedEligibility::class.java)
+      .returnResult().responseBody!!
+    assertTrue { eligibility.isValid }
+  }
+
+  @Test
+  fun `Ersed Eligibility should return false`() {
+    mockManageOffencesClient.stubToreraOffenceCodesByPart(listOf("TH68010A"), listOf("XYZ"))
+    val bookingID = "CRS-892".hashCode().toLong()
+    val eligibility = webTestClient.get()
+      .uri("/eligibility/$bookingID/ersed")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErsedEligibilityService.ErsedEligibility::class.java)
+      .returnResult().responseBody!!
+    assertFalse { eligibility.isValid }
+    assert(eligibility.reason == "EDS sentence with 19ZA part 1 offence")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityServiceTest.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.eligibility
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.manageoffencesapi.ToreraSchedulePartCodes
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ManageOffencesService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.PrisonService
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class ErsedEligibilityServiceTest {
+
+  @Mock
+  lateinit var manageOffencesService: ManageOffencesService
+
+  @Mock
+  lateinit var prisonService: PrisonService
+
+  lateinit var service: ErsedEligibilityService
+
+  @BeforeEach
+  fun setUp() {
+    service = ErsedEligibilityService(manageOffencesService, prisonService)
+  }
+
+  @Test
+  fun `should return ineligible when no sentence has valid type`() {
+    val bookingId = 123L
+    val sentence = createSentence(SentenceCalculationType.AFINE.name, "OFF_PART1")
+    whenever(prisonService.getSentencesAndOffences(any(), any())).thenReturn(listOf(sentence))
+
+    val result = service.sentenceIsEligible(bookingId)
+
+    assertThat(result).isEqualTo(ErsedEligibilityService.ErsedEligibility(false, "No valid ersed sentence types"))
+  }
+
+  @Test
+  fun `should return eligible when at least one sentence has valid type`() {
+    val bookingId = 123L
+    val edsSentence = createSentence(SentenceCalculationType.EDS18.name, "OFF_PART2")
+    val noneEdsSentence = createSentence(SentenceCalculationType.AFINE.name, "NOT_RELEVANT")
+    val partsMap = mapOf(1 to listOf("OFF_PART1"))
+    whenever(prisonService.getSentencesAndOffences(any(), any())).thenReturn(listOf(edsSentence, noneEdsSentence))
+    whenever(manageOffencesService.getToreraCodesByParts()).thenReturn(ToreraSchedulePartCodes(partsMap))
+
+    val result = service.sentenceIsEligible(bookingId)
+
+    assertThat(result).isEqualTo(ErsedEligibilityService.ErsedEligibility(true))
+  }
+
+  @Test
+  fun `should return ineligible when EDS sentence has 19ZA part 1 offence`() {
+    val bookingId = 456L
+    val edsSentence = createSentence(SentenceCalculationType.EDS18.name, "OFF_PART1")
+    val partsMap = mapOf(1 to listOf("OFF_PART1"))
+
+    whenever(prisonService.getSentencesAndOffences(bookingId)).thenReturn(listOf(edsSentence))
+    whenever(manageOffencesService.getToreraCodesByParts()).thenReturn(ToreraSchedulePartCodes(partsMap))
+
+    val result = service.sentenceIsEligible(bookingId)
+
+    assertThat(result).isEqualTo(ErsedEligibilityService.ErsedEligibility(false, "EDS sentence with 19ZA part 1 offence"))
+  }
+
+  @Test
+  fun `should return eligible when EDS sentence has no 19ZA part 1 offence`() {
+    val bookingId = 789L
+    val edsSentence = createSentence(SentenceCalculationType.EDS21.name, "OFF_NOT_PART1")
+    val noneEdsSentence = createSentence(SentenceCalculationType.AFINE.name, "NOT_RELEVANT")
+    val partsMap = mapOf(1 to listOf("OFF_PART1"))
+
+    whenever(prisonService.getSentencesAndOffences(bookingId)).thenReturn(listOf(edsSentence, noneEdsSentence))
+    whenever(manageOffencesService.getToreraCodesByParts()).thenReturn(ToreraSchedulePartCodes(partsMap))
+
+    val result = service.sentenceIsEligible(bookingId)
+
+    assertThat(result).isEqualTo(ErsedEligibilityService.ErsedEligibility(true))
+  }
+
+  private fun createSentence(type: String, code: String): SentenceAndOffenceWithReleaseArrangements = SentenceAndOffenceWithReleaseArrangements(
+    bookingId = 1L,
+    sentenceSequence = 3,
+    lineSequence = 2,
+    caseSequence = 1,
+    sentenceDate = ImportantDates.SDS_PLUS_COMMENCEMENT_DATE,
+    terms = listOf(
+      SentenceTerms(years = 8),
+    ),
+    sentenceStatus = "IMP",
+    sentenceCategory = "CAT",
+    sentenceCalculationType = type,
+    sentenceTypeDescription = "ADMIP",
+    offence = OffenderOffence(1L, LocalDate.of(2015, 1, 1), null, code, "description", listOf("A")),
+    caseReference = null,
+    fineAmount = null,
+    courtDescription = null,
+    consecutiveToSequence = null,
+    isSDSPlus = false,
+    isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+    isSDSPlusOffenceInPeriod = false,
+    hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/eligibility/ErsedEligibilityServiceTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -35,10 +37,10 @@ class ErsedEligibilityServiceTest {
     service = ErsedEligibilityService(manageOffencesService, prisonService)
   }
 
-  @Test
-  fun `should return ineligible when no sentence has valid type`() {
+  @ParameterizedTest
+  @MethodSource("ineligibleSentences")
+  fun `should return ineligible when sentence has invalid type`(sentence: SentenceAndOffenceWithReleaseArrangements) {
     val bookingId = 123L
-    val sentence = createSentence(SentenceCalculationType.AFINE.name, "OFF_PART1")
     whenever(prisonService.getSentencesAndOffences(any(), any())).thenReturn(listOf(sentence))
 
     val result = service.sentenceIsEligible(bookingId)
@@ -89,27 +91,38 @@ class ErsedEligibilityServiceTest {
     assertThat(result).isEqualTo(ErsedEligibilityService.ErsedEligibility(true))
   }
 
-  private fun createSentence(type: String, code: String): SentenceAndOffenceWithReleaseArrangements = SentenceAndOffenceWithReleaseArrangements(
-    bookingId = 1L,
-    sentenceSequence = 3,
-    lineSequence = 2,
-    caseSequence = 1,
-    sentenceDate = ImportantDates.SDS_PLUS_COMMENCEMENT_DATE,
-    terms = listOf(
-      SentenceTerms(years = 8),
-    ),
-    sentenceStatus = "IMP",
-    sentenceCategory = "CAT",
-    sentenceCalculationType = type,
-    sentenceTypeDescription = "ADMIP",
-    offence = OffenderOffence(1L, LocalDate.of(2015, 1, 1), null, code, "description", listOf("A")),
-    caseReference = null,
-    fineAmount = null,
-    courtDescription = null,
-    consecutiveToSequence = null,
-    isSDSPlus = false,
-    isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
-    isSDSPlusOffenceInPeriod = false,
-    hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
-  )
+  companion object {
+    @JvmStatic
+    fun ineligibleSentences() = listOf(
+      createSentence(SentenceCalculationType.AFINE.name, "OFF_PART1"),
+      createSentence(SentenceCalculationType.DTO.name, "OFF_PART2"),
+      createSentence(SentenceCalculationType.DTO_ORA.name, "OFF_PART3"),
+      createSentence(SentenceCalculationType.DTO_ORA.name, "OFF_PART4"),
+      createSentence(SentenceCalculationType.LR.name, "OFF_PART5"), // recall sentence type
+    )
+
+    private fun createSentence(type: String, code: String): SentenceAndOffenceWithReleaseArrangements = SentenceAndOffenceWithReleaseArrangements(
+      bookingId = 1L,
+      sentenceSequence = 3,
+      lineSequence = 2,
+      caseSequence = 1,
+      sentenceDate = ImportantDates.SDS_PLUS_COMMENCEMENT_DATE,
+      terms = listOf(
+        SentenceTerms(years = 8),
+      ),
+      sentenceStatus = "IMP",
+      sentenceCategory = "CAT",
+      sentenceCalculationType = type,
+      sentenceTypeDescription = "ADMIP",
+      offence = OffenderOffence(1L, LocalDate.of(2015, 1, 1), null, code, "description", listOf("A")),
+      caseReference = null,
+      fineAmount = null,
+      courtDescription = null,
+      consecutiveToSequence = null,
+      isSDSPlus = false,
+      isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+      isSDSPlusOffenceInPeriod = false,
+      hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
+    )
+  }
 }


### PR DESCRIPTION
New endpoint for ascertaining early release scheme availability for one or more sentences.

At least one sentence must not be Afine, DTO or a recall.

If sentence is EDS with offence listed on part 1 of schedule 19ZA, Ersed should not be available.