### PR TITLE
CRS-2730: Use 40% or 50% CRD for HDCED until disabled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType.HDCED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
 import java.time.LocalDate
@@ -20,9 +21,17 @@ class SDSProgressionModelFinalDatesService {
     val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
     val commencementDate = preLegislationCalculation.legislationApplied.legislation.commencementDate()
 
-    // default to the early release dates in the scenario no defaulting is required or there is no applicable tranche
+    // default to the early release dates for when there is no applicable tranche or further adjustment of dates required
     val mergedDates = earlyReleaseCalculation.dates.toMutableMap()
     val mergedBreakdown = earlyReleaseCalculation.breakdownByReleaseDateType.toMutableMap()
+
+   /*
+    * use the standard release date for HDC to support the operational recalculation period where progression model will
+    * be enabled but offenders can still be released on their HDCs calculated at 40% or 50% before commencement. Once
+    * progression model has commenced, calculation of HDC will be disabled for adult sentences.
+    */
+    standardReleaseCalculation.dates[HDCED]?.let { mergedDates[HDCED] = it }
+    standardReleaseCalculation.breakdownByReleaseDateType[HDCED]?.let { mergedBreakdown[HDCED] = it }
 
     if (earliestApplicableDate != null) {
       DATE_TYPES_TO_ADJUST_TO_COMMENCEMENT_DATE.forEach { releaseDateType ->

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2673-ac2-2a.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2673-ac2-2a.json
@@ -2,7 +2,7 @@
   "dates": {
     "SLED": "2028-06-02",
     "CRD": "2026-10-13",
-    "HDCED": "2026-05-05",
+    "HDCED": "2026-06-04",
     "ESED": "2028-06-02"
   },
   "effectiveSentenceLength": "P2Y6M"


### PR DESCRIPTION
Until HDC is disabled for adult sentences it should be calculated using a 40% or 50% CRD regardless of whether progression model is switched on or not.