### PR TITLE
CRS-2723: Apply PM defaulting everywhere

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/DefaultingOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/DefaultingOutcome.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
+
+enum class DefaultingOutcome {
+  RETAINED,
+  DEFAULTED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/DefaultingResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/DefaultingResult.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
+
+import java.time.LocalDate
+
+data class DefaultingResult(val date: LocalDate, val outcome: DefaultingOutcome)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
@@ -25,6 +25,12 @@ sealed interface SDSLegislation : Legislation {
 
   fun appliesToSentence(part: AbstractSentence) = filter.isIncluded(part)
 
+  fun applyDefaulting(calculatedDate: LocalDate, earliestApplicableDate: LocalDate?, awardedDays: Long, ualPostProgression: Long): DefaultingResult = if (earliestApplicableDate != null && earliestApplicableDate.isAfter(calculatedDate)) {
+    DefaultingResult(earliestApplicableDate, DefaultingOutcome.DEFAULTED)
+  } else {
+    DefaultingResult(calculatedDate, DefaultingOutcome.RETAINED)
+  }
+
   data class DefaultSDSLegislation(
     override val releaseMultiplier: Map<SentenceIdentificationTrack, ReleaseMultiplier>,
     override val filter: EarlyReleaseSentenceFilter,
@@ -102,5 +108,21 @@ sealed interface SDSLegislation : Legislation {
     override fun commencementDate(): LocalDate = tranches.minOf { it.date }
 
     override fun isSentenceSubjectToTraches(sentence: CalculableSentence) = sentence is StandardDeterminateSentence && filter.isIncluded(sentence)
+
+    /*
+     * ADAs and UAL occurring post progression should always be included in the final release dates. We remove them when comparing
+     * to the standard release date as if they would be due for release without them then they are not eligible for early release.
+     * We remove them when deciding whether to default to the tranche commencement date as they will be added to the tranche commencement
+     * date if they are defaulted and could be served twice in this scenario. If we did not add them to the tranche date then they
+     * may not be fully served.
+     */
+    override fun applyDefaulting(calculatedDate: LocalDate, earliestApplicableDate: LocalDate?, awardedDays: Long, ualPostProgression: Long): DefaultingResult {
+      val calculatedDateMinusAwardedAndUalPostProgression = calculatedDate.minusDays(awardedDays).minusDays(ualPostProgression)
+      return if (earliestApplicableDate != null && earliestApplicableDate.isAfter(calculatedDateMinusAwardedAndUalPostProgression)) {
+        DefaultingResult(earliestApplicableDate.plusDays(awardedDays).plusDays(ualPostProgression), DefaultingOutcome.DEFAULTED)
+      } else {
+        DefaultingResult(calculatedDate, DefaultingOutcome.RETAINED)
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceAdjustments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceAdjustments.kt
@@ -9,8 +9,9 @@ data class SentenceAdjustments(
   val ualDuringCustody: Long = 0,
   val awardedAfterDeterminateRelease: Long = 0,
   val ualAfterDeterminateRelease: Long = 0,
-  // UAL after FTR will also be included in the above UAL after determinate release.
+  // UAL after FTR and progression model will also be included in the above UAL after determinate release.
   val ualAfterFtr: Long = 0,
+  val ualAfterProgressionModel: Long = 0,
   val servedAdaDays: Long = 0,
   val unusedAdaDays: Long = 0,
   val unusedLicenceAdaDays: Long = 0,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalculation.kt
@@ -161,9 +161,9 @@ data class SentenceCalculation(
       _licenceExpiryDate = value
     }
 
-/*
- * This function will return the license expiry date at the point of initial release. If there was an immediate release and then a recall, more remand/tagged bail will be usable and therefore the license expiry will change, this returns the expiry before that change.
-*/
+  /*
+   * This function will return the license expiry date at the point of initial release. If there was an immediate release and then a recall, more remand/tagged bail will be usable and therefore the license expiry will change, this returns the expiry before that change.
+   */
   val licenceExpiryAtInitialRelease: LocalDate?
     get() {
       val adjustmentDaysForInitialRelease = adjustments.adjustmentsForInitialRelease()
@@ -197,13 +197,16 @@ data class SentenceCalculation(
       }
     }
 
-  fun releaseDateDefaultedByCommencement(): LocalDate = if (sentence.isRecall()) {
-    // PRRD is already adjusted for FTR56 commencement
-    adjustedPostRecallReleaseDate!!
-  } else if (isDateDefaultedToCommencement(adjustedDeterminateReleaseDate)) {
-    applicableSdsLegislation?.earliestApplicableDate!!
-  } else {
-    adjustedDeterminateReleaseDate
+  fun releaseDateDefaultedByCommencement(): LocalDate {
+    val applicableSdsLegislation = applicableSdsLegislation
+    return if (sentence.isRecall()) {
+      // PRRD is already adjusted for FTR56 commencement
+      adjustedPostRecallReleaseDate!!
+    } else if (applicableSdsLegislation != null && applicableSdsLegislation.earliestApplicableDate != null) {
+      applicableSdsLegislation.legislation.applyDefaulting(adjustedDeterminateReleaseDate, applicableSdsLegislation.earliestApplicableDate, adjustments.awardedDuringCustody, adjustments.ualAfterProgressionModel).date
+    } else {
+      adjustedDeterminateReleaseDate
+    }
   }
 
   val releaseDateWithoutDeductions: LocalDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.DefaultingOutcome
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType.HDCED
@@ -19,17 +21,19 @@ class SDSProgressionModelFinalDatesService {
   ): CalculationResult {
     val standardReleaseCalculation = preLegislationCalculation.beforeLegislationAppliedCalculationResult
     val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
-    val commencementDate = preLegislationCalculation.legislationApplied.legislation.commencementDate()
+    val legislation = preLegislationCalculation.legislationApplied.legislation
+    require(legislation is SDSLegislation.ProgressionModelLegislation) { "Using progression model defaulting rules for non-progression model legislation" }
+    val commencementDate = legislation.commencementDate()
 
     // default to the early release dates for when there is no applicable tranche or further adjustment of dates required
     val mergedDates = earlyReleaseCalculation.dates.toMutableMap()
     val mergedBreakdown = earlyReleaseCalculation.breakdownByReleaseDateType.toMutableMap()
 
-   /*
-    * use the standard release date for HDC to support the operational recalculation period where progression model will
-    * be enabled but offenders can still be released on their HDCs calculated at 40% or 50% before commencement. Once
-    * progression model has commenced, calculation of HDC will be disabled for adult sentences.
-    */
+    /*
+     * use the standard release date for HDC to support the operational recalculation period where progression model will
+     * be enabled but offenders can still be released on their HDCs calculated at 40% or 50% before commencement. Once
+     * progression model has commenced, calculation of HDC will be disabled for adult sentences.
+     */
     standardReleaseCalculation.dates[HDCED]?.let { mergedDates[HDCED] = it }
     standardReleaseCalculation.breakdownByReleaseDateType[HDCED]?.let { mergedBreakdown[HDCED] = it }
 
@@ -38,24 +42,19 @@ class SDSProgressionModelFinalDatesService {
         val early = earlyReleaseCalculation.dates[releaseDateType]
         val standard = standardReleaseCalculation.dates[releaseDateType]
 
-        /*
-         * ADAs and UAL occurring post progression should always be included in the final release dates. We remove them when comparing
-         * to the standard release date as if they would be due for release without them then they are not eligible for early release.
-         * We remove them when deciding whether to default to the tranche commencement date as they will be added to the tranche commencement
-         * date if they are defaulted and could be served twice in this scenario. If we did not add them to the tranche date then they
-         * may not be fully served.
-         */
-        val additionalDaysToBeAppliedPostCommencement = getAwardedDays(adjustments) + getUalPostProgression(adjustments, commencementDate)
+        val awardedDays = getAwardedDays(adjustments)
+        val ualPostProgression = getUalPostProgression(adjustments, commencementDate)
 
-        if (standard != null && standard.minusDays(additionalDaysToBeAppliedPostCommencement).isBefore(earliestApplicableDate)) {
+        // if the standard date is defaulted using PM rules then it was before the tranche date and should be retained here.
+        if (standard != null && legislation.applyDefaulting(standard, earliestApplicableDate, awardedDays, ualPostProgression).outcome == DefaultingOutcome.DEFAULTED) {
           mergedDates[releaseDateType] = standard
           standardReleaseCalculation.breakdownByReleaseDateType[releaseDateType]?.let { standardBreakdown -> mergedBreakdown[releaseDateType] = standardBreakdown }
-        } else if (early != null && early.minusDays(additionalDaysToBeAppliedPostCommencement).isBefore(earliestApplicableDate)) {
-          val earlyDefaultedToTracheWithAwarded = earliestApplicableDate.plusDays(additionalDaysToBeAppliedPostCommencement)
-          mergedDates[releaseDateType] = earlyDefaultedToTracheWithAwarded
+        } else if (early != null) {
+          val defaultingResult = legislation.applyDefaulting(early, earliestApplicableDate, awardedDays, ualPostProgression)
+          mergedDates[releaseDateType] = defaultingResult.date
           earlyReleaseCalculation.breakdownByReleaseDateType[releaseDateType]?.let { earlyBreakdown ->
             mergedBreakdown[releaseDateType] = earlyBreakdown.copy(
-              releaseDate = earlyDefaultedToTracheWithAwarded,
+              releaseDate = defaultingResult.date,
             )
           }
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculator.kt
@@ -138,6 +138,7 @@ class TimelineCalculator(
         awardedAfterDeterminateRelease = existingAdjustments.awardedAfterDeterminateRelease + adjustments.awardedAfterDeterminateRelease,
         ualAfterDeterminateRelease = existingAdjustments.ualAfterDeterminateRelease + adjustments.ualAfterDeterminateRelease,
         ualAfterFtr = existingAdjustments.ualAfterFtr + adjustments.ualAfterFtr,
+        ualAfterProgressionModel = existingAdjustments.ualAfterProgressionModel + adjustments.ualAfterProgressionModel,
 
         servedAdaDays = existingAdjustments.servedAdaDays + adjustments.servedAdaDays,
         unusedAdaDays = existingAdjustments.unusedAdaDays + adjustments.unusedAdaDays,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineUalAdjustmentCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineUalAdjustmentCalculationHandler.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAdjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.UALTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
@@ -13,6 +14,7 @@ import java.time.LocalDate
 @Service
 class TimelineUalAdjustmentCalculationHandler(
   timelineCalculator: TimelineCalculator,
+  private val sdsLegislationConfiguration: SDSLegislationConfiguration,
 ) : TimelineCalculationHandler<UALTimelineCalculationEvent>(timelineCalculator) {
   override fun handle(event: UALTimelineCalculationEvent, timelineTrackingData: TimelineTrackingData): TimelineHandleResult {
     with(timelineTrackingData) {
@@ -67,6 +69,16 @@ class TimelineUalAdjustmentCalculationHandler(
           ualAfterFtr = sentenceCalculation.adjustments.ualAfterFtr + ualAfterFtr,
         )
         sentenceCalculation.lastDayOfUal = lastDayOfUal
+      }
+
+      val progressionModelCommencementDate = sdsLegislationConfiguration.progressionModelLegislation?.commencementDate()
+      if (progressionModelCommencementDate != null && timelineCalculationDate.isAfterOrEqualTo(progressionModelCommencementDate)) {
+        sentencesAfterReleaseDate.forEach { sentence ->
+          val sentenceCalculation = sentence.sentenceCalculation
+          sentenceCalculation.adjustments = sentenceCalculation.adjustments.copy(
+            ualAfterProgressionModel = sentenceCalculation.adjustments.ualAfterProgressionModel + ualDays,
+          )
+        }
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/validator/AdjustmentsAfterReleaseDateValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/validation/validator/AdjustmentsAfterReleaseDateValidator.kt
@@ -35,6 +35,7 @@ class AdjustmentsAfterReleaseDateValidator : PostCalculationValidator {
     }
     return messages.toList()
   }
+
   private fun getSortedAdjustments(booking: Booking): List<Pair<AdjustmentType, Adjustment>> {
     val adas = booking.adjustments.getOrEmptyList(AdjustmentType.ADDITIONAL_DAYS_AWARDED)
       .map { AdjustmentType.ADDITIONAL_DAYS_AWARDED to it }
@@ -44,5 +45,6 @@ class AdjustmentsAfterReleaseDateValidator : PostCalculationValidator {
 
     return (adas + radas).sortedBy { it.second.appliesToSentencesFrom }
   }
+
   override fun validationOrder() = ValidationOrder.INVALID
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingAnonymiser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingAnonymiser.kt
@@ -15,11 +15,13 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SopcSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource.JsonTransformation
 import java.time.LocalDate
+import kotlin.test.Ignore
 
 /**
  * This test just takes a booking JSON file and anonymises any data and removes duplicate sentences.
  * Work in progress. Copy data from build file after.
  */
+@Ignore
 class BookingAnonymiser {
   private val jsonTransformation = JsonTransformation()
 


### PR DESCRIPTION
When using the sentence level release dates with defaulting the proper rules were not applied for progression model. Centralised this within SDS legislation so that the correct rules are applied in all places.