### PR TITLE
CRS-2697: Progression Model ADA handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSTrancheSelectionStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSTrancheSelectionStrategy.kt
@@ -32,14 +32,14 @@ abstract class SDSTrancheSelectionStrategy : TrancheSelectionStrategy {
       legislation: Legislation,
     ): Boolean {
       require(legislation is SDSLegislation.ProgressionModelLegislation) { "Tried to allocate incorrect legislation using SDSProgressionModelTrancheSelectionStrategy" }
-      val sentencesWithReleaseAfterTrancheCommencement = (timelineTrackingData.currentSentenceGroup + timelineTrackingData.licenceSentences).filter {
+      val sentencesWithReleaseAfterTrancheCommencement = (timelineTrackingData.currentSentenceGroup + timelineTrackingData.licenceSentences).filter { sentence ->
         // UAL awarded during custody for this sentence will have already been applied but if the UAL is on or after commencement then it shouldn't be
         // considered for tranche eligibility so subtract it from the calculated CRD
         val ualThatHasNotOccurredYet = timelineTrackingData.previousUalPeriods
           .filter { ual -> ual.first.isAfterOrEqualTo(legislation.commencementDate()) }
           .sumOf { ual -> ChronoUnit.DAYS.between(ual.first, ual.second) }
-        val adjustedDeterminateReleaseDateExcludingFutureUAL = it.sentenceCalculation.adjustedDeterminateReleaseDate.minusDays(ualThatHasNotOccurredYet)
-        adjustedDeterminateReleaseDateExcludingFutureUAL.isAfterOrEqualTo(legislation.commencementDate())
+        val adjustedDeterminateReleaseDateExcludingFutureUALAndAwardedDays = sentence.sentenceCalculation.releaseDateWithoutAwarded.minusDays(ualThatHasNotOccurredYet)
+        adjustedDeterminateReleaseDateExcludingFutureUALAndAwardedDays.isAfterOrEqualTo(legislation.commencementDate())
       }
       return sentencesWithReleaseAfterTrancheCommencement.any { sentence ->
         sentence.sentenceParts().any { sentencePart ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesService.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationWithTranches
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.TrancheName
@@ -18,9 +17,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeter
 import java.time.LocalDate
 
 @Service
-class SDSEarlyReleaseDefaultingRulesService(
-  val earlyReleaseConfigurations: SDSLegislationConfiguration,
-) {
+class SDS40EarlyReleaseDefaultingRulesService {
   fun applySDSEarlyReleaseRulesAndFinalizeDates(
     earlyReleaseResult: CalculationResult,
     preLegislationCalculation: PreLegislationCalculation,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+
+@Service
+class SDSProgressionModelFinalDatesService {
+
+  fun applyFinalDates(
+    earlyReleaseCalculation: CalculationResult,
+    preLegislationCalculation: PreLegislationCalculation,
+    adjustments: Adjustments,
+  ): CalculationResult {
+    val standardReleaseCalculation = preLegislationCalculation.beforeLegislationAppliedCalculationResult
+    val mergedDates = earlyReleaseCalculation.dates.toMutableMap()
+    val mergedBreakdown = earlyReleaseCalculation.breakdownByReleaseDateType.toMutableMap()
+    val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
+
+    // if there is no tranche then just accept the early release dates as-is
+    if (earliestApplicableDate != null) {
+      DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE.forEach { releaseDateType ->
+        val early = earlyReleaseCalculation.dates[releaseDateType]
+        val standard = standardReleaseCalculation.dates[releaseDateType]
+        val awardedDays = getAwardedDays(adjustments)
+
+        if (standard != null && standard.minusDays(awardedDays).isBefore(earliestApplicableDate)) {
+          // use the standard date as-is if it's before the tranche date unless they are serving ADAs over the tranche date in which case tranche defaulting applies
+          mergedDates[releaseDateType] = standard
+          standardReleaseCalculation.breakdownByReleaseDateType[releaseDateType]?.let { standardBreakdown -> mergedBreakdown[releaseDateType] = standardBreakdown }
+        } else if (early != null) {
+          // only default to tranche date if the release date excluding awarded is earlier. Awarded days are applied to the tranche date
+          if (early.minusDays(awardedDays).isBefore(earliestApplicableDate)) {
+            val earlyDefaultedToTracheWithAwarded = earliestApplicableDate.plusDays(awardedDays)
+            mergedDates[releaseDateType] = earlyDefaultedToTracheWithAwarded
+            earlyReleaseCalculation.breakdownByReleaseDateType[releaseDateType]?.let { earlyBreakdown ->
+              mergedBreakdown[releaseDateType] = earlyBreakdown.copy(
+                releaseDate = earlyDefaultedToTracheWithAwarded,
+              )
+            }
+          }
+        }
+        // the default is just to use the early release date
+      }
+    }
+
+    return CalculationResult(
+      dates = mergedDates,
+      breakdownByReleaseDateType = mergedBreakdown,
+      otherDates = earlyReleaseCalculation.otherDates,
+      effectiveSentenceLength = earlyReleaseCalculation.effectiveSentenceLength,
+      sentencesImpactingFinalReleaseDate = earlyReleaseCalculation.sentencesImpactingFinalReleaseDate,
+    )
+  }
+
+  private fun getAwardedDays(adjustments: Adjustments): Long = (adjustments.getOrEmptyList(AdjustmentType.ADDITIONAL_DAYS_AWARDED).sumOf { it.numberOfDays } - adjustments.getOrEmptyList(AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED).sumOf { it.numberOfDays }).toLong()
+
+  companion object {
+    private val DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE = listOf(
+      ReleaseDateType.CRD,
+      ReleaseDateType.PED,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.FTRLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.ADDITIONAL_DAYS_AWARDED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.RECALL_REMAND
@@ -22,7 +23,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOu
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalMovement
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceGroup
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SDSEarlyReleaseDefaultingRulesService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SDSProgressionModelFinalDatesService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.AwardedAdjustmentTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.ExternalMovementTimelineCalculationEvent
@@ -45,7 +46,6 @@ import java.time.LocalDate
 @Service
 class BookingTimelineService(
   private val workingDayService: WorkingDayService,
-  private val sdsEarlyReleaseDefaultingRulesService: SDSEarlyReleaseDefaultingRulesService,
   private val timelineCalculator: TimelineCalculator,
   private val timelineAwardedAdjustmentCalculationHandler: TimelineAwardedAdjustmentCalculationHandler,
   private val timelineSDSTrancheCalculationHandler: TimelineSDSTrancheCalculationHandler,
@@ -53,7 +53,8 @@ class BookingTimelineService(
   private val timelineSentenceCalculationHandler: TimelineSentenceCalculationHandler,
   private val timelineUalAdjustmentCalculationHandler: TimelineUalAdjustmentCalculationHandler,
   private val timelineExternalMovementCalculationHandler: TimelineExternalMovementCalculationHandler,
-  private val timelinePostTrancheAdjustmentService: TimelinePostTrancheAdjustmentService,
+  private val sds40FinalDatesService: SDS40FinalDatesService,
+  private val sdsProgressionModelFinalDatesService: SDSProgressionModelFinalDatesService,
   private val timelineSDSLegislationCommencementHandler: TimelineSDSLegislationCommencementHandler,
   private val timelineSDSLegislationAmendmentHandler: TimelineSDSLegislationAmendmentHandler,
   private val sdsLegislationConfiguration: SDSLegislationConfiguration,
@@ -143,20 +144,12 @@ class BookingTimelineService(
           returnToCustodyDate,
         )
 
-      if (beforeTrancheCalculation != null) {
+      beforeTrancheCalculation?.let { preLegislationCalculation ->
         val allSentences = releasedSentenceGroups.flatMap { it.sentences }
-        latestCalculation = sdsEarlyReleaseDefaultingRulesService.applySDSEarlyReleaseRulesAndFinalizeDates(
-          latestCalculation,
-          beforeTrancheCalculation!!,
-          allSentences,
-        )
-        val earliestApplicableDate = beforeTrancheCalculation?.legislationApplied?.earliestApplicableDate
-        if (earliestApplicableDate != null) {
-          latestCalculation = timelinePostTrancheAdjustmentService.applyTrancheAdjustmentLogic(
-            latestCalculation,
-            adjustments,
-            earliestApplicableDate,
-          )
+        latestCalculation = when (preLegislationCalculation.legislationApplied.legislation) {
+          is SDSLegislation.SDS40Legislation -> sds40FinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments, allSentences)
+          is SDSLegislation.ProgressionModelLegislation -> sdsProgressionModelFinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments)
+          else -> latestCalculation
         }
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/SDS40FinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/SDS40FinalDatesService.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SDS40EarlyReleaseDefaultingRulesService
+
+@Service
+class SDS40FinalDatesService(
+  private val sds40EarlyReleaseDefaultingRulesService: SDS40EarlyReleaseDefaultingRulesService,
+  private val timelinePostSDS40TrancheAdjustmentService: TimelinePostSDS40TrancheAdjustmentService,
+) {
+
+  fun applyFinalDates(earlyReleaseCalculation: CalculationResult, preLegislationCalculation: PreLegislationCalculation, adjustments: Adjustments, allSentences: List<CalculableSentence>): CalculationResult {
+    val calculationPostDefaulting = sds40EarlyReleaseDefaultingRulesService.applySDSEarlyReleaseRulesAndFinalizeDates(
+      earlyReleaseCalculation,
+      preLegislationCalculation,
+      allSentences,
+    )
+    val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
+    return if (earliestApplicableDate != null) {
+      timelinePostSDS40TrancheAdjustmentService.applyTrancheAdjustmentLogic(
+        calculationPostDefaulting,
+        adjustments,
+        earliestApplicableDate,
+      )
+    } else {
+      calculationPostDefaulting
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelinePostSDS40TrancheAdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelinePostSDS40TrancheAdjustmentService.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isBeforeOrEqua
 import java.time.LocalDate
 
 @Service
-class TimelinePostTrancheAdjustmentService {
+class TimelinePostSDS40TrancheAdjustmentService {
   fun applyTrancheAdjustmentLogic(
     calculation: CalculationResult,
     adjustments: Adjustments,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesServiceTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.EarlyReleaseSentenceFilter
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.TrancheConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.TrancheType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule
@@ -44,7 +43,7 @@ import java.time.temporal.ChronoUnit.YEARS
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
-class SDSEarlyReleaseDefaultingRulesServiceTest {
+class SDS40EarlyReleaseDefaultingRulesServiceTest {
 
   private val testCommencementDate = LocalDate.of(2024, 7, 29)
   private val testTrancheTwoCommencementDate = LocalDate.of(2024, 10, 22)
@@ -64,13 +63,9 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
     testTrancheThreeCommencementDate,
   )
 
-  val sdsLegislationConfiguration = SDSLegislationConfiguration(
-    defaultLegislation = SDSLegislation.DefaultSDSLegislation(mapOf(SentenceIdentificationTrack.SDS to ReleaseMultiplier.ONE_HALF, SentenceIdentificationTrack.SDS_PLUS to ReleaseMultiplier.TWO_THIRDS), EarlyReleaseSentenceFilter.SDS_OR_SDS_PLUS),
-    sds40Legislation = SDSLegislation.SDS40Legislation(trancheConfiguration.getSds40Tranches(), mapOf(SentenceIdentificationTrack.SDS to ReleaseMultiplier.FORTY_PERCENT), EarlyReleaseSentenceFilter.SDS_40_EXCLUSIONS),
-    sds40AdditionalExcludedOffencesLegislation = SDSLegislation.SDS40AdditionalExcludedOffencesLegislation(trancheConfiguration.trancheThreeCommencementDate, mapOf(SentenceIdentificationTrack.SDS to ReleaseMultiplier.ONE_HALF, SentenceIdentificationTrack.SDS_PLUS to ReleaseMultiplier.TWO_THIRDS), EarlyReleaseSentenceFilter.SDS_40_ADDITIONAL_EXCLUDED_OFFENCES),
-    progressionModelLegislation = null,
-  )
-  private val service = SDSEarlyReleaseDefaultingRulesService(sdsLegislationConfiguration)
+  val sds40Legislation = SDSLegislation.SDS40Legislation(trancheConfiguration.getSds40Tranches(), mapOf(SentenceIdentificationTrack.SDS to ReleaseMultiplier.FORTY_PERCENT), EarlyReleaseSentenceFilter.SDS_40_EXCLUSIONS)
+
+  private val service = SDS40EarlyReleaseDefaultingRulesService()
 
   @ParameterizedTest
   @CsvSource(
@@ -103,7 +98,7 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
     assertThat(
       service.applySDSEarlyReleaseRulesAndFinalizeDates(
         early,
-        PreLegislationCalculation(standard, ApplicableLegislation(sdsLegislationConfiguration.sds40Legislation, earlyReleaseTrancheOne.date)),
+        PreLegislationCalculation(standard, ApplicableLegislation(sds40Legislation, earlyReleaseTrancheOne.date)),
         createBookingWithSDSSentenceOfType(SentenceIdentificationTrack.SDS).sentences,
       ),
     ).isEqualTo(
@@ -264,7 +259,7 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
     assertThat(
       service.applySDSEarlyReleaseRulesAndFinalizeDates(
         early,
-        PreLegislationCalculation(standard, ApplicableLegislation(sdsLegislationConfiguration.sds40Legislation, earlyReleaseTrancheOne.date)),
+        PreLegislationCalculation(standard, ApplicableLegislation(sds40Legislation, earlyReleaseTrancheOne.date)),
         createBookingWithSDSSentenceOfType(SentenceIdentificationTrack.SDS).sentences,
       ),
     ).isEqualTo(
@@ -316,7 +311,7 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
     assertThat(
       service.applySDSEarlyReleaseRulesAndFinalizeDates(
         early,
-        PreLegislationCalculation(standard, ApplicableLegislation(sdsLegislationConfiguration.sds40Legislation, earlyReleaseTrancheOne.date)),
+        PreLegislationCalculation(standard, ApplicableLegislation(sds40Legislation, earlyReleaseTrancheOne.date)),
         createBookingWithSDSSentenceOfType(SentenceIdentificationTrack.SDS).sentences,
       ),
     ).isEqualTo(
@@ -362,7 +357,7 @@ class SDSEarlyReleaseDefaultingRulesServiceTest {
     assertThat(
       service.applySDSEarlyReleaseRulesAndFinalizeDates(
         early,
-        PreLegislationCalculation(standard, ApplicableLegislation(sdsLegislationConfiguration.sds40Legislation, earlyReleaseTrancheOne.date)),
+        PreLegislationCalculation(standard, ApplicableLegislation(sds40Legislation, earlyReleaseTrancheOne.date)),
         createBookingWithSDSSentenceOfType(
           SentenceIdentificationTrack.SDS,
           listOf(ReleaseDateType.CRD, ReleaseDateType.SLED),

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-1.json
@@ -1,0 +1,45 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-06-04"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 36
+          }
+        },
+        "sentencedAt": "2025-06-04",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2026-03-03",
+          "numberOfDays": 17,
+          "fromDate": "2026-03-03"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-2.json
@@ -1,0 +1,61 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2024-07-22"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 54
+          }
+        },
+        "sentencedAt": "2024-07-22",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [
+            "VIOLENT"
+          ],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2024-07-22",
+          "numberOfDays": 56,
+          "fromDate": "2024-05-27",
+          "toDate": "2024-07-21"
+        }
+      ],
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2026-03-03",
+          "numberOfDays": 17,
+          "fromDate": "2026-03-03"
+        }
+      ],
+      "RESTORATION_OF_ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2026-06-12",
+          "numberOfDays": 5
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-3.json
@@ -1,0 +1,73 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-23"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 19
+          }
+        },
+        "sentencedAt": "2025-10-23",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-23"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 19
+          }
+        },
+        "sentencedAt": "2025-10-23",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {
+      "TAGGED_BAIL": [
+        {
+          "appliesToSentencesFrom": "2025-10-23",
+          "numberOfDays": 8
+        }
+      ],
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2026-03-12",
+          "numberOfDays": 5,
+          "fromDate": "2026-03-12"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-4.json
@@ -1,0 +1,72 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2017-09-25"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 9
+          }
+        },
+        "sentencedAt": "2017-09-25",
+        "recall": {
+          "recallType": "STANDARD_RECALL",
+          "revocationDate": "2023-08-01"
+        },
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-08-07"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 7
+          }
+        },
+        "sentencedAt": "2023-08-07",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2023-12-15",
+          "numberOfDays": 5,
+          "fromDate": "2023-12-15"
+        },
+        {
+          "appliesToSentencesFrom": "2026-10-07",
+          "numberOfDays": 5,
+          "fromDate": "2026-10-07"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-5.json
@@ -1,0 +1,45 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-06-24"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2026-06-24",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2026-08-26",
+          "numberOfDays": 4,
+          "fromDate": "2026-08-26"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-6.json
@@ -1,0 +1,59 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2024-05-13"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2024-05-13"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-12-15"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-12-15",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2025-03-19",
+          "numberOfDays": 8,
+          "fromDate": "2025-03-19"
+        }
+      ]
+
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model"
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-7.json
@@ -1,0 +1,68 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2023-02-22"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2023-02-22",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-02-22"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2023-02-22",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2024-08-12",
+          "numberOfDays": 10,
+          "fromDate": "2024-08-12"
+        },
+        {
+          "appliesToSentencesFrom": "2026-09-26",
+          "numberOfDays": 10,
+          "fromDate": "2026-09-26"
+        }
+      ]
+
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model"
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2697-ac1-8.json
@@ -1,0 +1,65 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01"
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-01-09"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 6
+          }
+        },
+        "sentencedAt": "2023-01-09",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2023-01-09",
+          "numberOfDays": 21,
+          "fromDate": "2022-12-19",
+          "toDate": "2023-01-08"
+        }
+      ],
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2023-03-01",
+          "numberOfDays": 22,
+          "fromDate": "2023-03-01"
+        },
+        {
+          "appliesToSentencesFrom": "2023-09-01",
+          "numberOfDays": 22,
+          "fromDate": "2023-09-01"
+        },
+        {
+          "appliesToSentencesFrom": "2024-03-01",
+          "numberOfDays": 22,
+          "fromDate": "2024-03-01"
+        },
+        {
+          "appliesToSentencesFrom": "2024-09-01",
+          "numberOfDays": 22,
+          "fromDate": "2024-09-01"
+        }
+      ]
+
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model"
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-1.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2028-06-03",
+    "CRD": "2026-09-02",
+    "ESED": "2028-06-03"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {}
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-2.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-11-26",
+    "CRD": "2026-09-08",
+    "ESED": "2029-01-21"
+  },
+  "effectiveSentenceLength": "P4Y6M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_1"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-3.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-12-14",
+    "CRD": "2026-11-15",
+    "ESED": "2028-12-22"
+  },
+  "effectiveSentenceLength": "P3Y2M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-4.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2030-08-06",
+    "CRD": "2027-03-19",
+    "ESED": "2030-08-06"
+  },
+  "effectiveSentenceLength": "P12Y10M13D",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_7"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-5.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2029-06-23",
+    "CRD": "2027-06-28",
+    "ESED": "2029-06-23"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-6.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2030-05-12",
+    "CRD": "2028-05-20",
+    "PED": "2027-02-17",
+    "ESED": "2030-05-12"
+  },
+  "effectiveSentenceLength": "P6Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-7.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2032-02-21",
+    "CRD": "2028-11-12",
+    "PED": "2027-03-29",
+    "ESED": "2032-02-21"
+  },
+  "effectiveSentenceLength": "P9Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_7"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2697-ac1-8.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-12-18",
+    "CRD": "2027-03-17",
+    "ESED": "2029-01-08"
+  },
+  "effectiveSentenceLength": "P6Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  }
+}


### PR DESCRIPTION
Split out SDS early release finalisation for SDS40 and progression model.  Progression model defaulting excludes ADAs in consideration of the date and if defaulted to tranche commencement then ADAs should still be served.