### PR TITLE
Log and return supported response if pre-calc validation fails in supportedValidation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -175,7 +175,7 @@ class CalculationTransactionalService(
       log.error("Unexpected: manual entry journey should not be triggered by pre-calculation validation at this stage.")
       log.error(
         "Pre-calculation validation unexpectedly failed in supportedValidation for prisonerId=$prisonerId. " +
-          "Messages: ${bookingValidationMessages.joinToString("; ") { it.message }}"
+          "Messages: ${bookingValidationMessages.joinToString("; ") { it.message }}",
       )
       return supportedResponse
     }


### PR DESCRIPTION

Previously, we threw an IllegalStateException if pre-calculation validation failed after sentence and calculation validation had passed. This was intended to guard against unexpected entry into the manual entry journey.

However, this can occur in edge cases (e.g. missed validation earlier), and failing outright can cause misleading or inconsistent behaviour in the frontend.

We now log the unexpected condition and return the supportedResponse instead, preserving validation messages so the frontend can still determine routing.