### PR TITLE
CRS-2502: Alt progression model config

### DIFF
--- a/helm_deploy/values-alt-preprod.yaml
+++ b/helm_deploy/values-alt-preprod.yaml
@@ -14,7 +14,7 @@ generic-service:
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
-    SPRING_PROFILES_ACTIVE: "calculation-params,sds-progression-model"
+    SPRING_PROFILES_ACTIVE: "calculation-params,sds-progression-model-alt"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-preprod.prison.service.justice.gov.uk

--- a/src/main/resources/application-sds-progression-model-alt.yml
+++ b/src/main/resources/application-sds-progression-model-alt.yml
@@ -1,3 +1,4 @@
+# this version only exists to allow us to test on or after progression model commencement date scenarios in preprod ahead of time
 sds-legislations:
   progression-model-legislation:
     release-multiplier:
@@ -7,57 +8,57 @@ sds-legislations:
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 729
-        date: 2026-09-02
+        date: 2026-03-03
         name: TRANCHE_1
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 1094
-        date: 2026-10-13
+        date: 2026-04-07
         name: TRANCHE_2
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 1460
-        date: 2026-11-10
+        date: 2026-05-05
         name: TRANCHE_3
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 1825
-        date: 2026-12-08
+        date: 2026-06-09
         name: TRANCHE_4
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 2190
-        date: 2027-01-12
+        date: 2026-07-07
         name: TRANCHE_5
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 2921
-        date: 2027-02-09
+        date: 2026-08-11
         name: TRANCHE_6
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 3651
-        date: 2027-03-09
+        date: 2026-09-08
         name: TRANCHE_7
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 4747
-        date: 2027-04-13
+        date: 2026-10-06
         name: TRANCHE_8
 
       - type: SENTENCE_LENGTH
         unit: DAYS
         duration: 6208
-        date: 2027-05-11
+        date: 2026-11-10
         name: TRANCHE_9
 
       - type: FINAL
-        date: 2027-06-08
+        date: 2026-12-08
         name: TRANCHE_10


### PR DESCRIPTION
An alt progression model config with a commencement date in the past that allows us to test post-commencement scenarios in alt-preprod.

Also removed some dupe config in the regular progression model calc params.