### PR TITLE
CRS-2414: Remove unused dateText field from manual dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ManualEntryRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ManualEntryRequest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 data class ManualEntryRequest(
-  val selectedManualEntryDates: List<ManualEntrySelectedDate>,
+  val selectedManualEntryDates: List<ManuallyEnteredDate>,
   val reasonForCalculationId: Long,
   val otherReasonDescription: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ManuallyEnteredDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ManuallyEnteredDate.kt
@@ -2,8 +2,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 
-data class ManualEntrySelectedDate(
+data class ManuallyEnteredDate(
   val dateType: ReleaseDateType,
-  val dateText: String,
   val date: SubmittedDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SubmitCalculationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SubmitCalculationRequest.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 data class SubmitCalculationRequest(
   val calculationFragments: CalculationFragments,
-  val approvedDates: List<ManualEntrySelectedDate>?,
+  val approvedDates: List<ManuallyEnteredDate>?,
   val isSpecialistSupport: Boolean? = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationConfirmationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationConfirmationService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.ApprovedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.CalculationNotFoundException
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Booking
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.UpdateOffenderDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.ApprovedDatesSubmissionRepository
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
@@ -24,7 +24,7 @@ class CalculationConfirmationService(
   private val approvedDatesSubmissionRepository: ApprovedDatesSubmissionRepository,
 ) {
   @Transactional
-  fun storeApprovedDates(calculation: CalculatedReleaseDates, approvedDates: List<ManualEntrySelectedDate>) {
+  fun storeApprovedDates(calculation: CalculatedReleaseDates, approvedDates: List<ManuallyEnteredDate>) {
     val foundCalculation = calculationRequestRepository.findById(calculation.calculationRequestId)
     foundCalculation.map {
       val submittedDatesToSave = approvedDates.map { approvedDate ->
@@ -50,7 +50,7 @@ class CalculationConfirmationService(
     prisonerId: String,
     booking: Booking,
     calculation: CalculatedReleaseDates,
-    approvedDates: List<ManualEntrySelectedDate>?,
+    approvedDates: List<ManuallyEnteredDate>?,
     isSpecialistSupport: Boolean? = false,
   ) {
     val calculationRequest = calculationRequestRepository.findById(calculation.calculationRequestId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -34,7 +34,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFr
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRequestModel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SupportedValidationResponse
@@ -283,7 +283,7 @@ class CalculationTransactionalService(
     sourceData: CalculationSourceData,
     booking: Booking,
     userInput: CalculationUserInputs,
-    approvedDates: List<ManualEntrySelectedDate>?,
+    approvedDates: List<ManuallyEnteredDate>?,
     isSpecialistSupport: Boolean? = false,
     reasonForCalculation: CalculationReason?,
     otherReasonForCalculation: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/NomisCommentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/NomisCommentService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import java.time.LocalDate
 
 @Service
@@ -12,7 +12,7 @@ class NomisCommentService {
   fun getNomisComment(
     calculationRequest: CalculationRequest,
     isSpecialistSupport: Boolean,
-    approvedDates: List<ManualEntrySelectedDate>?,
+    approvedDates: List<ManuallyEnteredDate>?,
   ): String {
     val comment = if (isSpecialistSupport) {
       SPECIALIST_SUPPORT_COMMENT

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -89,7 +89,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalMovem
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalSentenceId
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.GenuineOverrideResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.HistoricalTusedData
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Recall
@@ -622,9 +622,8 @@ fun transform(
   )
 }
 
-fun transform(calculation: CalculatedReleaseDates, approvedDates: List<ManualEntrySelectedDate>?): OffenderKeyDates {
-  val groupedApprovedDates =
-    approvedDates?.map { it.dateType to LocalDate.of(it.date!!.year, it.date.month, it.date.day) }?.toMap()
+fun transform(calculation: CalculatedReleaseDates, approvedDates: List<ManuallyEnteredDate>?): OffenderKeyDates {
+  val groupedApprovedDates = approvedDates?.associate { it.dateType to it.date!!.toLocalDate() }
   val hdcad = groupedApprovedDates?.get(HDCAD) ?: calculation.dates[HDCAD]
   val rotl = groupedApprovedDates?.get(ROTL) ?: calculation.dates[ROTL]
   val apd = groupedApprovedDates?.get(APD) ?: calculation.dates[APD]
@@ -691,24 +690,17 @@ fun transform(fixedTermRecallDetails: FixedTermRecallDetails): ReturnToCustodyDa
 
 fun transform(
   calculationRequest: CalculationRequest,
-  manualEntrySelectedDate: ManualEntrySelectedDate,
+  manuallyEnteredDate: ManuallyEnteredDate,
 ): CalculationOutcome {
-  if (manualEntrySelectedDate.date != null) {
-    val date = manualEntrySelectedDate.date.year.let {
-      LocalDate.of(
-        it,
-        manualEntrySelectedDate.date.month,
-        manualEntrySelectedDate.date.day,
-      )
-    }
+  if (manuallyEnteredDate.date != null) {
     return CalculationOutcome(
-      calculationDateType = manualEntrySelectedDate.dateType.name,
-      outcomeDate = date,
+      calculationDateType = manuallyEnteredDate.dateType.name,
+      outcomeDate = manuallyEnteredDate.date.toLocalDate(),
       calculationRequestId = calculationRequest.id,
     )
   }
   return CalculationOutcome(
-    calculationDateType = manualEntrySelectedDate.dateType.name,
+    calculationDateType = manuallyEnteredDate.dateType.name,
     outcomeDate = null,
     calculationRequestId = calculationRequest.id,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedRel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRequestModel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecordARecallResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSentenceAndOffences
@@ -100,7 +100,7 @@ open class IntegrationTestBase internal constructor() {
 
   protected fun createConfirmCalculationForPrisoner(
     calculationRequestId: Long,
-    approvedDates: List<ManualEntrySelectedDate>,
+    approvedDates: List<ManuallyEnteredDate>,
   ): CalculatedReleaseDates = webTestClient.post()
     .uri("/calculation/confirm/$calculationRequestId")
     .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
@@ -41,7 +41,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRe
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResults
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationSentenceUserInput
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemand
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationResult
@@ -266,7 +266,7 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     val resultCalculation = createPreliminaryCalculation(PRISONER_ID)
     val calc = createConfirmCalculationForPrisoner(
       resultCalculation.calculationRequestId,
-      listOf(ManualEntrySelectedDate(APD, "APD", SubmittedDate(3, 3, 2023))),
+      listOf(ManuallyEnteredDate(APD, SubmittedDate(3, 3, 2023))),
     )
     assertThat(calc).isNotNull
     val result = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Releas
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualCalculationResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntryRequest
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
 import java.time.LocalDate
 
@@ -32,7 +32,7 @@ class ManualCalculationIntTest : IntegrationTestBase() {
   fun `Storing a no dates manual entry is successful`() {
     val response = webTestClient.post()
       .uri("/manual-calculation/$PRISONER_ID")
-      .bodyValue(ManualEntryRequest(listOf(ManualEntrySelectedDate(ReleaseDateType.None, "None", null)), 1L, ""))
+      .bodyValue(ManualEntryRequest(listOf(ManuallyEnteredDate(ReleaseDateType.None, null)), 1L, ""))
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
@@ -50,9 +50,8 @@ class ManualCalculationIntTest : IntegrationTestBase() {
       .bodyValue(
         ManualEntryRequest(
           listOf(
-            ManualEntrySelectedDate(
+            ManuallyEnteredDate(
               ReleaseDateType.CRD,
-              "CRD",
               SubmittedDate(1, 1, LocalDate.now().year + 1),
             ),
           ),
@@ -77,9 +76,8 @@ class ManualCalculationIntTest : IntegrationTestBase() {
       .bodyValue(
         ManualEntryRequest(
           listOf(
-            ManualEntrySelectedDate(
+            ManuallyEnteredDate(
               ReleaseDateType.CRD,
-              "CRD",
               SubmittedDate(1, 1, LocalDate.now().year + 1),
             ),
           ),
@@ -120,9 +118,8 @@ class ManualCalculationIntTest : IntegrationTestBase() {
           reasonForCalculationId = 1,
           otherReasonDescription = "",
           selectedManualEntryDates = listOf(
-            ManualEntrySelectedDate(
+            ManuallyEnteredDate(
               ReleaseDateType.PED,
-              "PED",
               SubmittedDate(
                 day = 1,
                 month = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/SpecialistSupportIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/SpecialistSupportIntTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.GenuineOverri
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.GenuineOverrideRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.GenuineOverrideResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntryRequest
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.GenuineOverrideRepository
 import java.util.UUID
@@ -117,7 +117,7 @@ class SpecialistSupportIntTest : IntegrationTestBase() {
         originalCalculationReference = preliminaryCalculation.calculationReference.toString(),
         manualEntryRequest = ManualEntryRequest(
           listOf(
-            ManualEntrySelectedDate(ReleaseDateType.APD, "text", SubmittedDate(day = 1, month = 2, year = 2023)),
+            ManuallyEnteredDate(ReleaseDateType.APD, SubmittedDate(day = 1, month = 2, year = 2023)),
           ),
           1L,
           "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalServiceTest.kt
@@ -56,7 +56,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRe
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalSentenceId
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
@@ -455,9 +455,9 @@ class CalculationTransactionalServiceTest {
       SubmitCalculationRequest(
         calculationFragments = CalculationFragments(""),
         approvedDates = listOf(
-          ManualEntrySelectedDate(ROTL, "rotl text", SubmittedDate(1, 1, 2020)),
-          ManualEntrySelectedDate(APD, "apd text", SubmittedDate(1, 2, 2020)),
-          ManualEntrySelectedDate(HDCAD, "hdcad text", SubmittedDate(1, 3, 2020)),
+          ManuallyEnteredDate(ROTL, SubmittedDate(1, 1, 2020)),
+          ManuallyEnteredDate(APD, SubmittedDate(1, 2, 2020)),
+          ManuallyEnteredDate(HDCAD, SubmittedDate(1, 3, 2020)),
         ),
       ),
     )
@@ -562,9 +562,9 @@ class CalculationTransactionalServiceTest {
       SubmitCalculationRequest(
         calculationFragments = CalculationFragments(""),
         approvedDates = listOf(
-          ManualEntrySelectedDate(ROTL, "rotl text", SubmittedDate(1, 1, 2020)),
-          ManualEntrySelectedDate(APD, "apd text", SubmittedDate(1, 2, 2020)),
-          ManualEntrySelectedDate(HDCAD, "hdcad text", SubmittedDate(1, 3, 2020)),
+          ManuallyEnteredDate(ROTL, SubmittedDate(1, 1, 2020)),
+          ManuallyEnteredDate(APD, SubmittedDate(1, 2, 2020)),
+          ManuallyEnteredDate(HDCAD, SubmittedDate(1, 3, 2020)),
         ),
       ),
     )
@@ -609,9 +609,9 @@ class CalculationTransactionalServiceTest {
       SubmitCalculationRequest(
         calculationFragments = CalculationFragments(""),
         approvedDates = listOf(
-          ManualEntrySelectedDate(ROTL, "rotl text", SubmittedDate(1, 1, 2020)),
-          ManualEntrySelectedDate(APD, "apd text", SubmittedDate(1, 2, 2020)),
-          ManualEntrySelectedDate(HDCAD, "hdcad text", SubmittedDate(1, 3, 2020)),
+          ManuallyEnteredDate(ROTL, SubmittedDate(1, 1, 2020)),
+          ManuallyEnteredDate(APD, SubmittedDate(1, 2, 2020)),
+          ManuallyEnteredDate(HDCAD, SubmittedDate(1, 3, 2020)),
         ),
       ),
     )
@@ -650,9 +650,9 @@ class CalculationTransactionalServiceTest {
         effectiveSentenceLength = Period.of(6, 2, 3),
       ),
       listOf(
-        ManualEntrySelectedDate(ROTL, "rotl text", SubmittedDate(1, 1, 2020)),
-        ManualEntrySelectedDate(APD, "apd text", SubmittedDate(1, 2, 2020)),
-        ManualEntrySelectedDate(HDCAD, "hdcad text", SubmittedDate(1, 3, 2020)),
+        ManuallyEnteredDate(ROTL, SubmittedDate(1, 1, 2020)),
+        ManuallyEnteredDate(APD, SubmittedDate(1, 2, 2020)),
+        ManuallyEnteredDate(HDCAD, SubmittedDate(1, 3, 2020)),
       ),
     )
     doNothing().`when`(prisonService).postReleaseDates(any(), any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ManualCalculationServiceTest.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOu
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntryRequest
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NormalisedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
@@ -122,9 +122,8 @@ class ManualCalculationServiceTest {
         BOOKING,
         ManualEntryRequest(
           listOf(
-            ManualEntrySelectedDate(
+            ManuallyEnteredDate(
               ReleaseDateType.LED,
-              "None",
               SubmittedDate(1, 1, 2026),
             ),
           ),
@@ -427,7 +426,7 @@ class ManualCalculationServiceTest {
         listOf(),
       ),
     )
-    val manualCalcRequest = ManualEntrySelectedDate(ReleaseDateType.None, "None of the dates apply", null)
+    val manualCalcRequest = ManuallyEnteredDate(ReleaseDateType.None, null)
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
     manualCalculationService.storeManualCalculation(PRISONER_ID, manualEntryRequest)
     val expectedUpdatedOffenderDates = UpdateOffenderDates(
@@ -463,9 +462,8 @@ class ManualCalculationServiceTest {
       ),
     )
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -498,9 +496,8 @@ class ManualCalculationServiceTest {
     whenever(serviceUserService.getUsername()).thenReturn(USERNAME)
     whenever(nomisCommentService.getManualNomisComment(any(), any(), any())).thenReturn("The NOMIS Reason")
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -551,9 +548,8 @@ class ManualCalculationServiceTest {
       ),
     )
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -591,9 +587,8 @@ class ManualCalculationServiceTest {
         any(),
       ),
     ).thenThrow(NullPointerException("An error was thrown"))
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -624,9 +619,8 @@ class ManualCalculationServiceTest {
     whenever(serviceUserService.getUsername()).thenReturn(USERNAME)
     whenever(nomisCommentService.getManualNomisComment(any(), any(), any())).thenReturn("The NOMIS Reason")
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -661,9 +655,8 @@ class ManualCalculationServiceTest {
       ),
     )
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -710,9 +703,8 @@ class ManualCalculationServiceTest {
       ),
     )
 
-    val manualCalcRequest = ManualEntrySelectedDate(
+    val manualCalcRequest = ManuallyEnteredDate(
       ReleaseDateType.CRD,
-      "CRD also known as the Conditional Release Date",
       SubmittedDate(3, 3, 2023),
     )
     val manualEntryRequest = ManualEntryRequest(listOf(manualCalcRequest), 1L, "")
@@ -910,9 +902,8 @@ class ManualCalculationServiceTest {
     private val BOOKING = Booking(OFFENDER, listOf(StandardSENTENCE), Adjustments(), null, null, BOOKING_ID)
     private val MANUAL_ENTRY = ManualEntryRequest(
       listOf(
-        ManualEntrySelectedDate(
+        ManuallyEnteredDate(
           ReleaseDateType.SED,
-          "None",
           SubmittedDate(1, 1, 2026),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/NomisCommentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/NomisCommentServiceTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntrySelectedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
 import java.time.LocalDate
 import java.util.UUID
@@ -33,7 +33,7 @@ class NomisCommentServiceTest {
       nomisCommentService.getNomisComment(
         CALCULATION_REQUEST,
         isSpecialistSupport = false,
-        approvedDates = listOf(ManualEntrySelectedDate(ReleaseDateType.CRD, "text", SubmittedDate(1, 1, 2023))),
+        approvedDates = listOf(ManuallyEnteredDate(ReleaseDateType.CRD, SubmittedDate(1, 1, 2023))),
       ),
       "If the calculation had manually entered dates this is captured in the NOMIS comment",
     )


### PR DESCRIPTION
Plus some small refactoring. This type seems to have been created in a way to avoid creating an extra type in the UI but it actually does more harm than good having this unused field so removing it and separating the types within the UI (hence the rename).