### PR TITLE
CRS-2711: Increase postgres restore timeout

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,6 +26,7 @@ generic-service:
 
   postgresDatabaseRestore:
     enabled: true
+    timeout: 5400 # an hour and a half
     namespace_secrets:
       rds-instance-output:
         DB_NAME: "database_name"


### PR DESCRIPTION
Set to an hour and a half. The default is 40 minutes and we are timing out in prod currently.