### PR TITLE
CRS-2745: SDS descriptions for UI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -243,3 +243,7 @@ configure<KtlintExtension> {
     }
   }
 }
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.compilerOptions {
+  freeCompilerArgs.set(listOf("-Xannotation-default-target=param-property"))
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/CalculationRequest.kt
@@ -73,7 +73,7 @@ data class CalculationRequest(
   @Type(value = JsonType::class)
   @Column(columnDefinition = "jsonb")
   val sentenceAndOffences: JsonNode? = null,
-  val sentenceAndOffencesVersion: Int? = 3,
+  val sentenceAndOffencesVersion: Int? = 4,
 
   @NotNull
   @Type(value = JsonType::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AnalysedSentenceAndOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/AnalysedSentenceAndOffence.kt
@@ -24,5 +24,6 @@ data class AnalysedSentenceAndOffence(
   val sentenceAndOffenceAnalysis: SentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.SAME,
   val isSDSPlus: Boolean,
   val hasAnSDSEarlyReleaseExclusion: SDSEarlyReleaseExclusionType,
+  val sdsDescriptions: SDSDescriptions?,
   val revocationDates: List<LocalDate>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSDescriptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSDescriptions.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
+
+data class SDSDescriptions(
+  @Schema(description = "Any reason this sentence might be excluded from SDS40", nullable = true)
+  val sds40ExclusionDescription: String?,
+  @Schema(description = "Any reason this sentence might be excluded from Progression Model", nullable = true)
+  val progressionModelExclusionDescription: String?,
+  @Schema(description = "The way to display SDS plus status for the sentence", allowableValues = ["SDS+", "YOI+", "S250+"], nullable = true)
+  val sdsPlusDisplayName: String?,
+) {
+  companion object {
+    fun from(sentenceAndOffence: SentenceAndOffenceWithReleaseArrangements): SDSDescriptions? {
+      val releaseArrangements = sentenceAndOffence.sdsReleaseArrangements
+      val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffence.sentenceCalculationType)
+      return if (releaseArrangements != null && sentenceCalculationType.isSDS()) {
+        val progressionModelExclusionDescription = if (sentenceCalculationType == SentenceCalculationType.SEC91_03 || sentenceCalculationType == SentenceCalculationType.SEC91_03_ORA) {
+          "Section 91"
+        } else if (sentenceCalculationType.isSection250()) {
+          "Section 250"
+        } else if (releaseArrangements.hasProgressionModelExclusion()) {
+          releaseArrangements.sdsEarlyReleaseExclusions.firstOrNull { it.progressionModelExclusion }?.displayName
+        } else if (releaseArrangements.wouldBeSDSPlusIfSentencedToday()) {
+          "Would be ${sentenceCalculationType.sdsPlusDisplayName}"
+        } else {
+          null
+        }
+        SDSDescriptions(
+          sds40ExclusionDescription = releaseArrangements.sdsEarlyReleaseExclusions.firstOrNull { it.sds40Exclusion || it.sds40AdditionalExcludedOffence }?.displayName,
+          progressionModelExclusionDescription = progressionModelExclusionDescription,
+          sdsPlusDisplayName = if (releaseArrangements.isSDSPlus) sentenceCalculationType.sdsPlusDisplayName else null,
+        )
+      } else {
+        null
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
@@ -10,17 +10,18 @@ enum class SDSEarlyReleaseExclusionType(
   val sds40Exclusion: Boolean,
   val sds40AdditionalExcludedOffence: Boolean,
   val progressionModelExclusion: Boolean,
+  val displayName: String?,
 ) {
-  SEXUAL(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
-  VIOLENT(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
-  DOMESTIC_ABUSE(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
-  NATIONAL_SECURITY(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
-  TERRORISM(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
-  SEXUAL_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
-  DOMESTIC_ABUSE_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
-  MURDER_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false),
-  PROGRESSION_MODEL_SCHEDULE_13_PART_3(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true),
-  NO(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false),
+  SEXUAL(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = "Sexual"),
+  VIOLENT(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = "Violent"),
+  DOMESTIC_ABUSE(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = "Domestic Abuse"),
+  NATIONAL_SECURITY(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = "National Security"),
+  TERRORISM(sds40Exclusion = true, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = "Terrorism"),
+  SEXUAL_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false, displayName = "Sexual (for prisoners in custody on or after the 16th Dec 2024)"),
+  DOMESTIC_ABUSE_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false, displayName = "Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)"),
+  MURDER_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false, displayName = "Murder (for prisoners in custody on or after the 16th Dec 2024)"),
+  PROGRESSION_MODEL_SCHEDULE_13_PART_3(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true, displayName = "Schedule 13 Part 3"),
+  NO(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = null),
 }
 
 class SDSEarlyReleaseExclusionTypeDeserializer : StdDeserializer<SDSEarlyReleaseExclusionType>(SDSEarlyReleaseExclusionType::class.java) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SentenceCalculationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/SentenceCalculationType.kt
@@ -25,16 +25,17 @@ enum class SentenceCalculationType(
   val toreraEligibilityType: ToreraEligibilityType = ToreraEligibilityType.NONE,
   val sdsPlusEligibilityType: SDSPlusEligibilityType = SDSPlusEligibilityType.NONE,
   val displayName: String? = null,
+  val sdsPlusDisplayName: String? = null,
 ) {
   //region SDS / ORA Sentences
-  ADIMP(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS),
-  ADIMP_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS),
+  ADIMP(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS, sdsPlusDisplayName = "SDS+"),
+  ADIMP_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS, sdsPlusDisplayName = "SDS+"),
   SEC91_03(sentenceType = StandardDeterminate, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250),
   SEC91_03_ORA(sentenceType = StandardDeterminate, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250),
-  SEC250(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250),
-  SEC250_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250),
-  YOI(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS, displayName = "Young offender institution"),
-  YOI_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS),
+  SEC250(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250, sdsPlusDisplayName = "S250+"),
+  SEC250_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SECTION250, sdsPlusDisplayName = "S250+"),
+  YOI(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS, displayName = "Young offender institution", sdsPlusDisplayName = "YOI+"),
+  YOI_ORA(sentenceType = StandardDeterminate, toreraEligibilityType = ToreraEligibilityType.SDS, sdsPlusEligibilityType = SDSPlusEligibilityType.SDS, sdsPlusDisplayName = "YOI+"),
   //endregion
 
   //region Extended Determinate Sentences

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.adjustmentsapi.model.AdjustmentDto
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.exceptions.NoActiveBookingException
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationRequestModel
@@ -30,6 +31,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.NomisCalculat
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDatesAndCalculationContext
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonerDetails
@@ -41,6 +43,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.DetailedCal
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.LatestCalculationService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.OffenderKeyDatesService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.RelevantRemandService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.transform
 
 @RestController
 @RequestMapping("/calculation", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -233,6 +236,30 @@ class CalculationController(
   ): List<SentenceAndOffenceWithReleaseArrangements> {
     log.info("Request received to get sentences and offences from $calculationRequestId calculation")
     return calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId)
+  }
+
+  @GetMapping(value = ["/sentence-and-offence-information/{calculationRequestId}"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'RELEASE_DATES_CALCULATOR', 'CALCULATE_RELEASE_DATES__RECALL__CALCULATE__RW', 'CALCULATE_RELEASE_DATES__CALCULATE__RW', 'CALCULATE_RELEASE_DATES__CALCULATE__RO')")
+  @ResponseBody
+  @Operation(
+    summary = "Get sentences and offence information for display for a calculationRequestId",
+    description = "This endpoint will return the sentences and offence information for display based on a calculationRequestId",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Returns sentences and offences"),
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+      ApiResponse(responseCode = "403", description = "Forbidden, requires an appropriate role"),
+      ApiResponse(responseCode = "404", description = "No calculation exists for this calculationRequestId"),
+    ],
+  )
+  fun getSentenceAndOffenceInformation(
+    @Parameter(required = true, example = "123456", description = "The calculationRequestId of the calculation")
+    @PathVariable("calculationRequestId")
+    calculationRequestId: Long,
+  ): List<AnalysedSentenceAndOffence> {
+    log.info("Request received to get sentences and offence information from $calculationRequestId calculation")
+    return transform(SentenceAndOffenceAnalysis.SAME, calculationTransactionalService.findSentenceAndOffencesFromCalculation(calculationRequestId))
   }
 
   @GetMapping(value = ["/prisoner-details/{calculationRequestId}"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TransformFunctions.kt
@@ -93,6 +93,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Recall
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSDescriptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
@@ -905,6 +906,7 @@ fun transform(
   sentenceAndOffenceAnalysis,
   sentenceAndOffences.sdsReleaseArrangements?.isSDSPlus == true,
   sentenceAndOffences.sdsReleaseArrangements?.sdsEarlyReleaseExclusions?.firstOrNull() ?: SDSEarlyReleaseExclusionType.NO,
+  SDSDescriptions.from(sentenceAndOffences),
   sentenceAndOffences.revocationDates,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/integration/IntegrationTestBase.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.context.annotation.Import
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
@@ -40,7 +39,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecordARecall
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecordARecallRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RecordARecallValidationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.PrisonApiSentenceAndOffences
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
 /*
@@ -146,16 +144,6 @@ open class IntegrationTestBase internal constructor() {
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(CalculatedReleaseDates::class.java)
-    .returnResult().responseBody!!
-
-  protected fun getSentencesAndOffencesForCalculation(calculationId: Long) = webTestClient.get()
-    .uri("/calculation/sentence-and-offences/$calculationId")
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
-    .exchange()
-    .expectStatus().isOk
-    .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(object : ParameterizedTypeReference<List<PrisonApiSentenceAndOffences>>() {})
     .returnResult().responseBody!!
 
   protected fun createManualCalculation(prisonerId: String, request: ManualEntryRequest) = webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
@@ -1,0 +1,154 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.OffenderOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceTerms
+import java.time.LocalDate
+
+class SDSMetaDataTest {
+
+  @ParameterizedTest
+  @EnumSource(SDSEarlyReleaseExclusionType::class)
+  fun `should provide display name texts based on exclusions`(exclusion: SDSEarlyReleaseExclusionType) {
+    val expected = when (exclusion) {
+      SDSEarlyReleaseExclusionType.SEXUAL -> SDSDescriptions("Sexual", null, null)
+      SDSEarlyReleaseExclusionType.VIOLENT -> SDSDescriptions("Violent", null, null)
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE -> SDSDescriptions("Domestic Abuse", null, null)
+      SDSEarlyReleaseExclusionType.NATIONAL_SECURITY -> SDSDescriptions("National Security", null, null)
+      SDSEarlyReleaseExclusionType.TERRORISM -> SDSDescriptions("Terrorism", null, null)
+      SDSEarlyReleaseExclusionType.SEXUAL_T3 -> SDSDescriptions("Sexual (for prisoners in custody on or after the 16th Dec 2024)", null, null)
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> SDSDescriptions("Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)", null, null)
+      SDSEarlyReleaseExclusionType.MURDER_T3 -> SDSDescriptions("Murder (for prisoners in custody on or after the 16th Dec 2024)", null, null)
+      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> SDSDescriptions(null, "Schedule 13 Part 3", null)
+      SDSEarlyReleaseExclusionType.NO -> SDSDescriptions(null, null, null)
+    }
+    val result = SDSDescriptions.from(
+      ADIMP_SENTENCE.copy(
+        sdsReleaseArrangements = SDSReleaseArrangements(
+          isSDSPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+          sdsEarlyReleaseExclusions = listOf(exclusion),
+          isSection250 = false,
+        ),
+      ),
+    )
+    assertThat(result).isEqualTo(expected)
+  }
+
+  @ParameterizedTest
+  @CsvSource("SEC91_03", "SEC91_03_ORA")
+  fun `should provide progression model exclusion if it's a section 91`(sentenceCalculationType: String) {
+    val result = SDSDescriptions.from(
+      ADIMP_SENTENCE.copy(sentenceCalculationType = sentenceCalculationType),
+    )
+    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 91", null))
+  }
+
+  @ParameterizedTest
+  @CsvSource("SEC250", "SEC250_ORA")
+  fun `should provide progression model exclusion if it's a section 250`(sentenceCalculationType: String) {
+    val result = SDSDescriptions.from(
+      ADIMP_SENTENCE.copy(sentenceCalculationType = sentenceCalculationType),
+    )
+    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 250", null))
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "ADIMP,Would be SDS+",
+    "ADIMP_ORA,Would be SDS+",
+    "YOI,Would be YOI+",
+    "YOI_ORA,Would be YOI+",
+  )
+  fun `should provide progression model exclusion if it would be SDS+`(sentenceCalculationType: String, expected: String) {
+    val result = SDSDescriptions.from(
+      ADIMP_SENTENCE.copy(
+        sentenceCalculationType = sentenceCalculationType,
+        sdsReleaseArrangements = SDSReleaseArrangements(
+          isSDSPlus = false,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = true,
+          sdsEarlyReleaseExclusions = emptyList(),
+          isSection250 = false,
+        ),
+      ),
+    )
+    assertThat(result).isEqualTo(SDSDescriptions(null, expected, null))
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "ADIMP,SDS+",
+    "ADIMP_ORA,SDS+",
+    "YOI,YOI+",
+    "YOI_ORA,YOI+",
+    "SEC250,S250+",
+    "SEC250_ORA,S250+",
+  )
+  fun `should provide correct SDS+ display name`(sentenceCalculationType: String, expected: String) {
+    val result = SDSDescriptions.from(
+      ADIMP_SENTENCE.copy(
+        sentenceCalculationType = sentenceCalculationType,
+        sdsReleaseArrangements = SDSReleaseArrangements(
+          isSDSPlus = true,
+          isSDSPlusEligibleSentenceTypeLengthAndOffence = true,
+          sdsEarlyReleaseExclusions = emptyList(),
+          isSection250 = false,
+        ),
+      ),
+    )
+    assertThat(result?.sdsPlusDisplayName).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should have no exclusions`() {
+    val result = SDSDescriptions.from(ADIMP_SENTENCE)
+    assertThat(result).isEqualTo(SDSDescriptions(null, null, null))
+  }
+
+  @Test
+  fun `should return null if not SDS`() {
+    val result = SDSDescriptions.from(ADIMP_SENTENCE.copy(sentenceCalculationType = "SOPC21"))
+    assertThat(result).isNull()
+  }
+
+  companion object {
+    private val ADIMP_SENTENCE = SentenceAndOffenceWithReleaseArrangements(
+      bookingId = 1L,
+      sentenceSequence = 1,
+      lineSequence = 1,
+      caseSequence = 1,
+      sentenceDate = LocalDate.of(2012, 1, 1),
+      terms = listOf(
+        SentenceTerms(years = 5),
+      ),
+      sentenceStatus = "A",
+      sentenceCategory = "SEN",
+      sentenceCalculationType = "ADIMP",
+      sentenceTypeDescription = "DESC",
+      offence = OffenderOffence(
+        123,
+        LocalDate.of(2012, 1, 1),
+        LocalDate.of(2012, 1, 1),
+        "AB123DEF",
+        "finagling",
+        emptyList(),
+      ),
+      caseReference = null,
+      fineAmount = null,
+      courtId = null,
+      courtDescription = null,
+      courtTypeCode = null,
+      consecutiveToSequence = null,
+      sdsReleaseArrangements = SDSReleaseArrangements(
+        isSDSPlus = false,
+        isSDSPlusEligibleSentenceTypeLengthAndOffence = false,
+        sdsEarlyReleaseExclusions = emptyList(),
+        isSection250 = false,
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.adjustmentsapi.model.AdjustmentDto
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.wiremoc
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.OffenceSdsExclusionIndicator
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.PcscMarkers
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.manageoffencesapi.model.SdsOffenceDetails
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedReleaseDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationFragments
@@ -45,6 +46,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantReman
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandCalculationResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.RelevantRemandSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSDescriptions
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmitCalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.UserInputType
@@ -114,11 +117,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val result = webTestClient.get()
       .uri("/calculation/results/$PRISONER_ID/$BOOKING_ID")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody
 
@@ -142,11 +145,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val result = webTestClient.get()
       .uri("/calculationReference/${resultCalculation.calculationReference}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody
 
@@ -170,11 +173,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val result = webTestClient.get()
       .uri("/calculationReference/${resultCalculation.calculationReference}?checkForChange=true")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody
 
@@ -195,11 +198,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Get the results for a calc that causes an error `() {
     val result = webTestClient.post()
       .uri("/calculation/$PRISONER_ERROR_ID")
-      .accept(MediaType.APPLICATION_JSON).bodyValue(calculationRequestModel)
+      .accept(APPLICATION_JSON).bodyValue(calculationRequestModel)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().is5xxServerError
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody
 
@@ -219,7 +222,7 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Attempt to get the results for a confirmed calculation where no confirmed calculation exists`() {
     webTestClient.get()
       .uri("/calculation/results/$PRISONER_ID/$BOOKING_ID_DOESNT_EXIST")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().is4xxClientError
@@ -239,11 +242,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val result = webTestClient.get()
       .uri("/calculation/breakdown/${calc.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculationBreakdown::class.java)
       .returnResult().responseBody!!
 
@@ -268,11 +271,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     assertThat(calc).isNotNull
     val result = webTestClient.get()
       .uri("/calculation/results/$PRISONER_ID/$BOOKING_ID")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody
     assertThat(result!!.approvedDates).isNotNull
@@ -319,12 +322,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on inactive data`() {
     val calculatedReleaseDates: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/$INACTIVE_PRISONER_ID")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -332,11 +335,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val result = webTestClient.get()
       .uri("/calculation/breakdown/${calculatedReleaseDates.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculationBreakdown::class.java)
       .returnResult().responseBody!!
 
@@ -351,27 +354,47 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val results = webTestClient.get()
       .uri("/calculation/results/${calc.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
     assertThat(results.calculationFragments?.breakdownHtml).isEqualTo("<p>BREAKDOWN</p>")
 
-    val sentenceAndOffences = getSentencesAndOffencesForCalculation(calc.calculationRequestId)
-
-    assertThat(sentenceAndOffences).isNotNull
-
-    val prisonerDetails = webTestClient.get()
-      .uri("/calculation/prisoner-details/${calc.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+    // old API returns SentenceAndOffenceWithReleaseArrangements
+    val sentenceAndOffences = webTestClient.get()
+      .uri("/calculation/sentence-and-offences/${calc.calculationRequestId}")
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
+      .expectBody(object : ParameterizedTypeReference<List<SentenceAndOffenceWithReleaseArrangements>>() {})
+      .returnResult().responseBody!!
+    assertThat(sentenceAndOffences).isNotNull
+
+    // new API returns SentenceAndOffenceWithReleaseArrangements
+    val newSentenceAndOffencesWithMetaData = webTestClient.get()
+      .uri("/calculation/sentence-and-offence-information/${calc.calculationRequestId}")
+      .accept(APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(APPLICATION_JSON)
+      .expectBody(object : ParameterizedTypeReference<List<AnalysedSentenceAndOffence>>() {})
+      .returnResult().responseBody!!
+    assertThat(newSentenceAndOffencesWithMetaData).isNotNull
+
+    val prisonerDetails = webTestClient.get()
+      .uri("/calculation/prisoner-details/${calc.calculationRequestId}")
+      .accept(APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(PrisonerDetails::class.java)
       .returnResult().responseBody!!
 
@@ -379,11 +402,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val bookingAndSentenceAdjustments = webTestClient.get()
       .uri("/calculation/adjustments/${calc.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(BookingAndSentenceAdjustments::class.java)
       .returnResult().responseBody!!
 
@@ -391,11 +414,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val adjustments = webTestClient.get()
       .uri("/calculation/adjustments/${calc.calculationRequestId}?adjustments-api=true")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(object : ParameterizedTypeReference<List<AdjustmentDto>>() {})
       .returnResult().responseBody!!
 
@@ -405,11 +428,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val returnToCustody = webTestClient.get()
       .uri("/calculation/return-to-custody/${calc.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(ReturnToCustodyDate::class.java)
       .returnResult().responseBody!!
 
@@ -417,15 +440,81 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   }
 
   @Test
+  fun `Get the source sentence data with metadata for a booking or a calculation`() {
+    val userInput = CalculationUserInputs(useOffenceIndicators = true)
+
+    mockManageOffencesClient.withSdsOffenceDetailsResponse(
+      SdsOffenceDetails(
+        offenceCode = "TH68007A",
+        pcscMarkers = PcscMarkers(inListA = false, inListB = false, inListC = false, inListD = false),
+        earlyReleaseExclusions = listOf(OffenceSdsExclusionIndicator.SEXUAL),
+      ),
+      SdsOffenceDetails(
+        offenceCode = "TR68132",
+        pcscMarkers = PcscMarkers(inListA = false, inListB = false, inListC = false, inListD = false),
+        earlyReleaseExclusions = listOf(OffenceSdsExclusionIndicator.SEXUAL),
+      ),
+      SdsOffenceDetails(
+        offenceCode = "SX03001",
+        pcscMarkers = PcscMarkers(inListA = true, inListB = false, inListC = false, inListD = false),
+        earlyReleaseExclusions = emptyList(),
+      ),
+      offences = "SX03001,TH68007A,TR68132",
+    )
+
+    val calculation: CalculatedReleaseDates = webTestClient.post()
+      .uri("/calculation/CRS-872")
+      .accept(APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .contentType(APPLICATION_JSON)
+      .bodyValue(CalculationRequestModel(userInput, 1L))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(APPLICATION_JSON)
+      .expectBody(CalculatedReleaseDates::class.java)
+      .returnResult().responseBody!!
+
+    val bookingSentenceAndOffences = webTestClient.get()
+      .uri("/sentence-and-offence-information/${calculation.bookingId}")
+      .accept(APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(APPLICATION_JSON)
+      .expectBody(object : ParameterizedTypeReference<List<AnalysedSentenceAndOffence>>() {})
+      .returnResult().responseBody!!
+
+    val calculationSentenceAndOffences = webTestClient.get()
+      .uri("/calculation/sentence-and-offence-information/${calculation.calculationRequestId}")
+      .accept(APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(APPLICATION_JSON)
+      .expectBody(object : ParameterizedTypeReference<List<AnalysedSentenceAndOffence>>() {})
+      .returnResult().responseBody!!
+
+    val sdsPlusFromBooking = bookingSentenceAndOffences.find { it.offence.offenceCode == "SX03001" }!!
+    val sdsPlusFromCalculation = calculationSentenceAndOffences.find { it.offence.offenceCode == "SX03001" }!!
+    assertThat(sdsPlusFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions(null, null, "SDS+"))
+    assertThat(sdsPlusFromBooking).usingRecursiveComparison().ignoringFields("sentenceAndOffenceAnalysis").isEqualTo(sdsPlusFromCalculation)
+
+    val sexualExclusionFromBooking = bookingSentenceAndOffences.find { it.offence.offenceCode == "TR68132" }!!
+    val sexualExclusionFromCalculation = calculationSentenceAndOffences.find { it.offence.offenceCode == "TR68132" }!!
+    assertThat(sexualExclusionFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions("Sexual", null, null))
+    assertThat(sexualExclusionFromBooking).usingRecursiveComparison().ignoringFields("sentenceAndOffenceAnalysis").isEqualTo(sexualExclusionFromCalculation)
+  }
+
+  @Test
   fun `Run calculation on recall`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/RECALL")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -438,12 +527,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on 14 day fixed term recall`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/14FTR")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -456,12 +545,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on 28 day fixed term recall`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/28FTR")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -474,7 +563,7 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on 14 day fixed term recall with no returntocustodydate`() {
     webTestClient.post()
       .uri("/calculation/BLANKFTR")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
@@ -492,12 +581,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     mockManageOffencesClient.notSDSPlusAndNoExclusions(listOf("FI68421", "MD71131C", "MD71230", "MD71239"))
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-829-1")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -513,12 +602,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on pre prod bug where adjustments are applied to wrong sentences CRS-829 AC-2`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-829-2")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -557,13 +646,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-872")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
-      .contentType(MediaType.APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -592,12 +681,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-2321-1")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -621,12 +710,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-2321-2")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -650,12 +739,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-2321-3")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -679,12 +768,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-2321-4")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -696,12 +785,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     mockManageOffencesClient.notSDSPlusAndNoExclusions(listOf("CD79009", "TR68132"))
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/EDS")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -720,12 +809,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on SOPC sentence`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/SOPC")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -744,12 +833,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on adjustment linked to inactive sentence CRS-892`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-892")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .bodyValue(calculationRequestModel)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -773,13 +862,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/SEC250")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(CalculationRequestModel(userInput, 1L))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -796,12 +885,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     webTestClient = webTestClient.mutate().responseTimeout(Duration.ofMinutes(5)).build()
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/CRS-1184")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
     assertThat(calculation.dates[SED]).isEqualTo("2022-11-22")
@@ -815,12 +904,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation on A FINE sentence`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/AFINE")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -837,12 +926,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     mockManageOffencesClient.notSDSPlusAndNoExclusions(listOf("A1234BC"))
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/EDSRECALL")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -877,19 +966,19 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/SDSPERR")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
     webTestClient.post()
       .uri("/calculation/confirm/${calculation.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(
         objectMapper.writeValueAsString(
@@ -901,7 +990,7 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
       )
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
   }
@@ -940,13 +1029,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREM")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -990,13 +1079,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREM")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -1033,13 +1122,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREMT")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -1070,13 +1159,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREMR")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -1106,13 +1195,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREMV")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -1141,13 +1230,13 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
     )
     val calculation: RelevantRemandCalculationResult = webTestClient.post()
       .uri("/calculation/relevant-remand/RELREMI")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(objectMapper.writeValueAsString(request))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(RelevantRemandCalculationResult::class.java)
       .returnResult().responseBody!!
 
@@ -1159,12 +1248,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation with external movements`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/crs-2107")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel)
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -1180,12 +1269,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
   fun `Run calculation with ERS return external movements`() {
     val calculation: CalculatedReleaseDates = webTestClient.post()
       .uri("/calculation/ERSRETURN")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .bodyValue(calculationRequestModel.copy(calculationUserInputs = CalculationUserInputs(calculateErsed = true)))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculatedReleaseDates::class.java)
       .returnResult().responseBody!!
 
@@ -1201,11 +1290,11 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val breakdown = webTestClient.get()
       .uri("/calculation/breakdown/${calculation.calculationRequestId}")
-      .accept(MediaType.APPLICATION_JSON)
+      .accept(APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_RELEASE_DATES_CALCULATOR")))
       .exchange()
       .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().contentType(APPLICATION_JSON)
       .expectBody(CalculationBreakdown::class.java)
       .returnResult().responseBody!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceServiceTest.kt
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.entity.CalculationRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AnalysedSentenceAndOffence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSDescriptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSEarlyReleaseExclusionType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SDSReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceAnalysis
@@ -72,6 +73,7 @@ class SentenceAndOffenceServiceTest {
       isSDSPlus = false,
       hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
       sentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.NEW,
+      sdsDescriptions = SDSDescriptions(null, null, null),
       revocationDates = listOf(LocalDate.of(2024, 1, 1)),
     )
     assertThat(response[0]).isEqualTo(analysedSentenceAndOffence)


### PR DESCRIPTION
Add new API for getting historical sentence and offence data from a calculation that has the same type as when loading for a booking. Previously it was using SentenceAndOffenceWithReleaseArrangements which should be more for internal use.

Add SDS description information to that including SDS 40 exclusion reason, progression model exclusion reason and the way to display SDS plus offences based on sentence type. This removes some of the logic from the UI.

Fix issue where we're not storing the new data model with the correct version number.