### PR TITLE
CRS-2386: Update HDC rules regarding UAL (part 2)

### DIFF
--- a/src/test/resources/test_data/overall_calculation/hdc-365/crs-2386-ac9.json
+++ b/src/test/resources/test_data/overall_calculation/hdc-365/crs-2386-ac9.json
@@ -1,0 +1,33 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "offence": {
+          "committedAt": "2022-04-20",
+          "offenceCode": "TH68068"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 5,
+            "MONTHS": 4
+          }
+        },
+        "sentencedAt": "2023-08-25",
+        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
+      }
+    ],
+    "adjustments": {
+      "UNLAWFULLY_AT_LARGE": [
+        {
+          "appliesToSentencesFrom": "2023-08-25",
+          "numberOfDays": 225,
+          "fromDate": "2023-08-26"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2343.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2343.json
@@ -2,7 +2,7 @@
   "dates": {
     "SLED": "2031-05-05",
     "CRD": "2027-08-22",
-    "HDCED": "2027-02-24",
+    "HDCED": "2026-08-23",
     "ESED": "2025-09-25"
   },
   "effectiveSentenceLength": "P6Y2M"

--- a/src/test/resources/test_data/overall_calculation_response/hdc-365/crs-2386-ac9.json
+++ b/src/test/resources/test_data/overall_calculation_response/hdc-365/crs-2386-ac9.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2029-08-06",
+    "CRD": "2026-05-25",
+    "HDCED": "2025-06-03",
+    "ESED": "2028-12-24"
+  },
+  "effectiveSentenceLength": "P5Y4M",
+  "affectedBySds40": true
+}


### PR DESCRIPTION
Further changes to the rules regarding UAL have been made, the 3rd calculation including UAL was not required as we only need to exclude UAL for any case where we default to the sentence date + 14 days.

Now the rules are as follows:

Step 1: Calculate HDC180 & HDC365 with Remand & TB If date falls before SD + 14, default to SD + 14 days for both HDC180 & HDC365

Step 2: Apply applicable UAL to calculated HDC180 and HDC365 dates

Step 3: Follow one of the following:
3a: If HDC180 falls before 03/06/2025 - Retain HDC180
3b: If HDC365 falls after 03/06/2025 Retain HDC365
3c: If HDC180 falls after 03/06/2025 and HDC365 is before 03/06/2025 Default to 03/06/25

Step 4: Apply ADAs & RADAs

Step 5: Defer any HDCED to later PRRD, PED, CRD, ARD of other sentences