### PR TITLE
CRS-2684: Update swagger for operative sentence envelope

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/OperativeSentenceEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/OperativeSentenceEnvelope.kt
@@ -5,14 +5,14 @@ import java.time.LocalDate
 
 @Schema
 data class OperativeSentenceEnvelope(
-  @param:Schema(description = "The length in days of the sentence envelope")
+  @param:Schema(description = "The length in days of the sentence envelope", example = "365")
   val sentenceEnvelopeLengthInDays: Long,
-  @param:Schema(description = "The date of the earliest sentence in the envelope")
+  @param:Schema(description = "The date of the earliest sentence in the envelope", example = "2013-06-21")
   val earliestSentenceStartDate: LocalDate,
-  @param:Schema(description = "Whether this is for a post recall sentence envelope. Null indicates this is unknown.")
+  @param:Schema(description = "Whether this is for a post recall sentence envelope. Null indicates this is unknown.", examples = ["true", "false", "null"])
   val isPostRecallSentenceEnvelope: Boolean?,
-  @param:Schema(description = "Whether the sentence envelope contains an SDS plus sentence or not. Null indicates this is unknown.")
+  @param:Schema(description = "Whether the sentence envelope contains an SDS plus sentence or not. Null indicates this is unknown.", examples = ["true", "false", "null"])
   val containsAnSDSPlusSentence: Boolean?,
-  @param:Schema(description = "The source of the data used to determine the operative sentence envelope")
+  @param:Schema(description = "The source of the data used to determine the operative sentence envelope", example = "CRDS")
   val sentenceEnvelopeSource: OperativeSentenceEnvelopeSource,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/OperativeSentenceEnvelopeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/OperativeSentenceEnvelopeController.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
 import arrow.core.getOrElse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -33,7 +35,41 @@ class OperativeSentenceEnvelopeController(private val operativeSentenceEnvelopeS
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "Operative sentence envelope data"),
+      ApiResponse(
+        responseCode = "200",
+        description = "Operative sentence envelope data",
+        content = [
+          Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            examples = [
+              ExampleObject(
+                name = "Sourced from CRDS",
+                value = """
+{
+  "sentenceEnvelopeLengthInDays": 365,
+  "earliestSentenceStartDate": "2013-06-21",
+  "isPostRecallSentenceEnvelope": true,
+  "containsAnSDSPlusSentence": false,
+  "sentenceEnvelopeSource": "CRDS"
+}
+  """,
+              ),
+              ExampleObject(
+                name = "Sourced from NOMIS",
+                value = """
+{
+  "sentenceEnvelopeLengthInDays": 365,
+  "earliestSentenceStartDate": "2013-06-21",
+  "isPostRecallSentenceEnvelope": null,
+  "containsAnSDSPlusSentence": null,
+  "sentenceEnvelopeSource": "NOMIS"
+}
+  """,
+              ),
+            ],
+          ),
+        ],
+      ),
       ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
       ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
       ApiResponse(responseCode = "404", description = "Could not locate an appropriate source of data to determine the operative sentence envelope"),


### PR DESCRIPTION
The default docs made it look like you wouldn't get null from NOMIS for SDS+ and recall flags