### PR TITLE
CRS-2656: Would be SDS+ and Schedule 13 Part 3 exclusions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/EarlyReleaseSentenceFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/EarlyReleaseSentenceFilter.kt
@@ -16,7 +16,10 @@ enum class EarlyReleaseSentenceFilter {
   SDS_PROGRESSION_MODEL {
     override fun isIncluded(part: AbstractSentence): Boolean = part is StandardDeterminateSentence &&
       !part.releaseArrangements.isSection250 &&
-      listOf(SentenceIdentificationTrack.SDS, SentenceIdentificationTrack.SDS_PLUS).contains(part.identificationTrack)
+      listOf(SentenceIdentificationTrack.SDS, SentenceIdentificationTrack.SDS_PLUS).contains(part.identificationTrack) &&
+      !part.isRecall() &&
+      !part.releaseArrangements.wouldBeSDSPlusIfSentencedToday() &&
+      !part.releaseArrangements.hasProgressionModelExclusion()
   },
   SDS_OR_SDS_PLUS {
     override fun isIncluded(part: AbstractSentence): Boolean = listOf(SentenceIdentificationTrack.SDS, SentenceIdentificationTrack.SDS_PLUS).contains(part.identificationTrack)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
@@ -101,6 +101,6 @@ sealed interface SDSLegislation : Legislation {
 
     override fun commencementDate(): LocalDate = tranches.minOf { it.date }
 
-    override fun isSentenceSubjectToTraches(sentence: CalculableSentence) = sentence is StandardDeterminateSentence && filter.isIncluded(sentence) && !sentence.isRecall()
+    override fun isSentenceSubjectToTraches(sentence: CalculableSentence) = sentence is StandardDeterminateSentence && filter.isIncluded(sentence)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
@@ -19,7 +19,7 @@ enum class SDSEarlyReleaseExclusionType(
   SEXUAL_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
   DOMESTIC_ABUSE_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
   MURDER_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
-  SCHEDULE_13_PART_3(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true),
+  PROGRESSION_MODEL_SCHEDULE_13_PART_3(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true),
   NO(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangements.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangements.kt
@@ -2,11 +2,12 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 
 data class SDSReleaseArrangements(
   val isSDSPlus: Boolean,
-  val isSDSPlusEligibleSentenceTypeLengthAndOffence: Boolean, // would be SDS+ if sentenced today
+  val isSDSPlusEligibleSentenceTypeLengthAndOffence: Boolean,
   val sdsEarlyReleaseExclusions: List<SDSEarlyReleaseExclusionType>,
   val isSection250: Boolean,
 ) {
   fun hasSDS40EarlyReleaseExclusion(): Boolean = sdsEarlyReleaseExclusions.any { it.sds40Exclusion }
   fun hasSDS40AdditionalExcludedOffences(): Boolean = sdsEarlyReleaseExclusions.any { it.sds40AdditionalExcludedOffence }
   fun hasProgressionModelExclusion(): Boolean = sdsEarlyReleaseExclusions.any { it.progressionModelExclusion }
+  fun wouldBeSDSPlusIfSentencedToday(): Boolean = !isSDSPlus && isSDSPlusEligibleSentenceTypeLengthAndOffence
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseExclusionMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSEarlyReleaseExclusionMappingService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.OffenceSdsExclusionIndicator
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffence
@@ -9,7 +10,7 @@ import java.time.LocalDate
 import java.time.Period
 
 @Service
-class SDSEarlyReleaseExclusionMappingService {
+class SDSEarlyReleaseExclusionMappingService(private val sdsLegislationConfiguration: SDSLegislationConfiguration) {
 
   internal fun exclusionForOffence(
     exclusionsForOffence: List<OffenceSdsExclusionIndicator>,
@@ -18,7 +19,7 @@ class SDSEarlyReleaseExclusionMappingService {
     if (exclusionsForOffence.isEmpty()) {
       return emptyList()
     }
-    return exclusionsForOffence.map {
+    return exclusionsForOffence.mapNotNull {
       when (it) {
         OffenceSdsExclusionIndicator.SEXUAL -> SDSEarlyReleaseExclusionType.SEXUAL
         OffenceSdsExclusionIndicator.SEXUAL_T3 -> SDSEarlyReleaseExclusionType.SEXUAL_T3
@@ -28,18 +29,26 @@ class SDSEarlyReleaseExclusionMappingService {
         OffenceSdsExclusionIndicator.TERRORISM -> SDSEarlyReleaseExclusionType.TERRORISM
         OffenceSdsExclusionIndicator.MURDER_T3 -> SDSEarlyReleaseExclusionType.MURDER_T3
         OffenceSdsExclusionIndicator.VIOLENT -> evaluateViolentExclusion(sentenceAndOffence)
-        OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3 -> SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3
-        OffenceSdsExclusionIndicator.NONE -> SDSEarlyReleaseExclusionType.NO
+        OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3 -> evaluateSchedule13Part3Exclusion(sentenceAndOffence)
+        OffenceSdsExclusionIndicator.NONE -> null
       }
     }
   }
 
   private fun evaluateViolentExclusion(
     sentenceAndOffence: SentenceAndOffence,
-  ): SDSEarlyReleaseExclusionType = if (fourYearsOrMore(sentenceAndOffence)) {
+  ): SDSEarlyReleaseExclusionType? = if (fourYearsOrMore(sentenceAndOffence)) {
     SDSEarlyReleaseExclusionType.VIOLENT
   } else {
-    SDSEarlyReleaseExclusionType.NO
+    null
+  }
+
+  private fun evaluateSchedule13Part3Exclusion(
+    sentenceAndOffence: SentenceAndOffence,
+  ): SDSEarlyReleaseExclusionType? = if (sdsLegislationConfiguration.progressionModelLegislation != null && sentenceAndOffence.sentenceDate.isBefore(sdsLegislationConfiguration.progressionModelLegislation.commencementDate())) {
+    SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3
+  } else {
+    null
   }
 
   private fun fourYearsOrMore(sentence: SentenceAndOffence): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/EarlyReleaseSentenceFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/EarlyReleaseSentenceFilterTest.kt
@@ -87,7 +87,7 @@ class EarlyReleaseSentenceFilterTest {
       SDSEarlyReleaseExclusionType.SEXUAL_T3 -> true
       SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> true
       SDSEarlyReleaseExclusionType.MURDER_T3 -> true
-      SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3 -> true
+      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> true
       SDSEarlyReleaseExclusionType.NO -> true
     }
     assertThat(isIncluded).describedAs("isIncluded expected to be $expected for $exclusion").isEqualTo(expected)
@@ -122,7 +122,7 @@ class EarlyReleaseSentenceFilterTest {
       SDSEarlyReleaseExclusionType.SEXUAL_T3 -> true
       SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> true
       SDSEarlyReleaseExclusionType.MURDER_T3 -> true
-      SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3 -> false
+      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> false
       SDSEarlyReleaseExclusionType.NO -> false
     }
     assertThat(isIncluded).describedAs("isIncluded expected to be $expected for $exclusion").isEqualTo(expected)
@@ -166,6 +166,41 @@ class EarlyReleaseSentenceFilterTest {
     )
     sentence.identificationTrack = SentenceIdentificationTrack.SDS
     assertThat(EarlyReleaseSentenceFilter.SDS_PROGRESSION_MODEL.isIncluded(sentence)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(SDSEarlyReleaseExclusionType::class)
+  fun `SDS Progression Model should exclude only Schedule 13 Part 3`(exclusion: SDSEarlyReleaseExclusionType) {
+    val sentence = StandardDeterminateSentence(
+      sentencedAt = LocalDate.of(2000, 1, 1),
+      duration = FIVE_YEAR_DURATION,
+      offence = Offence(
+        committedAt = LocalDate.of(2000, 1, 1),
+        offenceCode = "123",
+      ),
+      releaseArrangements = SDSReleaseArrangements(
+        isSDSPlus = false,
+        isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+        isSection250 = false,
+        sdsEarlyReleaseExclusions = listOf(exclusion),
+      ),
+    )
+    sentence.identificationTrack = SentenceIdentificationTrack.SDS
+
+    val isIncluded = EarlyReleaseSentenceFilter.SDS_PROGRESSION_MODEL.isIncluded(sentence)
+    val expected = when (exclusion) {
+      SDSEarlyReleaseExclusionType.SEXUAL -> true
+      SDSEarlyReleaseExclusionType.VIOLENT -> true
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE -> true
+      SDSEarlyReleaseExclusionType.NATIONAL_SECURITY -> true
+      SDSEarlyReleaseExclusionType.TERRORISM -> true
+      SDSEarlyReleaseExclusionType.SEXUAL_T3 -> true
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> true
+      SDSEarlyReleaseExclusionType.MURDER_T3 -> true
+      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> false
+      SDSEarlyReleaseExclusionType.NO -> true
+    }
+    assertThat(isIncluded).describedAs("isIncluded expected to be $expected for $exclusion").isEqualTo(expected)
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislationTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExtendedDeter
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Recall
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecallType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SopcSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
@@ -182,6 +183,48 @@ class SDSLegislationTest {
           offenceCode = "123",
         ),
       )
+
+      assertThat(progressionModelLegislation.isSentenceSubjectToTraches(sentence)).isFalse
+    }
+
+    @Test
+    fun `Would be SDS+ sentences should not be subject tranches`() {
+      val sentence = StandardDeterminateSentence(
+        sentencedAt = LocalDate.of(2000, 1, 1),
+        duration = FIVE_YEAR_DURATION,
+        offence = Offence(
+          committedAt = LocalDate.of(2000, 1, 1),
+          offenceCode = "123",
+        ),
+        releaseArrangements = SDSReleaseArrangements(
+          isSDSPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = true,
+          isSection250 = false,
+          sdsEarlyReleaseExclusions = emptyList(),
+        ),
+      )
+      sentence.identificationTrack = SentenceIdentificationTrack.SDS
+
+      assertThat(progressionModelLegislation.isSentenceSubjectToTraches(sentence)).isFalse
+    }
+
+    @Test
+    fun `SDS sentence with Schedule 13 Part 3 exclusion should not be subject tranches`() {
+      val sentence = StandardDeterminateSentence(
+        sentencedAt = LocalDate.of(2000, 1, 1),
+        duration = FIVE_YEAR_DURATION,
+        offence = Offence(
+          committedAt = LocalDate.of(2000, 1, 1),
+          offenceCode = "123",
+        ),
+        releaseArrangements = SDSReleaseArrangements(
+          isSDSPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+          isSection250 = false,
+          sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3),
+        ),
+      )
+      sentence.identificationTrack = SentenceIdentificationTrack.SDS
 
       assertThat(progressionModelLegislation.isSentenceSubjectToTraches(sentence)).isFalse
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangementsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangementsTest.kt
@@ -62,7 +62,7 @@ class SDSReleaseArrangementsTest {
     val arrangements = SDSReleaseArrangements(
       isSDSPlus = false,
       isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
-      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3),
+      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3),
       isSection250 = false,
     )
     assertThat(arrangements.hasSDS40EarlyReleaseExclusion()).describedAs("hasSDS40EarlyReleaseExclusion").isFalse()
@@ -75,7 +75,7 @@ class SDSReleaseArrangementsTest {
     val arrangements = SDSReleaseArrangements(
       isSDSPlus = false,
       isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
-      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.SEXUAL, SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3),
+      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.SEXUAL, SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3),
       isSection250 = false,
     )
     assertThat(arrangements.hasSDS40EarlyReleaseExclusion()).describedAs("hasSDS40EarlyReleaseExclusion").isTrue()
@@ -88,7 +88,7 @@ class SDSReleaseArrangementsTest {
     val arrangements = SDSReleaseArrangements(
       isSDSPlus = false,
       isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
-      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.SEXUAL_T3, SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3),
+      sdsEarlyReleaseExclusions = listOf(SDSEarlyReleaseExclusionType.SEXUAL_T3, SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3),
       isSection250 = false,
     )
     assertThat(arrangements.hasSDS40EarlyReleaseExclusion()).describedAs("hasSDS40EarlyReleaseExclusion").isFalse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ReleaseArrangementLookupServiceTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -14,6 +15,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.OffenceSdsExclusionIndicator
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.PcscMarkers
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.SdsOffenceDetails
@@ -27,8 +30,20 @@ import java.time.LocalDate
 class ReleaseArrangementLookupServiceTest {
 
   private val mockManageOffencesService = mock<ManageOffencesService>()
-  private val sdsEarlyReleaseExclusionMappingService = SDSEarlyReleaseExclusionMappingService()
+  private val progressionModelLegislation = mock<SDSLegislation.ProgressionModelLegislation>()
+  private val sdsLegislationConfiguration = SDSLegislationConfiguration(
+    defaultLegislation = mock(),
+    sds40Legislation = mock(),
+    sds40AdditionalExcludedOffencesLegislation = mock(),
+    progressionModelLegislation = progressionModelLegislation,
+  )
+  private val sdsEarlyReleaseExclusionMappingService = SDSEarlyReleaseExclusionMappingService(sdsLegislationConfiguration)
   private val underTest = ReleaseArrangementLookupService(sdsEarlyReleaseExclusionMappingService, mockManageOffencesService)
+
+  @BeforeEach
+  fun setUp() {
+    whenever(progressionModelLegislation.commencementDate()).thenReturn(LocalDate.of(2026, 9, 2))
+  }
 
   @Test
   fun `SDS+ Marker set when sentenced after SDS and before PCSC and sentence longer than 7 Years with singular offence - List A`() {
@@ -296,19 +311,25 @@ class ReleaseArrangementLookupServiceTest {
     verify(mockManageOffencesService).getSdsOffenceDetailsForOffenceCodes(listOf(OFFENCE_CODE_NON_SDS_PLUS))
   }
 
-  @Test
-  fun `should set has an SDS exclusion if offence is schedule 13 part 3`() {
+  @ParameterizedTest
+  @CsvSource(
+    "2026-09-01,true",
+    "2026-09-02,false",
+    "2026-09-03,false",
+  )
+  fun `should set has an SDS exclusion if offence is schedule 13 part 3 sentenced before progression commencement but not on or after commencement`(sentenceDate: LocalDate, shouldBeExcluded: Boolean) {
     whenever(mockManageOffencesService.getSdsOffenceDetailsForOffenceCodes(listOf(OFFENCE_CODE_NON_SDS_PLUS))).thenReturn(
       listOf(
         nonSdsPlusExclusion(OFFENCE_CODE_NON_SDS_PLUS, listOf(OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3)),
       ),
     )
 
-    val withReleaseArrangements = underTest.populateReleaseArrangements(listOf(nonSDSPlusSentenceAndOffenceFourYears))
-    assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.isSDSPlus).isFalse()
-    assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.sdsEarlyReleaseExclusions.firstOrNull()).isEqualTo(SDSEarlyReleaseExclusionType.SCHEDULE_13_PART_3)
-
-    verify(mockManageOffencesService).getSdsOffenceDetailsForOffenceCodes(listOf(OFFENCE_CODE_NON_SDS_PLUS))
+    val withReleaseArrangements = underTest.populateReleaseArrangements(listOf(nonSDSPlusSentenceAndOffenceFourYears.copy(sentenceDate = sentenceDate)))
+    if (shouldBeExcluded) {
+      assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.sdsEarlyReleaseExclusions.firstOrNull()).isEqualTo(SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3)
+    } else {
+      assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.sdsEarlyReleaseExclusions).isEmpty()
+    }
   }
 
   @Test
@@ -337,7 +358,7 @@ class ReleaseArrangementLookupServiceTest {
     val nonSDSPlusSentenceLessThanFourYears = nonSDSPlusSentenceAndOffenceFourYears.copy(terms = listOf(SentenceTerms(3, 11, 0, 0)))
     val withReleaseArrangements = underTest.populateReleaseArrangements(listOf(nonSDSPlusSentenceLessThanFourYears))
     assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.isSDSPlus).isFalse()
-    assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.sdsEarlyReleaseExclusions.firstOrNull()).isEqualTo(SDSEarlyReleaseExclusionType.NO)
+    assertThat(withReleaseArrangements[0].sdsReleaseArrangements!!.sdsEarlyReleaseExclusions).isEmpty()
 
     verify(mockManageOffencesService, times(1)).getSdsOffenceDetailsForOffenceCodes(listOf(OFFENCE_CODE_NON_SDS_PLUS))
   }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac1-1.json
@@ -1,0 +1,33 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2020-01-28"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 15
+          }
+        },
+        "sentencedAt": "2020-01-28",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        }
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac2-1.json
@@ -1,0 +1,33 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2024-10-25"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2024-10-25",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        }
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac3-1.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2019-03-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2019-03-15",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2019-03-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 13
+          }
+        },
+        "sentencedAt": "2019-03-15",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac4-1.json
@@ -1,0 +1,51 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-01-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 6
+          }
+        },
+        "sentencedAt": "2022-01-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-05-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-05-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["DOMESTIC_ABUSE"],
+          "isSection250": false
+        }
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac5-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac5-1.json
@@ -1,0 +1,64 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-05-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-05-15",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [
+            "NATIONAL_SECURITY",
+            "PROGRESSION_MODEL_SCHEDULE_13_PART_3"
+          ],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-01-25"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-01-25",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-05-15",
+          "numberOfDays": 15,
+          "fromDate": "2025-04-30",
+          "toDate": "2025-05-14"
+        }
+      ]
+    }
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac6-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac6-1.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-05-10"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 7
+          }
+        },
+        "sentencedAt": "2022-05-10",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-05-10"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2022-05-10",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac7-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac7-1.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-05-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2025-05-15",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-05-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2025-05-15",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["SEXUAL"],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac7-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac7-2.json
@@ -1,0 +1,98 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-01-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2025-01-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-01-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2025-01-01",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["SEXUAL"],
+          "isSection250": false
+        },
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      },
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2025-01-01"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2025-01-01",
+        "identifier": "5dfde034-b7d7-4c54-a86c-67d42a1fd669",
+        "consecutiveSentenceUUIDs": [
+          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+        ]
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-01-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2025-01-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "5dfde034-b7d7-4c54-a86c-67d42a1fd669"
+        ]
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac8-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2656-ac8-1.json
@@ -1,0 +1,34 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-02"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2026-09-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "comment": "This is a schedule 13 part 3 offence sentenced on or after progression model commencement so wouldn't get the PM exclusion",
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY"],
+          "isSection250": false
+        }
+      }
+    ]
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac1-1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2035-01-27",
+    "CRD": "2027-07-29",
+    "ESED": "2035-01-27"
+  },
+  "effectiveSentenceLength": "P15Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac2-1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2028-10-24",
+    "CRD": "2026-10-25",
+    "ESED": "2028-10-24"
+  },
+  "effectiveSentenceLength": "P4Y",
+  "trancheAllocationByLegislationName": {}
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac3-1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2035-03-14",
+    "CRD": "2027-03-14",
+    "ESED": "2035-03-14"
+  },
+  "effectiveSentenceLength": "P16Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac4-1.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-04-30",
+    "CRD": "2026-10-30",
+    "ESED": "2028-04-30"
+  },
+  "effectiveSentenceLength": "P6Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac5-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac5-1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-04-29",
+    "CRD": "2026-10-29",
+    "ESED": "2028-05-14"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac6-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac6-1.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2033-05-09",
+    "CRD": "2027-04-13",
+    "ESED": "2033-05-09"
+  },
+  "effectiveSentenceLength": "P11Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_8"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac7-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac7-1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2031-05-14",
+    "CRD": "2028-05-14",
+    "ESED": "2031-05-14"
+  },
+  "effectiveSentenceLength": "P6Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac7-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac7-2.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2038-12-31",
+    "CRD": "2033-09-01",
+    "PED": "2032-01-02",
+    "ESED": "2038-12-31"
+  },
+  "effectiveSentenceLength": "P14Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_9"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac8-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2656-ac8-1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2029-09-01",
+    "CRD": "2027-09-02",
+    "ESED": "2029-09-01"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {}
+}


### PR DESCRIPTION
Schedule 13 Part 3 is only excluded on sentences before progression model commencement. Sentences that would be SDS+ if sentenced today are excluded from progression as they will also have an SDS40 exclusion so will be calculated at 50% which is the same as SDS+ under progression model.