### PR TITLE
CRS-2414: Fix genuine override with no further detail

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/GenuineOverrideRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/GenuineOverrideRequest.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 data class GenuineOverrideRequest(
   val dates: List<GenuineOverrideDate>,
   val reason: GenuineOverrideReason,
-  val reasonFurtherDetail: String,
+  val reasonFurtherDetail: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/GenuineOverrideIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/GenuineOverrideIntTest.kt
@@ -26,7 +26,65 @@ class GenuineOverrideIntTest : IntegrationTestBase() {
 
   @Test
   fun `should create a new calculation using the overridden dates and update the original calculation to say it was overridden`() {
-    val preliminaryCalculation = createPreliminaryCalculation(CalculationIntTest.PRISONER_ID)
+    val preliminaryCalculation = createPreliminaryCalculation(PRISONER_ID)
+    val request = GenuineOverrideRequest(
+      dates = listOf(
+        GenuineOverrideDate(ReleaseDateType.SED, LocalDate.of(2025, 1, 2)),
+        GenuineOverrideDate(ReleaseDateType.LED, LocalDate.of(2029, 12, 13)),
+        GenuineOverrideDate(ReleaseDateType.HDCED, LocalDate.of(2021, 6, 7)),
+      ),
+      reason = GenuineOverrideReason.TERRORISM,
+      reasonFurtherDetail = null,
+    )
+    val response = webTestClient.post()
+      .uri("/calculation/genuine-override/${preliminaryCalculation.calculationRequestId}")
+      .accept(MediaType.APPLICATION_JSON)
+      .bodyValue(request)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(GenuineOverrideCreatedResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(response.originalCalculationRequestId).isEqualTo(preliminaryCalculation.calculationRequestId)
+    val originalRequest = calculationRequestRepository.findById(response.originalCalculationRequestId).orElseThrow { fail("Couldn't load original request") }
+    val newRequest = calculationRequestRepository.findById(response.newCalculationRequestId).orElseThrow { fail("Couldn't load new request") }
+
+    assertThat(originalRequest.overridesCalculationRequestId).isNull()
+    assertThat(originalRequest.overriddenByCalculationRequestId).isEqualTo(newRequest.id)
+    assertThat(originalRequest.genuineOverrideReason).isEqualTo(GenuineOverrideReason.TERRORISM)
+    assertThat(originalRequest.genuineOverrideReasonFurtherDetail).isNull()
+    assertThat(originalRequest.calculationStatus).isEqualTo(CalculationStatus.OVERRIDDEN.name)
+
+    assertThat(newRequest.overridesCalculationRequestId).isEqualTo(originalRequest.id)
+    assertThat(newRequest.overriddenByCalculationRequestId).isNull()
+    assertThat(newRequest.genuineOverrideReason).isEqualTo(GenuineOverrideReason.TERRORISM)
+    assertThat(newRequest.genuineOverrideReasonFurtherDetail).isNull()
+    assertThat(newRequest.calculationStatus).isEqualTo(CalculationStatus.CONFIRMED.name)
+
+    // Check the latest results are from the override
+    val result = webTestClient.get()
+      .uri("/calculation/results/${preliminaryCalculation.prisonerId}/${preliminaryCalculation.bookingId}")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(CalculatedReleaseDates::class.java)
+      .returnResult().responseBody
+
+    assertThat(result).isNotNull
+    assertThat(result!!.calculationRequestId).isEqualTo(newRequest.id)
+    assertThat(result.dates).containsOnlyKeys(ReleaseDateType.SED, ReleaseDateType.LED, ReleaseDateType.HDCED)
+    assertThat(result.dates[ReleaseDateType.SED]!!).isEqualTo(LocalDate.of(2025, 1, 2))
+    assertThat(result.dates[ReleaseDateType.LED]!!).isEqualTo(LocalDate.of(2029, 12, 13))
+    assertThat(result.dates[ReleaseDateType.HDCED]!!).isEqualTo(LocalDate.of(2021, 6, 7))
+  }
+
+  @Test
+  fun `should create a genuine override with reason other and further detail`() {
+    val preliminaryCalculation = createPreliminaryCalculation(PRISONER_ID)
     val request = GenuineOverrideRequest(
       dates = listOf(
         GenuineOverrideDate(ReleaseDateType.SED, LocalDate.of(2025, 1, 2)),
@@ -62,24 +120,6 @@ class GenuineOverrideIntTest : IntegrationTestBase() {
     assertThat(newRequest.genuineOverrideReason).isEqualTo(GenuineOverrideReason.OTHER)
     assertThat(newRequest.genuineOverrideReasonFurtherDetail).isEqualTo("A test reason")
     assertThat(newRequest.calculationStatus).isEqualTo(CalculationStatus.CONFIRMED.name)
-
-    // Check the latest results are from the override
-    val result = webTestClient.get()
-      .uri("/calculation/results/${preliminaryCalculation.prisonerId}/${preliminaryCalculation.bookingId}")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(CalculatedReleaseDates::class.java)
-      .returnResult().responseBody
-
-    assertThat(result).isNotNull
-    assertThat(result!!.calculationRequestId).isEqualTo(newRequest.id)
-    assertThat(result.dates).containsOnlyKeys(ReleaseDateType.SED, ReleaseDateType.LED, ReleaseDateType.HDCED)
-    assertThat(result.dates[ReleaseDateType.SED]!!).isEqualTo(LocalDate.of(2025, 1, 2))
-    assertThat(result.dates[ReleaseDateType.LED]!!).isEqualTo(LocalDate.of(2029, 12, 13))
-    assertThat(result.dates[ReleaseDateType.HDCED]!!).isEqualTo(LocalDate.of(2021, 6, 7))
   }
 
   @Test


### PR DESCRIPTION
Should have been a nullable type on the request object.