### PR TITLE
CRS-2439: Suppress SDS40 hint text for ERS30 defaulting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationResultEnrichmentService.kt
@@ -270,7 +270,7 @@ class CalculationResultEnrichmentService(
   private fun sds40Hint(type: ReleaseDateType, calculationBreakdown: CalculationBreakdown): ReleaseDateHint? {
     if (calculationBreakdown.breakdownByReleaseDateType.containsKey(type)) {
       val rules = calculationBreakdown.breakdownByReleaseDateType[type]!!.rules
-      if (rules.contains(CalculationRule.SDS_EARLY_RELEASE_APPLIES) && type.isEarlyReleaseHintType && !rules.contains(CalculationRule.HDCED_ADJUSTED_TO_365_COMMENCEMENT)) {
+      if (rules.contains(CalculationRule.SDS_EARLY_RELEASE_APPLIES) && type.isEarlyReleaseHintType && !rules.contains(CalculationRule.HDCED_ADJUSTED_TO_365_COMMENCEMENT) && !rules.contains(CalculationRule.ERSED_ADJUSTED_TO_ERS30_COMMENCEMENT)) {
         return ReleaseDateHint("40% date has been applied")
       }
       if ((
@@ -284,7 +284,7 @@ class CalculationResultEnrichmentService(
         val trancheText = if (rules.contains(CalculationRule.SDS_EARLY_RELEASE_ADJUSTED_TO_TRANCHE_1_COMMENCEMENT)) "1" else "2"
         return ReleaseDateHint("Defaulted to tranche $trancheText commencement")
       }
-      if (rules.contains(CalculationRule.SDS_STANDARD_RELEASE_APPLIES) && type.isStandardReleaseHintType && !rules.contains(CalculationRule.HDCED_ADJUSTED_TO_365_COMMENCEMENT)) {
+      if (rules.contains(CalculationRule.SDS_STANDARD_RELEASE_APPLIES) && type.isStandardReleaseHintType && !rules.contains(CalculationRule.HDCED_ADJUSTED_TO_365_COMMENCEMENT) && !rules.contains(CalculationRule.ERSED_ADJUSTED_TO_ERS30_COMMENCEMENT)) {
         return ReleaseDateHint("50% date has been applied")
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HintTextTest.kt
@@ -11,7 +11,9 @@ import org.mockito.kotlin.mock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.TestUtil.Companion.overrideFeatureTogglesForTest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.calculation.CalculationExampleTests
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.FeatureToggles
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationOutcome
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationOutcomeHistoricOverride
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationReason
@@ -51,6 +53,9 @@ class HintTextTest : SpringTestBase() {
   @Autowired
   private lateinit var workingDayService: WorkingDayService
 
+  @Autowired
+  private lateinit var featureToggles: FeatureToggles
+
   @Test
   fun `Historic SLED date`() {
     val historicDates = listOf(
@@ -80,6 +85,7 @@ class HintTextTest : SpringTestBase() {
   private fun runHintText(testCase: String, historicDates: List<CalculationOutcomeHistoricOverride>) {
     log.info("Running test-case $testCase")
     val calculationFile = jsonTransformation.loadCalculationTestFile("/hint-text/input-data/$testCase")
+    overrideFeatureTogglesForTest(calculationFile, featureToggles)
     val calculation = calculationService.calculateReleaseDates(calculationFile.booking, calculationFile.userInputs)
     val calculatedReleaseDates = createCalculatedReleaseDates(calculation.calculationResult)
     val calculationBreakdown = performCalculationBreakdown(calculationFile.booking, calculatedReleaseDates, calculationFile.userInputs)

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac1-hint-text.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac1-hint-text.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "SLED",
+    "date": "2030-08-16",
+    "hints": []
+  },
+  {
+    "type": "CRD",
+    "date": "2027-04-11",
+    "hints": ["Friday, 09 April 2027 when adjusted to a working day", "40% date has been applied"]
+  },
+  {
+    "type": "ERSED",
+    "date": "2025-09-23",
+    "hints": []
+  },
+  {
+    "type": "ESED",
+    "date": "2032-01-25",
+    "hints": []
+  }
+]

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac2-hint-text.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac2-hint-text.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "SLED",
+    "date": "2028-10-31",
+    "hints": []
+  },
+  {
+    "type": "CRD",
+    "date": "2025-08-19",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "HDCED",
+    "date": "2025-02-21",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "ERSED",
+    "date": "2024-10-22",
+    "hints": ["Defaulted to tranche 2 commencement"]
+  },
+  {
+    "type": "ESED",
+    "date": "2029-10-31",
+    "hints": []
+  }
+]

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac3-hint-text.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac3-hint-text.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "SLED",
+    "date": "2030-10-30",
+    "hints": []
+  },
+  {
+    "type": "CRD",
+    "date": "2027-02-28",
+    "hints": ["Friday, 26 February 2027 when adjusted to a working day", "40% date has been applied"]
+  },
+  {
+    "type": "HDCED",
+    "date": "2026-03-01",
+    "hints": ["Monday, 02 March 2026 when adjusted to a working day", "40% date has been applied"]
+  },
+  {
+    "type": "ERSED",
+    "date": "2025-09-02",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "ESED",
+    "date": "2031-03-13",
+    "hints": []
+  }
+]

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac4-hint-text.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac4-hint-text.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "SLED",
+    "date": "2030-10-02",
+    "hints": []
+  },
+  {
+    "type": "CRD",
+    "date": "2027-06-15",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "HDCED",
+    "date": "2026-06-16",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "ERSED",
+    "date": "2025-12-01",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "ESED",
+    "date": "2024-06-18",
+    "hints": []
+  }
+]

--- a/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac5-hint-text.json
+++ b/src/test/resources/test_data/hint-text/expected-results/crs-2439-ac5-hint-text.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "SLED",
+    "date": "2029-04-15",
+    "hints": []
+  },
+  {
+    "type": "CRD",
+    "date": "2025-09-08",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "HDCED",
+    "date": "2025-03-13",
+    "hints": ["40% date has been applied"]
+  },
+  {
+    "type": "ERSED",
+    "date": "2024-10-18",
+    "hints": ["50% date has been applied"]
+  },
+  {
+    "type": "ESED",
+    "date": "2029-04-15",
+    "hints": []
+  }
+]

--- a/src/test/resources/test_data/hint-text/input-data/crs-2439-ac1-hint-text.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2439-ac1-hint-text.json
@@ -1,0 +1,117 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "A1234EQ",
+      "dateOfBirth": "1985-04-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2021-01-29",
+          "offenceCode": "SX03002"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 99
+          }
+        },
+        "isSDSPlus": true,
+        "identifier": "1f90b983-e59b-3ce3-8b16-252c124730d2",
+        "recallType": null,
+        "sentencedAt": "2022-10-26",
+        "caseSequence": 3,
+        "lineSequence": 1,
+        "caseReference": "C3",
+        "externalSentenceId": {
+          "sentenceSequence": 1
+        },
+        "consecutiveSentenceUUIDs": [
+          "ae231a2d-0f2a-3366-a4c7-c347b636e491"
+        ],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": true
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2021-01-29",
+          "offenceCode": "OF61102"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 32
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "40bf31f2-c773-314e-aa0a-ec638690758a",
+        "recallType": null,
+        "sentencedAt": "2022-10-26",
+        "caseSequence": 3,
+        "lineSequence": 2,
+        "caseReference": "C3",
+        "externalSentenceId": {
+          "sentenceSequence": 2
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2021-05-15",
+          "offenceCode": "CA03007"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 1,
+            "MONTHS": 0
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "ae231a2d-0f2a-3366-a4c7-c347b636e491",
+        "recallType": null,
+        "sentencedAt": "2022-10-26",
+        "caseSequence": 1,
+        "lineSequence": 3,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 3
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "toDate": "2022-10-25",
+          "fromDate": "2021-05-17",
+          "numberOfDays": 527,
+          "appliesToSentencesFrom": "2022-10-26"
+        }
+      ]
+    },
+    "externalMovements": [],
+    "historicalTusedData": null,
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}

--- a/src/test/resources/test_data/hint-text/input-data/crs-2439-ac2-hint-text.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2439-ac2-hint-text.json
@@ -1,0 +1,179 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "A1234EK",
+      "dateOfBirth": "1993-08-01",
+      "isActiveSexOffender": false
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-09",
+          "offenceCode": "MD71231"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 64
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "1a0161e9-7dde-3824-86d9-e41dc5fc3b48",
+        "recallType": null,
+        "sentencedAt": "2024-07-01",
+        "caseSequence": 1,
+        "lineSequence": 2,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 2
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-09",
+          "offenceCode": "MD71230"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 64
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "0fec1e42-3291-3312-9c6f-64334ad1a55a",
+        "recallType": null,
+        "sentencedAt": "2024-07-01",
+        "caseSequence": 1,
+        "lineSequence": 3,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 3
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-09",
+          "offenceCode": "MD71526"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 64
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "69b9c7c0-99b9-34bf-8c0b-f7993d173b01",
+        "recallType": null,
+        "sentencedAt": "2024-07-01",
+        "caseSequence": 1,
+        "lineSequence": 4,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 4
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-09",
+          "offenceCode": "MD71170"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 64
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "3d249269-b279-3d27-b6d3-491456904b27",
+        "recallType": null,
+        "sentencedAt": "2024-07-01",
+        "caseSequence": 1,
+        "lineSequence": 5,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 5
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-09",
+          "offenceCode": "MD71191"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 64
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "b596485d-ad36-3775-80dd-19a50a3f1261",
+        "recallType": null,
+        "sentencedAt": "2024-07-01",
+        "caseSequence": 1,
+        "lineSequence": 6,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 6
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "toDate": "2022-02-10",
+          "fromDate": "2022-02-10",
+          "numberOfDays": 1,
+          "appliesToSentencesFrom": "2024-07-01"
+        },
+        {
+          "toDate": "2024-06-30",
+          "fromDate": "2023-07-03",
+          "numberOfDays": 364,
+          "appliesToSentencesFrom": "2024-07-01"
+        }
+      ]
+    },
+    "externalMovements": [],
+    "historicalTusedData": null,
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}

--- a/src/test/resources/test_data/hint-text/input-data/crs-2439-ac3-hint-text.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2439-ac3-hint-text.json
@@ -1,0 +1,175 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "A1234EZ",
+      "dateOfBirth": "1996-01-01",
+      "isActiveSexOffender": false
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-05-14",
+          "offenceCode": "TH68023"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 81
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "730c9170-1ad9-327b-af44-c517fb22a06b",
+        "recallType": null,
+        "sentencedAt": "2023-12-14",
+        "caseSequence": 1,
+        "lineSequence": 1,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 1
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "VIOLENT",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-08-01",
+          "offenceCode": "ID10001"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 6
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "a3556c6d-0b1f-3ccd-b18b-7597391b2ab1",
+        "recallType": null,
+        "sentencedAt": "2023-12-14",
+        "caseSequence": 1,
+        "lineSequence": 2,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 2
+        },
+        "consecutiveSentenceUUIDs": [
+          "730c9170-1ad9-327b-af44-c517fb22a06b"
+        ],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-08-01",
+          "offenceCode": "ID10001"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 12
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "7ee43b9d-68ed-3f24-a17c-c7f24974cee0",
+        "recallType": null,
+        "sentencedAt": "2023-12-14",
+        "caseSequence": 1,
+        "lineSequence": 3,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 9
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-08-01",
+          "offenceCode": "PC02021C"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 12
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "7ee43b9d-68ed-3f24-a17c-c7f24974cee0",
+        "recallType": null,
+        "sentencedAt": "2023-12-14",
+        "caseSequence": 1,
+        "lineSequence": 3,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 9
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-04-23",
+          "offenceCode": "TH68023"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 67
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "ed20ec03-0420-33ac-bc18-29fa85e09aaa",
+        "recallType": null,
+        "sentencedAt": "2023-12-14",
+        "caseSequence": 1,
+        "lineSequence": 4,
+        "caseReference": "C1",
+        "externalSentenceId": {
+          "sentenceSequence": 16
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": true,
+        "hasAnSDSEarlyReleaseExclusion": "VIOLENT",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "toDate": "2023-12-13",
+          "fromDate": "2023-08-02",
+          "numberOfDays": 134,
+          "appliesToSentencesFrom": "2023-12-14"
+        }
+      ]
+    },
+    "externalMovements": [],
+    "historicalTusedData": null,
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}

--- a/src/test/resources/test_data/hint-text/input-data/crs-2439-ac4-hint-text.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2439-ac4-hint-text.json
@@ -1,0 +1,115 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "A1234FG",
+      "dateOfBirth": "1974-06-01",
+      "isActiveSexOffender": false
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-11-17",
+          "offenceCode": "PC02020"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 5,
+            "MONTHS": 6
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "1b9c2ba0-9523-36d3-bdae-4ac1f76d273a",
+        "recallType": null,
+        "sentencedAt": "2018-12-19",
+        "caseSequence": 2,
+        "lineSequence": 1,
+        "caseReference": "C2",
+        "externalSentenceId": {
+          "sentenceSequence": 1
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-11-17",
+          "offenceCode": "PC02021"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 18
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "08f06750-16fe-3120-b2c3-f95744b62d45",
+        "recallType": null,
+        "sentencedAt": "2018-12-19",
+        "caseSequence": 2,
+        "lineSequence": 2,
+        "caseReference": "C2",
+        "externalSentenceId": {
+          "sentenceSequence": 2
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-11-11",
+          "offenceCode": "PC02021"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 0,
+            "MONTHS": 12
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "262b54a5-b4b2-3b75-b672-1e2b6bb8dd43",
+        "recallType": null,
+        "sentencedAt": "2018-12-19",
+        "caseSequence": 2,
+        "lineSequence": 3,
+        "caseReference": "C2",
+        "externalSentenceId": {
+          "sentenceSequence": 3
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      }
+    ],
+    "adjustments": {
+      "UNLAWFULLY_AT_LARGE": [
+        {
+          "toDate": "2025-04-02",
+          "fromDate": "2018-12-19",
+          "numberOfDays": 2297,
+          "appliesToSentencesFrom": "2018-12-19"
+        }
+      ]
+    },
+    "externalMovements": [],
+    "historicalTusedData": null,
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}

--- a/src/test/resources/test_data/hint-text/input-data/crs-2439-ac5-hint-text.json
+++ b/src/test/resources/test_data/hint-text/input-data/crs-2439-ac5-hint-text.json
@@ -1,0 +1,48 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "A1234FG",
+      "dateOfBirth": "1974-06-01",
+      "isActiveSexOffender": false
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-11-17",
+          "offenceCode": "PC02020"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 0,
+            "WEEKS": 0,
+            "YEARS": 6,
+            "MONTHS": 0
+          }
+        },
+        "isSDSPlus": false,
+        "identifier": "1b9c2ba0-9523-36d3-bdae-4ac1f76d273a",
+        "recallType": null,
+        "sentencedAt": "2023-04-16",
+        "caseSequence": 2,
+        "lineSequence": 1,
+        "caseReference": "C2",
+        "externalSentenceId": {
+          "sentenceSequence": 1
+        },
+        "consecutiveSentenceUUIDs": [],
+        "isSDSPlusOffenceInPeriod": false,
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+      }
+    ],
+    "adjustments": {},
+    "externalMovements": [],
+    "historicalTusedData": null,
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}


### PR DESCRIPTION
When the ERSED has been defaulted to the ERS30 commencement date we should not display the SDS40 hint text "40/50% date has been applied".

Fixed a couple of tests runners that did not apply the feature toggles as per the input json.