### PR TITLE
crs-2370-booking-data-error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.TrancheO
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationType
 import java.time.LocalDate
 import java.util.UUID
 
@@ -252,7 +253,9 @@ class CalculationTransactionalService(
       throw PreconditionFailedException("The booking data used for the preliminary calculation has changed")
     }
 
-    if (validationService.validateBeforeCalculation(sourceData, userInput).isNotEmpty()) {
+    val validationErrors = validationService.validateBeforeCalculation(sourceData, userInput)
+
+    if (validationErrors.any { it.type !== ValidationType.CONCURRENT_CONSECUTIVE }) {
       throw PreconditionFailedException("The booking now fails validation")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -50,7 +50,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.TrancheO
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationType
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SentenceValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/SentenceValidationService.kt
@@ -35,7 +35,7 @@ class SentenceValidationService(
     validateNoBrokenConsecutiveChains(sentences)?.let { validationMessages += it }
 
     if (bulkCalcValidation && featuresToggles.concurrentConsecutiveSentencesEnabled) {
-      validateConsecutiveChainsForBulkCalculation(sentences)?.let { validationMessages += it }
+      validateConsecutiveChainsForBulkCalculation(sentences).let { validationMessages += it }
     } else {
       validationMessages += validateConsecutiveChains(sentences)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/ValidationType.kt
@@ -11,4 +11,5 @@ enum class ValidationType {
   ;
 
   fun isUnsupported(): Boolean = listOf(UNSUPPORTED_OFFENCE, UNSUPPORTED_SENTENCE, UNSUPPORTED_CALCULATION, MANUAL_ENTRY_JOURNEY_REQUIRED).contains(this)
+  fun excludedInSave(): Boolean = this == CONCURRENT_CONSECUTIVE
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
@@ -98,6 +98,19 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   }
 
   @Test
+  fun `Confirm calculation for a prisoner where CONCURRENT_CONSECUTIVE validation is ignored`() {
+    mockManageOffencesClient.noneInPCSC(listOf("SX03001,TH68007A,TR68132"))
+    val prelim = createPreliminaryCalculation("CRS-2370")
+    val confirmed = createConfirmCalculationForPrisoner(prelim.calculationRequestId)
+    val calculationRequest: CalculationRequest =
+      calculationRequestRepository.findById(confirmed.calculationRequestId)
+        .orElseThrow { EntityNotFoundException("No calculation request exists for id ${confirmed.calculationRequestId}") }
+
+    assertThat(calculationRequest.calculationStatus).isEqualTo("CONFIRMED")
+    assertThat(calculationRequest.inputData["offender"]["reference"].asText()).isEqualTo("CRS-2370")
+  }
+
+  @Test
   fun `Get the results for a confirmed calculation`() {
     val resultCalculation = createPreliminaryCalculation(PRISONER_ID)
     createConfirmCalculationForPrisoner(resultCalculation.calculationRequestId)

--- a/src/test/resources/test_data/api_integration/sentences/CRS-2370.json
+++ b/src/test/resources/test_data/api_integration/sentences/CRS-2370.json
@@ -1,0 +1,133 @@
+[
+  {
+    "bookingId": 1202231,
+    "sentenceSequence": 1,
+    "lineSequence": 1,
+    "caseSequence": 1,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP_ORA",
+    "sentenceTypeDescription": "ORA Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-05-05",
+    "terms": [
+      {
+        "years": 0,
+        "months": 3,
+        "weeks": 0,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3932966,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "TH68007A",
+        "offenceDescription": "Attempt theft from motor vehicle",
+        "indicators": [
+          "D",
+          "50"
+        ]
+      }
+    ]
+  },
+  {
+    "bookingId": 1202231,
+    "sentenceSequence": 2,
+    "consecutiveToSequence": 1,
+    "lineSequence": 2,
+    "caseSequence": 1,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-05-05",
+    "terms": [
+      {
+        "years": 7,
+        "months": 6,
+        "weeks": 0,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3932972,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "SX03001",
+        "offenceDescription": "Rape a girl aged 13 / 14 / 15 - SOA 2003",
+        "indicators": [
+          "M",
+          "S",
+          "23",
+          "ERS",
+          "PIMMS1",
+          "S1",
+          "SOR",
+          "S15/CJIB",
+          "V",
+          "SCH15/CJIB/L"
+        ]
+      },
+      {
+        "offenderChargeId": 3932973,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "TR68132",
+        "offenceDescription": "13 hours or more working",
+        "indicators": []
+      }
+    ]
+  },
+  {
+    "bookingId": 1202231,
+    "sentenceSequence": 3,
+    "consecutiveToSequence": 1,
+    "lineSequence": 3,
+    "caseSequence": 1,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "A",
+    "sentenceCategory": "2020",
+    "sentenceCalculationType": "ADIMP",
+    "sentenceTypeDescription": "Sentencing Code Standard Determinate Sentence",
+    "sentenceDate": "2022-05-06",
+    "terms": [
+      {
+        "years": 8,
+        "months": 6,
+        "weeks": 0,
+        "days": 0,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3932972,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "SX03001",
+        "offenceDescription": "Rape a girl aged 13 / 14 / 15 - SOA 2003",
+        "indicators": [
+          "M",
+          "S",
+          "23",
+          "ERS",
+          "PIMMS1",
+          "S1",
+          "SOR",
+          "S15/CJIB",
+          "V",
+          "SCH15/CJIB/L"
+        ]
+      },
+      {
+        "offenderChargeId": 3932973,
+        "offenceStartDate": "2022-05-04",
+        "offenceCode": "TR68132",
+        "offenceDescription": "13 hours or more working",
+        "indicators": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Ignore CONCURRENT_CONSECUTIVE validation messages when confirming calculation.

The validation type is informational rather than preventing a calculation.

Future refactoring should resolve such ambiguity.