### PR TITLE
CRS-2503: Add dates to tranche eligibility tests

### DIFF
--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -44,5 +45,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-10.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-10.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -29,5 +30,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-2.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -52,5 +53,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-3.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -53,5 +54,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-4.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -30,5 +31,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-5.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -29,5 +30,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-6.json
@@ -2,13 +2,14 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-01-01"
+          "committedAt": "2024-10-29"
         },
         "duration": {
           "durationElements": {
@@ -27,7 +28,7 @@
       {
         "type": "ExtendedDeterminateSentence",
         "offence": {
-          "committedAt": "2017-07-16"
+          "committedAt": "2023-06-17"
         },
         "custodialDuration": {
           "durationElements": {
@@ -47,5 +48,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-7.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -48,5 +49,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-8.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -46,5 +47,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac1-9.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -53,5 +54,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -63,5 +64,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-2.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -54,5 +55,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-3.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -55,7 +56,7 @@
         },
         "duration": {
           "durationElements": {
-            "YEARS": 3
+            "YEARS": 4
           }
         },
         "sentencedAt": "2025-05-16",
@@ -75,5 +76,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac2-4.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -55,8 +56,7 @@
         },
         "duration": {
           "durationElements": {
-            "YEARS": 1,
-            "MONTHS": 4
+            "MONTHS": 8
           }
         },
         "sentencedAt": "2026-09-15",
@@ -76,5 +76,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac3-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -47,5 +48,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac4-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -50,5 +51,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac5-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac5-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -46,5 +47,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac6-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac6-1.json
@@ -2,7 +2,8 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
@@ -47,5 +48,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac6-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2503-ac6-2.json
@@ -2,20 +2,21 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2000-01-01"
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2026-09-02"
+          "committedAt": "2026-09-20"
         },
         "duration": {
           "durationElements": {
             "MONTHS": 18
           }
         },
-        "sentencedAt": "2026-09-02",
+        "sentencedAt": "2026-09-20",
         "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
         "releaseArrangements": {
           "isSDSPlus": false,
@@ -27,14 +28,14 @@
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2026-01-23"
+          "committedAt": "2026-09-20"
         },
         "duration": {
           "durationElements": {
             "MONTHS": 4
           }
         },
-        "sentencedAt": "2026-09-03",
+        "sentencedAt": "2026-09-20",
         "consecutiveSentenceUUIDs": [
           "d211f333-aa1a-3e25-ac8d-0459c1f98868"
         ],
@@ -51,5 +52,8 @@
   "userInputs": {
     "useOffenceIndicators": true
   },
-  "params": "sds-progression-model"
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
 }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-1.json
@@ -1,5 +1,13 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2027-10-31",
+    "CRD": "2026-09-02",
+    "MTD": "2026-01-17",
+    "ETD": "2025-11-17",
+    "LTD": "2026-03-17",
+    "ESED": "2027-10-31"
+  },
+  "effectiveSentenceLength": "P2Y8M30D",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_1"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-10.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-10.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2042-05-22",
+    "CRD": "2030-05-23",
+    "ESED": "2042-05-22"
+  },
+  "effectiveSentenceLength": "P18Y",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_2",
     "SDS_PROGRESSION_MODEL": "TRANCHE_10"

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-2.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2027-08-22",
+    "CRD": "2026-09-29",
+    "ESED": "2027-08-22"
+  },
+  "effectiveSentenceLength": "P3Y5M11D",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_1",
     "FTR_56": "FTR_56_TRANCHE_1",

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-3.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2029-07-11",
+    "CRD": "2027-11-10",
+    "ESED": "2029-07-11"
+  },
+  "effectiveSentenceLength": "P3Y7M24D",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_3"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-4.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2029-06-24",
+    "CRD": "2026-09-06",
+    "ESED": "2029-06-24"
+  },
+  "effectiveSentenceLength": "P4Y8M",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_4"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-5.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2028-12-31",
+    "CRD": "2027-01-12",
+    "ESED": "2028-12-31"
+  },
+  "effectiveSentenceLength": "P5Y",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_5"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-6.json
@@ -1,5 +1,11 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2030-07-28",
+    "CRD": "2028-06-16 ",
+    "PED": "2027-02-09",
+    "ESED": "2030-07-28"
+  },
+  "effectiveSentenceLength": "P7Y1M12D",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_6"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-7.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2038-09-02",
+    "CRD": "2030-09-02",
+    "ESED": "2038-09-02"
+  },
+  "effectiveSentenceLength": "P14Y3M11D",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_2",
     "SDS_PROGRESSION_MODEL": "TRANCHE_7"

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-8.json
@@ -1,5 +1,11 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2030-12-31",
+    "CRD": "2029-12-31",
+    "PED": "2027-04-01",
+    "ESED": "2030-12-31"
+  },
+  "effectiveSentenceLength": "P12Y",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_8"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac1-9.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2038-02-14",
+    "CRD": "2028-12-14",
+    "ESED": "2038-02-14"
+  },
+  "effectiveSentenceLength": "P28Y11M3D",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_2",
     "SDS_PROGRESSION_MODEL": "TRANCHE_9"

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-1.json
@@ -1,5 +1,12 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SED": "2030-02-02",
+    "LED": "2029-09-26",
+    "CRD": "2027-09-25",
+    "PED": "2026-02-02",
+    "ESED": "2030-02-02"
+  },
+  "effectiveSentenceLength": "P8Y",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_2",
     "SDS_PROGRESSION_MODEL": "TRANCHE_6"

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-2.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2028-08-22",
+    "CRD": "2026-09-05",
+    "ESED": "2028-08-22"
+  },
+  "effectiveSentenceLength": "P3Y3M7D",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_3"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-3.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2036-05-15",
+    "CRD": "2029-09-15",
+    "ESED": "2036-05-15"
+  },
+  "effectiveSentenceLength": "P11Y",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_8"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac2-4.json
@@ -1,5 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2029-02-14",
+    "CRD": "2027-01-04",
+    "ESED": "2029-02-14"
+  },
+  "effectiveSentenceLength": "P3Y2M",
   "trancheAllocationByLegislationName": {
     "SDS_PROGRESSION_MODEL": "TRANCHE_2"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac3-1.json
@@ -1,4 +1,9 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2027-12-11",
+    "CRD": "2026-08-11",
+    "ESED": "2027-12-11"
+  },
+  "effectiveSentenceLength": "P4Y",
   "trancheAllocationByLegislationName": {}
 }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac4-1.json
@@ -1,5 +1,11 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2032-05-08",
+    "CRD": "2026-07-20",
+    "PED": "2024-10-22 ",
+    "ESED": "2032-05-08"
+  },
+  "effectiveSentenceLength": "P13Y",
   "trancheAllocationByLegislationName": {
     "SDS_40": "TRANCHE_2"
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac5-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac5-1.json
@@ -1,4 +1,10 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2034-08-29",
+    "CRD": "2032-08-29",
+    "PED": "2030-08-30",
+    "ESED": "2034-08-29"
+  },
+  "effectiveSentenceLength": "P8Y7M7D",
   "trancheAllocationByLegislationName": {}
 }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac6-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac6-1.json
@@ -1,4 +1,9 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2032-09-02",
+    "CRD": "2029-09-02",
+    "ESED": "2032-09-02"
+  },
+  "effectiveSentenceLength": "P6Y1D",
   "trancheAllocationByLegislationName": {}
 }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac6-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2503-ac6-2.json
@@ -1,4 +1,9 @@
 {
-  "skipAssertingDates": true,
+  "dates": {
+    "SLED": "2028-07-19",
+    "CRD": "2027-04-30",
+    "ESED": "2028-07-19"
+  },
+  "effectiveSentenceLength": "P1Y10M",
   "trancheAllocationByLegislationName": {}
 }


### PR DESCRIPTION
Originally we were only validating the tranche eligibility but now these tests check the dates as well and form part of the defaulting test coverage for progression model. Discovered a number of issues with the original test definitions which didn't impact tranche allocation but do impact the dates generated.