### PR TITLE
CRS-2657: Affected by progression model flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/TrancheOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/entity/TrancheOutcome.kt
@@ -45,5 +45,8 @@ data class TrancheOutcome(
   @NotNull
   val affectedBySds40: Boolean = false,
 
+  @NotNull
+  val affectedByProgressionModel: Boolean = false,
+
   val outcomeDate: LocalDate? = LocalDate.now(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculableSentence.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.SentenceIdentificationTrack
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ReleaseMultiplier
@@ -188,5 +189,11 @@ interface CalculableSentence {
   fun isAffectedBySds40EarlyRelease(): Boolean = this.sentenceParts().any {
     it.identificationTrack == SentenceIdentificationTrack.SDS &&
       sentenceCalculation.unadjustedReleaseDate.multiplierForSentence(it) == ReleaseMultiplier.FORTY_PERCENT
+  }
+
+  @JsonIgnore
+  fun isAffectedBySdsProgressionModel(): Boolean = this.sentenceParts().any {
+    (it.identificationTrack == SentenceIdentificationTrack.SDS || it.identificationTrack == SentenceIdentificationTrack.SDS_PLUS) &&
+      sentenceCalculation.applicableSdsLegislation?.legislation?.legislationName == LegislationName.SDS_PROGRESSION_MODEL
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/CalculationResult.kt
@@ -17,6 +17,7 @@ data class CalculationResult(
   val sdsEarlyReleaseAllocatedTranche: TrancheName = TrancheName.TRANCHE_0,
   val sdsEarlyReleaseTranche: TrancheName = TrancheName.TRANCHE_0,
   val affectedBySds40: Boolean = false,
+  val affectedByProgressionModel: Boolean = false,
   val showSds40Hints: Boolean = true,
   val usedPreviouslyRecordedSLED: PreviouslyRecordedSLED? = null,
   val trancheAllocationByLegislationName: Map<LegislationName, TrancheName> = emptyMap(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.CalculationRule.ERSED_ADJUSTED_TO_MTD
@@ -138,6 +136,7 @@ class BookingExtractionService(
       false,
       historicalTusedSource,
       affectedBySds40 = isAffectedBySds40(sentence),
+      affectedByProgressionModel = isAffectedByProgressionModel(sentence),
       sentencesImpactingFinalReleaseDate = sentence.sentenceParts(),
     )
   }
@@ -336,7 +335,7 @@ class BookingExtractionService(
      *  --- PED ---
      *  only extract PED if date belongs to the active sentence
      **/
-    if (activeSentenceCalculation.releaseDateTypes.contains(PED)) {
+    val pedExtractionResult = if (activeSentenceCalculation.releaseDateTypes.contains(PED)) {
       extractPedForBooking(
         latestExtendedDeterminateParoleEligibilityDate,
         mostRecentSentenceByAdjustedDeterminateReleaseDate,
@@ -344,6 +343,8 @@ class BookingExtractionService(
         dates,
         breakdownByReleaseDateType,
       )
+    } else {
+      PedExtractionResult.NO_PED_REQUIRED
     }
 
     /** --- ERSED --- **/
@@ -371,13 +372,25 @@ class BookingExtractionService(
     /** --- ESED --- **/
     dates[ESED] = latestUnadjustedExpiryDate
 
-    val sds40EligibleReleaseTypes = listOf(CRD, ARD, HDCED, TUSED, PED, ERSED)
-
     val isAnyRelevantSentenceAffectedBySds40 = sentences.any { sentence ->
       isAffectedBySds40(sentence) &&
-        sds40EligibleReleaseTypes.any { type ->
-          val targetDate = dates[type] // only include the eligible types of dates
+        SDS40_ELIGIBLE_RELEASE_TYPES.any { type ->
+          val targetDate = dates[type]
           targetDate != null && sentence.sentenceCalculation.getDateByType(type) == targetDate
+        }
+    }
+
+    val isAnyRelevantSentenceAffectedByProgressionModel = sentences.any { sentence ->
+      isAffectedByProgressionModel(sentence) &&
+        PROGRESSION_MODEL_ELIGIBLE_RELEASE_TYPES.any { type ->
+          val targetDate = dates[type]
+          val targetType = if (type == ReleaseDateType.PED && pedExtractionResult == PedExtractionResult.PED_ADJUSTED_TO_NON_PED_RELEASE) {
+            // if the PED was adjusted to the CRD and the CRD was affected by progression model then the calculation was affected by progression
+            CRD
+          } else {
+            type
+          }
+          targetDate != null && sentence.sentenceCalculation.getDateByType(targetType) == targetDate
         }
     }
 
@@ -388,12 +401,16 @@ class BookingExtractionService(
       effectiveSentenceLength,
       ersedNotApplicableDueToDtoLaterThanCrd,
       affectedBySds40 = isAnyRelevantSentenceAffectedBySds40,
+      affectedByProgressionModel = isAnyRelevantSentenceAffectedByProgressionModel,
       sentencesImpactingFinalReleaseDate = sentencesImpactingFinalReleaseDate,
     )
   }
 
   private fun isAffectedBySds40(sentence: CalculableSentence): Boolean = !sentence.isRecall() &&
     sentence.isAffectedBySds40EarlyRelease()
+
+  private fun isAffectedByProgressionModel(sentence: CalculableSentence): Boolean = !sentence.isRecall() &&
+    sentence.isAffectedBySdsProgressionModel()
 
   fun extractCrdOrArd(
     mostRecentSentencesByReleaseDate: List<CalculableSentence>,
@@ -425,7 +442,7 @@ class BookingExtractionService(
     sentences: List<CalculableSentence>,
     dates: MutableMap<ReleaseDateType, LocalDate>,
     breakdownByReleaseDateType: MutableMap<ReleaseDateType, ReleaseDateCalculationBreakdown>,
-  ) {
+  ): PedExtractionResult {
     if (latestExtendedDeterminateParoleEligibilityDate != null) {
       val mostRecentReleaseSentenceParoleDate =
         mostRecentSentenceByAdjustedDeterminateReleaseDate.sentenceCalculation.extendedDeterminateParoleEligibilityDate
@@ -441,6 +458,7 @@ class BookingExtractionService(
           )
         ) {
           // SDS release is after PED, so no PED required.
+          return PedExtractionResult.SDS_RELEASE_AFTER_PED
         } else {
           if (latestNonPedRelease != null && latestExtendedDeterminateParoleEligibilityDate.isBefore(latestNonPedRelease)) {
             dates[PED] = latestNonPedRelease
@@ -455,16 +473,19 @@ class BookingExtractionService(
               releaseDate = dates[PED]!!,
               unadjustedDate = latestExtendedDeterminateParoleEligibilityDate,
             )
+            return PedExtractionResult.PED_ADJUSTED_TO_NON_PED_RELEASE
           } else {
             dates[PED] = latestExtendedDeterminateParoleEligibilityDate
             breakdownByReleaseDateType[PED] = ReleaseDateCalculationBreakdown(
               releaseDate = dates[PED]!!,
               unadjustedDate = latestExtendedDeterminateParoleEligibilityDate,
             )
+            return PedExtractionResult.LATEST_PED_USED
           }
         }
       }
     }
+    return PedExtractionResult.NO_PED_REQUIRED
   }
 
   private fun extractErsedAndNotApplicableDueToDtoLaterThanCrdFlag(
@@ -703,7 +724,15 @@ class BookingExtractionService(
     val canHaveLicenceExpiry: Boolean,
   )
 
+  private enum class PedExtractionResult {
+    NO_PED_REQUIRED,
+    PED_ADJUSTED_TO_NON_PED_RELEASE,
+    LATEST_PED_USED,
+    SDS_RELEASE_AFTER_PED,
+  }
+
   companion object {
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
+    private val SDS40_ELIGIBLE_RELEASE_TYPES = listOf(CRD, ARD, HDCED, TUSED, PED, ERSED)
+    private val PROGRESSION_MODEL_ELIGIBLE_RELEASE_TYPES = listOf(CRD, PED, ERSED)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/CalculationTransactionalService.kt
@@ -223,6 +223,7 @@ class CalculationTransactionalService(
         allocatedTranche = sds40TrancheName,
         tranche = sds40TrancheName,
         affectedBySds40 = calculationResult.affectedBySds40,
+        affectedByProgressionModel = calculationResult.affectedByProgressionModel,
         ftr56Tranche = calculationResult.trancheAllocationByLegislationName[LegislationName.FTR_56] ?: TrancheName.FTR_56_TRANCHE_0,
         progressionModelTranche = calculationResult.trancheAllocationByLegislationName[LegislationName.SDS_PROGRESSION_MODEL] ?: TrancheName.TRANCHE_0,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -67,6 +67,7 @@ class SDSProgressionModelFinalDatesService {
       otherDates = earlyReleaseCalculation.otherDates,
       effectiveSentenceLength = earlyReleaseCalculation.effectiveSentenceLength,
       sentencesImpactingFinalReleaseDate = earlyReleaseCalculation.sentencesImpactingFinalReleaseDate,
+      affectedByProgressionModel = mergedDates != standardReleaseCalculation.dates,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSentenceCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSentenceCalculationHandler.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.Ti
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.getSentencePartIdentifiers
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -96,9 +97,18 @@ class TimelineSentenceCalculationHandler(
     with(timelineTrackingData) {
       newSentencesToCalculate.forEach { sentence ->
         // Find the latest applicable legislation at the consecutive or single sentence level so that tranche defaulting
-        // occurs correctly even if the sentence parts might have different legislation applied.
+        // occurs correctly even if the sentence parts might have different legislation applied. If it was sentenced on or
+        // after commencement then tranche defaulting should not be applied.
         val applicableSdsLegislation = applicableSdsLegislations.legislationByCommencementDate()
           .find { (legislation, _) -> sentence.sentenceParts().any { part -> legislation.appliesToSentence(part) } }
+          ?.let {
+            if (it.earliestApplicableDate != null && timelineCalculationDate.isAfterOrEqualTo(it.legislation.commencementDate())) {
+              it.copy(earliestApplicableDate = null)
+            } else {
+              it
+            }
+          }
+
         sentence.sentenceCalculation = SentenceCalculation(
           UnadjustedReleaseDate(
             sentence,

--- a/src/main/resources/migration/common/V94__add_affected_by_progression_to_tranche_outcome.sql
+++ b/src/main/resources/migration/common/V94__add_affected_by_progression_to_tranche_outcome.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tranche_outcome ADD COLUMN affected_by_progression_model BOOLEAN NOT NULL DEFAULT false;
+COMMENT ON COLUMN tranche_outcome.affected_by_progression_model IS E'Description: Whether the release dates were affected by progression model. \nSource System: CRDS';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/calculation/CalculationExampleTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/calculation/CalculationExampleTests.kt
@@ -119,6 +119,11 @@ abstract class CalculationExampleTests : SpringTestBase() {
           calculatedReleaseDates.calculationResult.trancheAllocationByLegislationName,
         )
       }
+      if (expectedResult.affectedByProgressionModel != null) {
+        assertThat(calculatedReleaseDates.calculationResult.affectedByProgressionModel)
+          .describedAs("affectedByProgressionModel")
+          .isEqualTo(expectedResult.affectedByProgressionModel)
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/GenuineOverrideIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/GenuineOverrideIntTest.kt
@@ -66,12 +66,18 @@ class GenuineOverrideIntTest(private val mockPrisonService: MockPrisonService) :
     assertThat(originalRequest.genuineOverrideReason).isEqualTo(GenuineOverrideReason.AGGRAVATING_FACTOR_OFFENCE)
     assertThat(originalRequest.genuineOverrideReasonFurtherDetail).isNull()
     assertThat(originalRequest.calculationStatus).isEqualTo(CalculationStatus.OVERRIDDEN.name)
+    assertThat(originalRequest.allocatedSDSTranche)
+      .describedAs("CRS-2657 AC1.8 - Genuine override should store original tranche information")
+      .isNotNull()
 
     assertThat(newRequest.overridesCalculationRequestId).isEqualTo(originalRequest.id)
     assertThat(newRequest.overriddenByCalculationRequestId).isNull()
     assertThat(newRequest.genuineOverrideReason).isEqualTo(GenuineOverrideReason.AGGRAVATING_FACTOR_OFFENCE)
     assertThat(newRequest.genuineOverrideReasonFurtherDetail).isNull()
     assertThat(newRequest.calculationStatus).isEqualTo(CalculationStatus.CONFIRMED.name)
+    assertThat(newRequest.allocatedSDSTranche)
+      .describedAs("CRS-2657 AC1.8 - Genuine override should not store any tranche information on manual entered calculation")
+      .isNull()
 
     // Check the latest results are from the override
     val result = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/ManualCalculationIntTest.kt
@@ -2,16 +2,25 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.ReleaseDateType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualCalculationResponse
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManualEntryRequest
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ManuallyEnteredDate
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SubmittedDate
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.repository.CalculationRequestRepository
 import java.time.LocalDate
+import kotlin.jvm.optionals.getOrElse
+import kotlin.test.junit5.JUnit5Asserter.fail
 
+@Sql(scripts = ["classpath:/test_data/reset-base-data.sql", "classpath:/test_data/load-base-data.sql"])
 class ManualCalculationIntTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var calculationRequestRepository: CalculationRequestRepository
 
   @Test
   fun `Check if booking has indeterminate sentences`() {
@@ -67,6 +76,10 @@ class ManualCalculationIntTest : IntegrationTestBase() {
       .expectBody(ManualCalculationResponse::class.java)
       .returnResult().responseBody!!
     assertThat(response.calculationRequestId).isNotNull
+    val calcRequest = calculationRequestRepository.findById(response.calculationRequestId).getOrElse { fail("couldn't find calc request") }
+    assertThat(calcRequest.allocatedSDSTranche)
+      .describedAs("CRS-2657 AC1.5 - Manual calculation should not store any tranche information")
+      .isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/util/TestExpectedCalculationResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/util/TestExpectedCalculationResult.kt
@@ -14,6 +14,7 @@ data class TestExpectedCalculationResult(
   val affectedBySds40: Boolean? = null,
   val trancheAllocationByLegislationName: Map<LegislationName, TrancheName>? = null,
   val skipAssertingDates: Boolean? = null,
+  val affectedByProgressionModel: Boolean? = null,
 ) {
   init {
     require(dates != null || skipAssertingDates == true) { "dates are missing but you have not skipped asserting dates" }

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-1.json
@@ -1,0 +1,38 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-03-12"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2026-03-12",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["NATIONAL_SECURITY", "PROGRESSION_MODEL_SCHEDULE_13_PART_3"],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-2-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-2-1.json
@@ -1,0 +1,38 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-06-09"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-06-09",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-2-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-2-2.json
@@ -1,0 +1,38 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-06-13"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 40
+          }
+        },
+        "sentencedAt": "2025-06-13",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-3.json
@@ -1,0 +1,47 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-20"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 40
+          }
+        },
+        "sentencedAt": "2025-10-20",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-10-20",
+          "numberOfDays": 73,
+          "fromDate": "2025-08-08",
+          "toDate": "2025-10-19"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-6.json
@@ -1,0 +1,70 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2024-03-02"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "sentencedAt": "2024-03-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "recall": {
+          "recallType": "STANDARD_RECALL",
+          "returnToCustodyDate": "2026-05-01",
+          "revocationDate": "2026-05-01"
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-05-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-05-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-10-20",
+          "numberOfDays": 73,
+          "fromDate": "2025-08-08",
+          "toDate": "2025-10-19"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-7.json
@@ -1,0 +1,65 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-07-30"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-07-30",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": true
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-05"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-09-05",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": true
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-10-20",
+          "numberOfDays": 73,
+          "fromDate": "2025-08-08",
+          "toDate": "2025-10-19"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac1-9.json
@@ -1,0 +1,47 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-08-31"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 575
+          }
+        },
+        "sentencedAt": "2026-08-31",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2026-08-31",
+          "numberOfDays": 200,
+          "fromDate": "2026-02-12",
+          "toDate": "2026-08-30"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-1.json
@@ -1,0 +1,39 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2015-01-18"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 11
+          }
+        },
+        "sentencedAt": "2026-05-04",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true,
+    "calculateErsed": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-2.json
@@ -1,0 +1,59 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2019-10-29"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 6
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2019-10-29",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2019-10-29"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2019-10-29",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-3.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2022-11-10"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 6
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2022-11-10"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-07"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "sentencedAt": "2025-10-07",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac2-4.json
@@ -1,0 +1,39 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-06-01"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "sentencedAt": "2026-06-01",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true,
+    "calculateErsed": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-1.json
@@ -1,0 +1,56 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-28"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 30
+          }
+        },
+        "sentencedAt": "2025-10-28",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-11"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 2
+          }
+        },
+        "sentencedAt": "2026-09-11",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-2.json
@@ -1,0 +1,38 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-10-12"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-10-12",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-3.json
@@ -1,0 +1,59 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "SopcSentence",
+        "offence": {
+          "committedAt": "2025-10-28"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2025-10-28",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-11-19"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 6
+          }
+        },
+        "sentencedAt": "2026-11-19",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-4.json
@@ -1,0 +1,55 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "SopcSentence",
+        "offence": {
+          "committedAt": "2025-11-03"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2025-11-03"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-12-16"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2026-12-16",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2657-ac3-5.json
@@ -1,0 +1,57 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-08-03"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 14
+          }
+        },
+        "sentencedAt": "2026-08-03",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-02"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 5
+          }
+        },
+        "sentencedAt": "2026-09-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true,
+    "calculateErsed": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-1.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2030-03-11",
+    "CRD": "2028-03-11",
+    "ESED": "2030-03-11"
+  },
+  "effectiveSentenceLength": "P4Y",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-2-1.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2028-06-08",
+    "CRD": "2026-08-21",
+    "ESED": "2028-06-08"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-2-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-2-2.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-10-12",
+    "CRD": "2026-10-13",
+    "ESED": "2028-10-12"
+  },
+  "effectiveSentenceLength": "P3Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_4"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-3.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-12-08",
+    "CRD": "2026-12-08",
+    "ESED": "2029-02-19"
+  },
+  "effectiveSentenceLength": "P3Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_4"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-6.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2029-03-01",
+    "PRRD": "2029-03-01",
+    "ESED": "2029-03-01"
+  },
+  "effectiveSentenceLength": "P5Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_5"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-7.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2028-09-04",
+    "CRD": "2027-06-24",
+    "ESED": "2028-09-04"
+  },
+  "effectiveSentenceLength": "P2Y1M6D",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac1-9.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2027-09-09",
+    "CRD": "2026-09-29",
+    "ESED": "2028-03-27"
+  },
+  "effectiveSentenceLength": "P1Y6M28D",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_2"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-1.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2027-04-03",
+    "CRD": "2026-09-02",
+    "ERSED": "2026-06-14",
+    "ESED": "2027-04-03"
+  },
+  "effectiveSentenceLength": "P11M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_1"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-2.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2031-10-28",
+    "CRD": "2027-05-11",
+    "PED": "2025-06-04",
+    "ESED": "2031-10-28"
+  },
+  "effectiveSentenceLength": "P12Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_9"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-3.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2030-11-09",
+    "CRD": "2028-11-09",
+    "PED": "2027-06-07",
+    "ESED": "2030-11-09"
+  },
+  "effectiveSentenceLength": "P8Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_7"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac2-4.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2031-05-31",
+    "CRD": "2028-01-30",
+    "ERSED": "2027-01-12",
+    "ESED": "2031-05-31"
+  },
+  "effectiveSentenceLength": "P5Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_5"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-1.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-04-27",
+    "CRD": "2026-10-28",
+    "ESED": "2028-04-27"
+  },
+  "effectiveSentenceLength": "P2Y6M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-2.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2028-10-11",
+    "CRD": "2027-06-12",
+    "ESED": "2028-10-11"
+  },
+  "effectiveSentenceLength": "P2Y",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-3.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2030-04-27",
+    "CRD": "2028-12-27",
+    "PED": "2027-12-28",
+    "ESED": "2030-04-27"
+  },
+  "effectiveSentenceLength": "P4Y6M",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-4.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2029-12-15",
+    "CRD": "2028-11-02",
+    "PED": "2027-12-16",
+    "ESED": "2029-12-15"
+  },
+  "effectiveSentenceLength": "P4Y1M13D",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2657-ac3-5.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2027-10-02",
+    "CRD": "2026-12-22",
+    "ERSED": "2026-09-18",
+    "ESED": "2027-10-02"
+  },
+  "effectiveSentenceLength": "P1Y2M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_1"
+  },
+  "affectedByProgressionModel": true
+}


### PR DESCRIPTION
Add flag to db to highlight when a calculation was affected by progression model, this is similar to the affected by SDS40 flag.

It only applies when actually calculating dates and should not include instances where the dates do not come from sentences affected by progression model.

Also fixed issue where post-progression sentences could be defaulted to a tranche when selecting the sentence to extract. If that was a short sentence it could end up being an early release. (AC3.1)