### PR TITLE
CRS-1160: PED should not be earlier than earliest sentence date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -100,7 +100,8 @@ class BookingExtractionService(
     }
 
     if (sentenceCalculation.extendedDeterminateParoleEligibilityDate != null) {
-      dates[PED] = sentenceCalculation.extendedDeterminateParoleEligibilityDate!!
+      val ped = sentenceCalculation.extendedDeterminateParoleEligibilityDate!!
+      dates[PED] = if (ped.isAfter(sentence.sentencedAt)) ped else sentence.sentencedAt
     }
 
     if (sentenceCalculation.earlyReleaseSchemeEligibilityDate != null) {
@@ -202,7 +203,15 @@ class BookingExtractionService(
     val latestExtendedDeterminateParoleEligibilityDate: LocalDate? = extractionService.mostRecentOrNull(
       sentences,
       SentenceCalculation::extendedDeterminateParoleEligibilityDate,
-    )
+    )?.let { adjustedPed ->
+      // adjustments can make the PED earlier than the earliest sentence date
+      val earliestSentenceDate = sentences.minOf { it.sentencedAt }
+      if (adjustedPed.isAfter(earliestSentenceDate)) {
+        adjustedPed
+      } else {
+        earliestSentenceDate
+      }
+    }
 
     val concurrentOraAndNonOraDetails = extractConcurrentOraAndNonOraDetails(
       mostRecentSentenceByAdjustedDeterminateReleaseDate.releaseDateTypes.getReleaseDateTypes(),
@@ -414,9 +423,9 @@ class BookingExtractionService(
     breakdownByReleaseDateType: MutableMap<ReleaseDateType, ReleaseDateCalculationBreakdown>,
   ) {
     if (latestExtendedDeterminateParoleEligibilityDate != null) {
-      val mostRecentReleaseSentenceHasParoleDate =
+      val mostRecentReleaseSentenceParoleDate =
         mostRecentSentenceByAdjustedDeterminateReleaseDate.sentenceCalculation.extendedDeterminateParoleEligibilityDate
-      if (mostRecentReleaseSentenceHasParoleDate != null) {
+      if (mostRecentReleaseSentenceParoleDate != null) {
         val latestNonPedReleaseSentence = extractionService.mostRecentSentenceOrNull(
           sentences.filter { !it.isRecall() && it.sentenceCalculation.extendedDeterminateParoleEligibilityDate == null && !it.isDto() && !it.sentenceCalculation.isImmediateRelease() },
           SentenceCalculation::releaseDate,

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac1.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac1.json
@@ -1,0 +1,37 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2021-05-06"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2021-05-06"
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2021-05-06",
+          "numberOfDays": 510,
+          "fromDate": "2019-12-13",
+          "toDate": "2021-05-05"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac2.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac2.json
@@ -1,0 +1,37 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "SopcSentence",
+        "offence": {
+          "committedAt": "2022-01-01"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2022-01-01"
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2022-01-01",
+          "numberOfDays": 250,
+          "fromDate": "2021-04-26",
+          "toDate": "2021-12-31"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac5.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-1160-ac5.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "SopcSentence",
+        "offence": {
+          "committedAt": "2025-09-05"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2025-09-05",
+        "identifier": "70b10e6a-a5b2-43e7-a5db-3694d75bedec"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-11"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 2
+          }
+        },
+        "sentencedAt": "2025-10-11",
+        "hasAnSDSEarlyReleaseExclusion": "NO",
+        "identifier": "09a755e1-c13a-4dc4-81b6-baed0f9724bd",
+        "consecutiveSentenceUUIDs": [
+          "70b10e6a-a5b2-43e7-a5db-3694d75bedec"
+        ]
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-09-05",
+          "numberOfDays": 515,
+          "fromDate": "2024-04-08",
+          "toDate": "2025-09-04"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac1.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2022-12-12",
+    "CRD": "2021-12-11",
+    "PED": "2021-05-06",
+    "ESED": "2024-05-05"
+  },
+  "effectiveSentenceLength": "P3Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac2.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2023-04-25",
+    "CRD": "2022-04-25",
+    "PED": "2022-01-01",
+    "ESED": "2023-12-31"
+  },
+  "effectiveSentenceLength": "P2Y"
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac5.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-1160-ac5.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2027-06-08",
+    "CRD": "2026-05-02",
+    "PED": "2025-09-05",
+    "ESED": "2028-11-04"
+  },
+  "effectiveSentenceLength": "P3Y2M"
+}


### PR DESCRIPTION
Large amounts of remand could make the PED earlier than the sentence date. If it's earlier than the earliest sentence date in the sentence envelope then default to the earliest sentence date instead.