### PR TITLE
log booking JSON when preliminary and current data hashes differ

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -242,8 +242,13 @@ class CalculationTransactionalService(
     val sourceData = calculationSourceDataService.getCalculationSourceData(calculationRequest.prisonerId, InactiveDataOptions.default())
     val userInput = transform(calculationRequest.calculationRequestUserInput)
     val booking = bookingService.getBooking(sourceData, userInput)
+    val currentBookingJson = objectToJson(booking, objectMapper)
+    val preliminaryBookingJson = calculationRequest.inputData
 
-    if (calculationRequest.inputData.hashCode() != objectToJson(booking, objectMapper).hashCode()) {
+    if (preliminaryBookingJson.hashCode() != currentBookingJson.hashCode()) {
+      log.info("Booking data has changed since preliminary calculation")
+      log.info("Preliminary booking JSON: {}", preliminaryBookingJson)
+      log.info("Current booking JSON: {}", currentBookingJson)
       throw PreconditionFailedException("The booking data used for the preliminary calculation has changed")
     }
 


### PR DESCRIPTION
This helps identify changes in booking data that cause validation to fail when confirming a preliminary calculation. Logs are set to INFO temporarily for visibility