### PR TITLE
CRS-2663: Updated UAL scenarios for progression model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/OperativeSentenceEnvelopeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/OperativeSentenceEnvelopeController.kt
@@ -33,7 +33,7 @@ class OperativeSentenceEnvelopeController(private val operativeSentenceEnvelopeS
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "Operational sentence envelope data"),
+      ApiResponse(responseCode = "200", description = "Operative sentence envelope data"),
       ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
       ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
       ApiResponse(responseCode = "404", description = "Could not locate an appropriate source of data to determine the operative sentence envelope"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.Adjust
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import java.time.LocalDate
 
 @Service
 class SDSProgressionModelFinalDatesService {
@@ -19,6 +20,7 @@ class SDSProgressionModelFinalDatesService {
     val mergedDates = earlyReleaseCalculation.dates.toMutableMap()
     val mergedBreakdown = earlyReleaseCalculation.breakdownByReleaseDateType.toMutableMap()
     val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
+    val commencementDate = preLegislationCalculation.legislationApplied.legislation.commencementDate()
 
     // if there is no tranche then just accept the early release dates as-is
     if (earliestApplicableDate != null) {
@@ -34,7 +36,8 @@ class SDSProgressionModelFinalDatesService {
         } else if (early != null) {
           // only default to tranche date if the release date excluding awarded is earlier. Awarded days are applied to the tranche date
           if (early.minusDays(awardedDays).isBefore(earliestApplicableDate)) {
-            val earlyDefaultedToTracheWithAwarded = earliestApplicableDate.plusDays(awardedDays)
+            val ualPostProgression = getUalPostProgression(adjustments, commencementDate)
+            val earlyDefaultedToTracheWithAwarded = earliestApplicableDate.plusDays(awardedDays).plusDays(ualPostProgression)
             mergedDates[releaseDateType] = earlyDefaultedToTracheWithAwarded
             earlyReleaseCalculation.breakdownByReleaseDateType[releaseDateType]?.let { earlyBreakdown ->
               mergedBreakdown[releaseDateType] = earlyBreakdown.copy(
@@ -57,6 +60,11 @@ class SDSProgressionModelFinalDatesService {
   }
 
   private fun getAwardedDays(adjustments: Adjustments): Long = (adjustments.getOrEmptyList(AdjustmentType.ADDITIONAL_DAYS_AWARDED).sumOf { it.numberOfDays } - adjustments.getOrEmptyList(AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED).sumOf { it.numberOfDays }).toLong()
+
+  fun getUalPostProgression(adjustments: Adjustments, commencementDate: LocalDate) = adjustments.getOrEmptyList(AdjustmentType.UNLAWFULLY_AT_LARGE)
+    .filter { it.appliesToSentencesFrom >= commencementDate }
+    .sumOf { it.numberOfDays }
+    .toLong()
 
   companion object {
     private val DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE = listOf(

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-1.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2026-03-25",
+          "appliesToSentencesFrom": "2026-06-03",
           "numberOfDays": 10,
           "fromDate": "2026-06-03",
           "toDate": "2026-06-12",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-10.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-10.json
@@ -9,14 +9,14 @@
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-08-29"
+          "committedAt": "2024-10-22"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 33
+            "MONTHS": 60
           }
         },
-        "sentencedAt": "2025-08-29",
+        "sentencedAt": "2024-10-22",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
@@ -28,13 +28,12 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2026-08-30",
+          "appliesToSentencesFrom": "2026-06-24",
           "numberOfDays": 4,
-          "fromDate": "2026-08-30",
-          "toDate": "2026-09-02",
+          "fromDate": "2026-06-24",
+          "toDate": "2026-06-27",
           "additionalInfo": {
-            "type": "UAL",
-            "reason": "ESCAPE"
+            "type": "UAL"
           }
         }
       ]
@@ -44,7 +43,6 @@
     "useOffenceIndicators": true
   },
   "params": "sds-progression-model",
-  "expectedValidationException": "UNSUPPORTED_OUT_OF_CUSTODY_AT_PROGRESSION_MODEL_COMMENCEMENT",
   "featureToggles": {
     "applyPostRecallRepealRules": true
   }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-2.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-04-18",
+          "appliesToSentencesFrom": "2027-01-05",
           "numberOfDays": 14,
           "fromDate": "2027-01-05",
           "toDate": "2027-01-18",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-3.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-09-01",
+          "appliesToSentencesFrom": "2026-03-03",
           "numberOfDays": 5,
           "fromDate": "2026-03-03",
           "toDate": "2026-03-07",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-4.json
@@ -54,7 +54,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-06-30",
+          "appliesToSentencesFrom": "2025-08-30",
           "numberOfDays": 5,
           "fromDate": "2025-08-30",
           "toDate": "2025-09-03",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-5.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-08-29",
+          "appliesToSentencesFrom": "2026-08-29",
           "numberOfDays": 4,
           "fromDate": "2026-08-29",
           "toDate": "2026-09-01",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-6.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2008-05-14",
+          "appliesToSentencesFrom": "2008-07-20",
           "numberOfDays": 6617,
           "fromDate": "2008-07-20",
           "toDate": "2026-08-31",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-8.json
@@ -30,7 +30,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2024-11-10",
+          "appliesToSentencesFrom": "2026-08-29",
           "numberOfDays": 3,
           "fromDate": "2026-08-29",
           "toDate": "2026-08-31",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac1-9.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2024-04-13",
+          "appliesToSentencesFrom": "2024-08-23",
           "numberOfDays": 56,
           "fromDate": "2024-08-23",
           "toDate": "2024-10-17",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-2.json
@@ -13,7 +13,7 @@
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 30
+            "MONTHS": 33
           }
         },
         "sentencedAt": "2025-08-29",
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-08-29",
+          "appliesToSentencesFrom": "2026-09-01",
           "numberOfDays": 4,
           "fromDate": "2026-09-01",
           "toDate": "2026-09-04",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-3.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2008-05-14",
+          "appliesToSentencesFrom": "2008-07-20",
           "numberOfDays": 6618,
           "fromDate": "2008-07-20",
           "toDate": "2026-09-01",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-6.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2024-11-10",
+          "appliesToSentencesFrom": "2026-08-29",
           "numberOfDays": 4,
           "fromDate": "2026-08-29",
           "toDate": "2026-09-01",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-7.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-7.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2024-11-10",
+          "appliesToSentencesFrom": "2026-09-02",
           "numberOfDays": 4,
           "fromDate": "2026-09-02",
           "toDate": "2026-09-05",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-8.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-8.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-10-09",
+          "appliesToSentencesFrom": "2026-08-30",
           "numberOfDays": 6,
           "fromDate": "2026-08-30",
           "toDate": "2026-09-04",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-9.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac2-9.json
@@ -33,7 +33,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2023-11-16",
+          "appliesToSentencesFrom": "2026-08-28",
           "numberOfDays": 6,
           "fromDate": "2026-08-28",
           "toDate": "2026-09-02",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-1.json
@@ -9,14 +9,14 @@
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-01-23"
+          "committedAt": "2025-02-23"
         },
         "duration": {
           "durationElements": {
             "MONTHS": 48
           }
         },
-        "sentencedAt": "2025-01-23",
+        "sentencedAt": "2025-02-23",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2025-01-23",
+          "appliesToSentencesFrom": "2026-09-02",
           "numberOfDays": 4,
           "fromDate": "2026-09-02",
           "toDate": "2026-09-05",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-2.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2024-08-27",
+          "appliesToSentencesFrom": "2026-10-23",
           "numberOfDays": 6,
           "fromDate": "2026-10-23",
           "toDate": "2026-10-28",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-4.json
@@ -28,7 +28,7 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2023-11-29",
+          "appliesToSentencesFrom": "2026-09-03",
           "numberOfDays": 3,
           "fromDate": "2026-09-03",
           "toDate": "2026-09-05",

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2663-ac3-5.json
@@ -9,14 +9,14 @@
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-08-29"
+          "committedAt": "2025-08-14"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 33
+            "MONTHS": 40
           }
         },
-        "sentencedAt": "2025-08-29",
+        "sentencedAt": "2025-08-14",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
@@ -28,10 +28,20 @@
     "adjustments": {
       "UNLAWFULLY_AT_LARGE": [
         {
-          "appliesToSentencesFrom": "2026-08-30",
+          "appliesToSentencesFrom": "2025-12-04",
           "numberOfDays": 4,
-          "fromDate": "2026-08-30",
-          "toDate": "2026-09-02",
+          "fromDate": "2025-12-04",
+          "toDate": "2025-12-07",
+          "additionalInfo": {
+            "type": "UAL",
+            "reason": "ESCAPE"
+          }
+        },
+        {
+          "appliesToSentencesFrom": "2026-10-06",
+          "numberOfDays": 5,
+          "fromDate": "2026-10-06",
+          "toDate": "2026-10-10",
           "additionalInfo": {
             "type": "UAL",
             "reason": "ESCAPE"
@@ -44,7 +54,6 @@
     "useOffenceIndicators": true
   },
   "params": "sds-progression-model",
-  "expectedValidationException": "UNSUPPORTED_OUT_OF_CUSTODY_AT_PROGRESSION_MODEL_COMMENCEMENT",
   "featureToggles": {
     "applyPostRecallRepealRules": true
   }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac1-10.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac1-10.json
@@ -1,8 +1,8 @@
 {
   "dates": {
-    "SLED": "2030-05-01",
-    "CRD": "2027-01-26",
-    "ESED": "2030-04-17"
+    "SLED": "2029-10-25",
+    "CRD": "2026-10-26",
+    "ESED": "2029-10-21"
   },
   "effectiveSentenceLength": "P5Y",
   "trancheAllocationByLegislationName": {

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac3-1.json
@@ -1,9 +1,11 @@
 {
   "dates": {
-    "SLED": "2029-01-26",
-    "CRD": "2026-09-03",
-    "ESED": "2029-01-22"
+    "SLED": "2029-02-26",
+    "CRD": "2026-10-04",
+    "ESED": "2029-02-22"
   },
   "effectiveSentenceLength": "P4Y",
-  "trancheAllocationByLegislationName": {}
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL":"TRANCHE_4"
+  }
 }

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac3-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2663-ac3-5.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2028-12-22",
+    "CRD": "2026-11-15",
+    "ESED": "2028-12-13"
+  },
+  "effectiveSentenceLength": "P3Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  }
+}


### PR DESCRIPTION
On review of the UAL scenarios there were some that were invalid or missing. Included in that was the addition of post-progression UAL to a defaulted tranche commencement date.