### PR TITLE
CRS-2694: Progression model - remove unconditional release

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/ApplicableLegislation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/ApplicableLegislation.kt
@@ -20,6 +20,7 @@ data class ApplicableLegislation<T : Legislation>(
       sentence.sentenceCalculation.unadjustedReleaseDate.calculationTrigger = sentence.sentenceCalculation.unadjustedReleaseDate.calculationTrigger.copy(
         timelineCalculationDate = timelineCalculationDate,
       )
+      legislation.modifyConditionalReleaseAndReleaseDateTypes(sentence)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.confi
 
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSTrancheSelectionStrategy.SDS40TrancheSelectionStrategy
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSTrancheSelectionStrategy.SDSProgressionModelTrancheSelectionStrategy
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.SentenceIdentificationTrack
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AbstractSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalMovementReason
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ReleaseMultiplier
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.ExternalMovementTimeline
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent
@@ -16,6 +18,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.Ti
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 sealed interface SDSLegislation : Legislation {
   val releaseMultiplier: Map<SentenceIdentificationTrack, ReleaseMultiplier>
@@ -30,6 +33,8 @@ sealed interface SDSLegislation : Legislation {
   } else {
     DefaultingResult(calculatedDate, DefaultingOutcome.RETAINED)
   }
+
+  fun modifyConditionalReleaseAndReleaseDateTypes(sentence: CalculableSentence) = Unit
 
   data class DefaultSDSLegislation(
     override val releaseMultiplier: Map<SentenceIdentificationTrack, ReleaseMultiplier>,
@@ -122,6 +127,22 @@ sealed interface SDSLegislation : Legislation {
         DefaultingResult(earliestApplicableDate.plusDays(awardedDays).plusDays(ualPostProgression), DefaultingOutcome.DEFAULTED)
       } else {
         DefaultingResult(calculatedDate, DefaultingOutcome.RETAINED)
+      }
+    }
+
+    /*
+     * Under progression model rules sentences of less than 12 months for offences committed before ORA are no longer
+     * eligible for unconditional release and should have CRD + SLED instead of ARD + SED.
+     */
+    override fun modifyConditionalReleaseAndReleaseDateTypes(sentence: CalculableSentence) {
+      if (sentence.durationIsLessThan(12, ChronoUnit.MONTHS) && sentence.offence.committedAt?.isBefore(ImportantDates.ORA_DATE) == true) {
+        sentence.sentenceCalculation.isReleaseDateConditional = true
+        val switchedArdAndSedForCrdAndSled = sentence.releaseDateTypes.initialTypes.toMutableList()
+        switchedArdAndSedForCrdAndSled += ReleaseDateType.SLED
+        switchedArdAndSedForCrdAndSled += ReleaseDateType.CRD
+        switchedArdAndSedForCrdAndSled -= ReleaseDateType.SED
+        switchedArdAndSedForCrdAndSled -= ReleaseDateType.ARD
+        sentence.releaseDateTypes = sentence.releaseDateTypes.copy(initialTypes = switchedArdAndSedForCrdAndSled)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/ReleaseDateTypes.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import java.time.temporal.ChronoUnit.MONTHS
 
-class ReleaseDateTypes(
+data class ReleaseDateTypes(
   val initialTypes: List<ReleaseDateType>,
   private val sentence: CalculableSentence,
   private val offender: Offender,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSentenceCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSentenceCalculationHandler.kt
@@ -112,6 +112,7 @@ class TimelineSentenceCalculationHandler(
         )
         sentence.sentenceCalculation.applicableFtrLegislation = applicableFtrLegislation
         sentence.sentenceCalculation.applicableSdsLegislation = applicableSdsLegislation
+        applicableSdsLegislation?.legislation?.modifyConditionalReleaseAndReleaseDateTypes(sentence)
       }
     }
   }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-1.json
@@ -1,0 +1,37 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-01-18"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 11
+          }
+        },
+        "sentencedAt": "2026-05-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-2.json
@@ -1,0 +1,37 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-01-18"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 10
+          }
+        },
+        "sentencedAt": "2026-10-12",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-3.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-04-27"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 14
+          }
+        },
+        "sentencedAt": "2026-04-27",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-11-03"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 11
+          }
+        },
+        "sentencedAt": "2026-08-16",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-4.json
@@ -1,0 +1,69 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-11-20"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 6
+          }
+        },
+        "sentencedAt": "2026-11-25",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-11-20"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 5
+          }
+        },
+        "sentencedAt": "2026-11-25",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ],
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2026-11-25",
+          "numberOfDays": 5,
+          "fromDate": "2026-11-20",
+          "toDate": "2026-11-24"
+        }
+      ]
+
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-5.json
@@ -1,0 +1,51 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-10-13"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 10
+          }
+        },
+        "sentencedAt": "2026-08-29",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "UNLAWFULLY_AT_LARGE": [
+        {
+          "appliesToSentencesFrom": "2026-08-29",
+          "numberOfDays": 4,
+          "fromDate": "2026-08-29",
+          "toDate": "2026-09-01",
+          "additionalInfo": {
+            "type": "UAL",
+            "reason": "SENTENCED_IN_ABSENCE"
+          }
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  },
+  "expectedValidationException": "UNSUPPORTED_OUT_OF_CUSTODY_AT_PROGRESSION_MODEL_COMMENCEMENT"
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2694-ac1-6.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-10-13"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 10
+          }
+        },
+        "sentencedAt": "2026-07-17",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2014-10-13"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 11
+          }
+        },
+        "sentencedAt": "2026-07-17",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-1.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2027-03-31",
+    "CRD": "2026-09-02",
+    "ESED": "2027-03-31"
+  },
+  "effectiveSentenceLength": "P11M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_1"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-2.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2027-08-11",
+    "CRD": "2027-01-21",
+    "ESED": "2027-08-11"
+  },
+  "effectiveSentenceLength": "P10M",
+  "trancheAllocationByLegislationName": {}
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-3.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2027-07-15",
+    "CRD": "2026-12-05",
+    "ESED": "2027-07-15"
+  },
+  "effectiveSentenceLength": "P1Y2M19D",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_1"
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-4.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SLED": "2027-10-19",
+    "CRD": "2027-03-11",
+    "ESED": "2027-10-24"
+  },
+  "effectiveSentenceLength": "P11M",
+  "trancheAllocationByLegislationName": {}
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2694-ac1-6.json
@@ -1,0 +1,9 @@
+{
+  "dates": {
+    "SED": "2027-06-16",
+    "ARD": "2026-12-31",
+    "ESED": "2027-06-16"
+  },
+  "effectiveSentenceLength": "P11M",
+  "trancheAllocationByLegislationName": {}
+}


### PR DESCRIPTION
Sentences under 12 months with an offence date before ORA were eligible for unconditional release (ARD + SED). Under progression model these sentences should now have a conditional release date (CRD + SLED).