### PR TITLE
CRS-2656: Fix unsupported sentence type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangements.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSReleaseArrangements.kt
@@ -10,4 +10,8 @@ data class SDSReleaseArrangements(
   fun hasSDS40AdditionalExcludedOffences(): Boolean = sdsEarlyReleaseExclusions.any { it.sds40AdditionalExcludedOffence }
   fun hasProgressionModelExclusion(): Boolean = sdsEarlyReleaseExclusions.any { it.progressionModelExclusion }
   fun wouldBeSDSPlusIfSentencedToday(): Boolean = !isSDSPlus && isSDSPlusEligibleSentenceTypeLengthAndOffence
+
+  companion object {
+    fun default() = SDSReleaseArrangements(isSDSPlus = false, isSDSPlusEligibleSentenceTypeLengthAndOffence = false, sdsEarlyReleaseExclusions = emptyList(), isSection250 = false)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceAndOffenceWithReleaseArrangements.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceAndOffenceWithReleaseArrangements.kt
@@ -57,12 +57,16 @@ data class SentenceAndOffenceWithReleaseArrangements(
     source.courtTypeCode,
     source.fineAmount,
     source.revocationDates,
-    SDSReleaseArrangements(
-      isSDSPlus = isSdsPlus,
-      isSDSPlusEligibleSentenceTypeLengthAndOffence = isSDSPlusEligibleSentenceTypeLengthAndOffence,
-      sdsEarlyReleaseExclusions = if (hasAnSDSExclusion == SDSEarlyReleaseExclusionType.NO) emptyList() else listOf(hasAnSDSExclusion),
-      isSection250 = SentenceCalculationType.from(source.sentenceCalculationType).isSection250(),
-    ),
+    if (SentenceCalculationType.from(source.sentenceCalculationType).isSDS()) {
+      SDSReleaseArrangements(
+        isSDSPlus = isSdsPlus,
+        isSDSPlusEligibleSentenceTypeLengthAndOffence = isSDSPlusEligibleSentenceTypeLengthAndOffence,
+        sdsEarlyReleaseExclusions = if (hasAnSDSExclusion == SDSEarlyReleaseExclusionType.NO) emptyList() else listOf(hasAnSDSExclusion),
+        isSection250 = SentenceCalculationType.from(source.sentenceCalculationType).isSection250(),
+      )
+    } else {
+      null
+    },
   )
 
   constructor(sentenceAndOffence: SentenceAndOffence, releaseArrangements: SDSReleaseArrangements?) : this(
@@ -112,11 +116,15 @@ data class SentenceAndOffenceWithReleaseArrangements(
     courtTypeCode = source.courtTypeCode,
     fineAmount = source.fineAmount,
     revocationDates = source.revocationDates,
-    sdsReleaseArrangements = SDSReleaseArrangements(
-      isSDSPlus = isSdsPlus,
-      isSDSPlusEligibleSentenceTypeLengthAndOffence = isSDSPlusEligibleSentenceTypeLengthAndOffence,
-      sdsEarlyReleaseExclusions = if (hasAnSDSExclusion == SDSEarlyReleaseExclusionType.NO) emptyList() else listOf(hasAnSDSExclusion),
-      isSection250 = SentenceCalculationType.from(source.sentenceCalculationType).isSection250(),
-    ),
+    sdsReleaseArrangements = if (SentenceCalculationType.from(source.sentenceCalculationType).isSDS()) {
+      SDSReleaseArrangements(
+        isSDSPlus = isSdsPlus,
+        isSDSPlusEligibleSentenceTypeLengthAndOffence = isSDSPlusEligibleSentenceTypeLengthAndOffence,
+        sdsEarlyReleaseExclusions = if (hasAnSDSExclusion == SDSEarlyReleaseExclusionType.NO) emptyList() else listOf(hasAnSDSExclusion),
+        isSection250 = SentenceCalculationType.from(source.sentenceCalculationType).isSection250(),
+      )
+    } else {
+      null
+    },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -94,6 +94,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Recall
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SopcSentence
@@ -252,9 +253,7 @@ fun transform(
         recall = recall,
       )
     }
-
-    // Fallback Sentence
-    else -> {
+    StandardDeterminateSentence::class.java -> {
       StandardDeterminateSentence(
         sentencedAt = sentence.sentenceDate,
         duration = transform(sentence.terms.firstOrNull() ?: SentenceTerms()),
@@ -267,6 +266,22 @@ fun transform(
         caseReference = sentence.caseReference,
         recall = recall,
         releaseArrangements = requireNotNull(sentence.sdsReleaseArrangements) { "SDS must have release arrangements populated" },
+      )
+    }
+    else -> {
+      // Fall back to standard determinate sentence with default release arrangements
+      StandardDeterminateSentence(
+        sentencedAt = sentence.sentenceDate,
+        duration = transform(sentence.terms.firstOrNull() ?: SentenceTerms()),
+        offence = offence,
+        identifier = generateUUIDForSentence(sentence.bookingId, sentence.sentenceSequence),
+        consecutiveSentenceUUIDs = consecutiveSentenceUUIDs,
+        caseSequence = sentence.caseSequence,
+        lineSequence = sentence.lineSequence,
+        externalSentenceId = externalSentenceId,
+        caseReference = sentence.caseReference,
+        recall = recall,
+        releaseArrangements = SDSReleaseArrangements.default(),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctionsTest.kt
@@ -607,7 +607,7 @@ class TransformFunctionsTest {
         ),
         sentenceStatus = "IMP",
         sentenceCategory = "CAT",
-        sentenceCalculationType = SentenceCalculationType.ADIMP.name,
+        sentenceCalculationType = type.name,
         sentenceTypeDescription = "Generic",
         offences = listOf(offence),
         lineSequence = lineSequence,


### PR DESCRIPTION
Unsupported sentence types are parsed as StandardDeterminateSentence for the purpose of display and analysis for the manual journey. These won't have the release arrangements populated.

Now only require release arrangements to be populated on actual SDS sentences and use default release arrangements for non-SDS offences. Fixed an issue with the transform function test which caused it not to fail for indeterminate sentences.