### PR TITLE
CRS-2401: Fix issue with unsupported sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -159,16 +159,18 @@ class CalculationTransactionalService(
   @Transactional(readOnly = true)
   fun supportedValidation(prisonerId: String, inactiveDataOptions: InactiveDataOptions = InactiveDataOptions.default()): SupportedValidationResponse {
     val sourceData = calculationSourceDataService.getCalculationSourceData(prisonerId, inactiveDataOptions)
-    val noInputs = CalculationUserInputs()
-    val booking = bookingService.getBooking(sourceData, noInputs)
-
     val supportedResponse = validationService.validateSupportedSentencesAndCalculations(sourceData)
+
     if (
       supportedResponse.unsupportedSentenceMessages.isNotEmpty() ||
       supportedResponse.unsupportedCalculationMessages.isNotEmpty()
     ) {
+      // loading the booking will blow up unless the sentences and calculation are supported so return early if not.
       return supportedResponse
     }
+
+    val noInputs = CalculationUserInputs()
+    val booking = bookingService.getBooking(sourceData, noInputs)
     val bookingValidationMessages = validationService.validateBeforeCalculation(booking)
 
     if (bookingValidationMessages.isNotEmpty()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -20,6 +20,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.slf4j.Logger
@@ -63,6 +64,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOf
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SupportedValidationResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.CalculationSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderKeyDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
@@ -80,6 +82,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.Calculat
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationReasonRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.TrancheOutcomeRepository
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationCode
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationMessage
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.validation.ValidationService
 import java.time.LocalDate
 import java.time.Period
@@ -724,6 +728,67 @@ class CalculationTransactionalServiceTest {
         true,
       )
     }
+  }
+
+  @Test
+  fun `supported validation check returns without loading the booking if there are unsupported sentences`() {
+    whenever(calculationSourceDataService.getCalculationSourceData(prisonerDetails.offenderNo, InactiveDataOptions.default())).thenReturn(SOURCE_DATA)
+    val expectedResponse = SupportedValidationResponse(
+      unsupportedSentenceMessages = listOf(ValidationMessage(ValidationCode.SENTENCE_HAS_NO_IMPRISONMENT_TERM)),
+    )
+    whenever(validationService.validateSupportedSentencesAndCalculations(SOURCE_DATA)).thenReturn(expectedResponse)
+
+    val response = calculationTransactionalService.supportedValidation(prisonerDetails.offenderNo)
+
+    assertThat(response).isEqualTo(expectedResponse)
+    verify(bookingService, never()).getBooking(any(), any())
+    verify(calculationService, never()).calculateReleaseDates(any(), any())
+  }
+
+  @Test
+  fun `supported validation check returns without loading the booking if the calculation is unsupported`() {
+    whenever(calculationSourceDataService.getCalculationSourceData(prisonerDetails.offenderNo, InactiveDataOptions.default())).thenReturn(SOURCE_DATA)
+    val expectedResponse = SupportedValidationResponse(
+      unsupportedCalculationMessages = listOf(ValidationMessage(ValidationCode.UNSUPPORTED_CALCULATION_DTO_WITH_RECALL)),
+    )
+    whenever(validationService.validateSupportedSentencesAndCalculations(SOURCE_DATA)).thenReturn(expectedResponse)
+
+    val response = calculationTransactionalService.supportedValidation(prisonerDetails.offenderNo)
+
+    assertThat(response).isEqualTo(expectedResponse)
+    verify(bookingService, never()).getBooking(any(), any())
+    verify(calculationService, never()).calculateReleaseDates(any(), any())
+  }
+
+  @Test
+  fun `supported validation check loads booking and validates the booking then returns immediately without calc if there are booking validation errors`() {
+    val expectedResponse = SupportedValidationResponse()
+    whenever(calculationSourceDataService.getCalculationSourceData(prisonerDetails.offenderNo, InactiveDataOptions.default())).thenReturn(SOURCE_DATA)
+    whenever(validationService.validateSupportedSentencesAndCalculations(SOURCE_DATA)).thenReturn(expectedResponse)
+    whenever(bookingService.getBooking(SOURCE_DATA, CalculationUserInputs())).thenReturn(BOOKING)
+    whenever(validationService.validateBeforeCalculation(BOOKING)).thenReturn(listOf(ValidationMessage(ValidationCode.FTR_14_DAYS_SENTENCE_GE_12_MONTHS)))
+
+    val response = calculationTransactionalService.supportedValidation(prisonerDetails.offenderNo)
+
+    assertThat(response).isEqualTo(expectedResponse)
+    verify(calculationService, never()).calculateReleaseDates(any(), any())
+  }
+
+  @Test
+  fun `supported validation performs a calculation and validates for manual entry journey if there are no other issues with the booking`() {
+    val expectedResponse = SupportedValidationResponse(
+      unsupportedManualMessages = listOf(ValidationMessage(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE)),
+    )
+    whenever(calculationSourceDataService.getCalculationSourceData(prisonerDetails.offenderNo, InactiveDataOptions.default())).thenReturn(SOURCE_DATA)
+    whenever(validationService.validateSupportedSentencesAndCalculations(SOURCE_DATA)).thenReturn(expectedResponse)
+    whenever(bookingService.getBooking(SOURCE_DATA, CalculationUserInputs())).thenReturn(BOOKING)
+    whenever(validationService.validateBeforeCalculation(BOOKING)).thenReturn(emptyList())
+    whenever(calculationService.calculateReleaseDates(BOOKING, CalculationUserInputs())).thenReturn(CALCULATION_OUTPUT)
+    whenever(validationService.validateManualEntryJourneyRequirements(BOOKING, CALCULATION_OUTPUT)).thenReturn(listOf(ValidationMessage(ValidationCode.FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE)))
+
+    val response = calculationTransactionalService.supportedValidation(prisonerDetails.offenderNo)
+
+    assertThat(response).isEqualTo(expectedResponse)
   }
 
   private fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()


### PR DESCRIPTION
We were loading the booking even if there were unsupported sentences. The booking load checks has failsafes to ensure validation has been called and throws an exception. We were already returning if there were unsupported sentence or calculation messages so just moved the loading of the booking after that.

Also added some tests.