### PR TITLE
CRS-2764: Apply defaulting to saved SDS40 calc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.FTRLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.ADDITIONAL_DAYS_AWARDED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.RECALL_REMAND
@@ -87,13 +86,14 @@ class BookingTimelineService(
     val externalMovementTimeline = ExternalMovementTimeline(externalMovements)
 
     val timelineTrackingData = TimelineTrackingData(
-      futureData,
-      calculationsByDate,
+      futureData = futureData,
+      calculationsByDate = calculationsByDate,
       latestRelease = earliestSentence.sentencedAt to earliestSentence,
-      returnToCustodyDate,
-      offender,
-      options,
-      externalMovementTimeline,
+      returnToCustodyDate = returnToCustodyDate,
+      offender = offender,
+      options = options,
+      externalMovements = externalMovementTimeline,
+      originalAdjustments = adjustments,
     )
 
     calculationsByDate.forEach { (timelineCalculationDate, calculations) ->
@@ -144,13 +144,11 @@ class BookingTimelineService(
           returnToCustodyDate,
         )
 
-      beforeTrancheCalculation?.let { preLegislationCalculation ->
-        val allSentences = releasedSentenceGroups.flatMap { it.sentences }
-        latestCalculation = when (preLegislationCalculation.legislationApplied.legislation) {
-          is SDSLegislation.SDS40Legislation -> sds40FinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments, allSentences)
-          is SDSLegislation.ProgressionModelLegislation -> sdsProgressionModelFinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments)
-          else -> latestCalculation
-        }
+      val allSentences = releasedSentenceGroups.flatMap { it.sentences }
+      if (LegislationName.SDS_PROGRESSION_MODEL in beforeTrancheCalculations) {
+        latestCalculation = sdsProgressionModelFinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_PROGRESSION_MODEL]!!, adjustments)
+      } else if (LegislationName.SDS_40 in beforeTrancheCalculations) {
+        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, adjustments, allSentences)
       }
 
       val sds40TrancheName = timelineTrackingData.trancheAllocationByLegislationName[LegislationName.SDS_40] ?: TrancheName.TRANCHE_0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineTrackingData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineTrackingData.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.TrancheName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
@@ -30,11 +31,12 @@ data class TimelineTrackingData(
   val previousUalPeriods: MutableList<Pair<LocalDate, LocalDate>> = mutableListOf(),
 
   var padas: Long = 0,
-  var beforeTrancheCalculation: PreLegislationCalculation? = null,
+  var beforeTrancheCalculations: MutableMap<LegislationName, PreLegislationCalculation> = mutableMapOf(),
 
   var applicableFtrLegislation: ApplicableLegislation<FTRLegislation>? = null,
   val applicableSdsLegislations: ApplicableSDSLegislations = ApplicableSDSLegislations(),
   val trancheAllocationByLegislationName: MutableMap<LegislationName, TrancheName> = mutableMapOf(),
+  val originalAdjustments: Adjustments,
 ) {
 
   lateinit var latestCalculation: CalculationResult

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
@@ -3,11 +3,13 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.h
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableLegislation.Companion.applyToSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationWithTranches
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.TrancheAllocationService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SDS40FinalDatesService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
@@ -17,7 +19,8 @@ import java.time.LocalDate
 @Service
 class TimelineSDSTrancheCalculationHandler(
   timelineCalculator: TimelineCalculator,
-  val trancheAllocationService: TrancheAllocationService,
+  private val trancheAllocationService: TrancheAllocationService,
+  private val sds40FinalDatesService: SDS40FinalDatesService,
 ) : TimelineCalculationHandler<SDSTrancheTimelineCalculationEvent>(timelineCalculator) {
 
   override fun handle(
@@ -44,8 +47,14 @@ class TimelineSDSTrancheCalculationHandler(
     val currentTimelineDateIsTheAllocatedTrancheDate = timelineCalculationDate == applicableLegislation?.earliestApplicableDate
     return if (applicableLegislation != null && currentTimelineDateIsTheAllocatedTrancheDate && sentencesToModifyReleaseDates.isNotEmpty()) {
       val allSentences = releasedSentenceGroups.map { it.sentences }.plus(listOf(currentSentenceGroup))
-      beforeTrancheCalculation = PreLegislationCalculation(
-        timelineCalculator.getLatestCalculation(allSentences, offender, returnToCustodyDate),
+      var latestCalculation = timelineCalculator.getLatestCalculation(allSentences, offender, returnToCustodyDate)
+      if (legislationToApply.legislationName == LegislationName.SDS_PROGRESSION_MODEL && LegislationName.SDS_40 in beforeTrancheCalculations) {
+        // if there was already an SDS40 tranche allocated then apply defaulting and adjustments at this point so that any SDS50 dates that were
+        // retained for SDS40 are used in the progression model defaulting and will likely still be retained then as well.
+        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, originalAdjustments, releasedSentenceGroups.flatMap { it.sentences })
+      }
+      beforeTrancheCalculations[legislationToApply.legislationName] = PreLegislationCalculation(
+        latestCalculation,
         applicableLegislation,
       )
       sentencesToModifyReleaseDates.forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/TrancheAllocationServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.TrancheSelectionStrategy
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.TrancheType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.TrancheName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOptions
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Duration
@@ -50,6 +51,7 @@ class TrancheAllocationServiceTest {
     offender = Offender("AB1234C", LocalDate.of(1980, 1, 1)),
     options = CalculationOptions(calculateErsed = false),
     externalMovements = ExternalMovementTimeline(emptyList()),
+    originalAdjustments = Adjustments(),
   )
 
   @BeforeEach

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-1.json
@@ -1,0 +1,192 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2012-07-30",
+          "offenceCode": "SX03002"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 16
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2013-06-21",
+        "identifier": "d5c31584-7eb7-336c-bf41-6e3824b0ea4a",
+        "caseReference": null
+      },
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2012-07-30",
+          "offenceCode": "SX03002"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 16
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2013-06-21",
+        "identifier": "2843e74e-bcfe-3e0f-b027-ffd455011e83",
+        "caseReference": null
+      },
+      {
+        "offence": {
+          "committedAt": "2004-09-12",
+          "offenceCode": "COML017"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2013-06-21",
+        "identifier": "f86a9af5-c62c-3464-93e6-5a5e3b7ce5aa",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2012-07-30",
+          "offenceCode": "COML017"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2013-06-21",
+        "identifier": "0fbe656b-2b34-3b8b-af3c-e974f6a7a726",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2012-07-30",
+          "offenceCode": "SX03007"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2013-06-21",
+        "identifier": "90647994-5daa-3d6c-8b78-8ef310b382c2",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [
+            "SEXUAL"
+          ],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2004-09-12",
+          "offenceCode": "SX03002"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 16
+          }
+        },
+        "sentencedAt": "2013-06-21",
+        "identifier": "898d67cf-5c03-31f5-8c96-6a59e5cd38a4",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [
+            "SEXUAL"
+          ],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2014-04-07",
+          "offenceCode": "CD71017"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2015-01-09",
+        "identifier": "7105d0bf-bf1b-3e43-9233-1d7a1e338d2e",
+        "consecutiveSentenceUUIDs": [
+          "d5c31584-7eb7-336c-bf41-6e3824b0ea4a"
+        ],
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2013-06-21",
+          "numberOfDays": 185,
+          "fromDate": "2012-12-18",
+          "toDate": "2013-06-20",
+          "additionalInfo": {
+            "type": "NONE"
+          }
+        }
+      ]
+    },
+    "externalMovements": [
+      {
+        "movementDate": "2015-06-04",
+        "movementReason": "SENTENCE",
+        "direction": "IN"
+      },
+      {
+        "movementDate": "2016-07-04",
+        "movementReason": "SENTENCE",
+        "direction": "IN"
+      }
+    ]
+  },
+  "userInputs": {
+    "calculateErsed": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-2.json
@@ -1,0 +1,117 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2013-09-21",
+          "offenceCode": "TH68023"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 9
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2014-01-24",
+        "identifier": "c3dadd1a-6469-3991-919b-7375109b1259",
+        "caseReference": null
+      },
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2013-09-22",
+          "offenceCode": "FI68076"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 6
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2014-01-24",
+        "identifier": "754dbff1-97cd-3456-af56-52a1d1f8b84d",
+        "consecutiveSentenceUUIDs": [
+          "c3dadd1a-6469-3991-919b-7375109b1259"
+        ],
+        "caseReference": null
+      },
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2013-09-20",
+          "offenceCode": "TH68023"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2014-01-24",
+        "identifier": "c512b733-09eb-3cce-bbcd-df81d9b1da09",
+        "caseReference": null
+      },
+      {
+        "offence": {
+          "committedAt": "2016-04-08",
+          "offenceCode": "CJ91015-034N"
+        },
+        "duration": {
+          "durationElements": {
+            "WEEKS": 8
+          }
+        },
+        "sentencedAt": "2016-11-22",
+        "identifier": "a8f6b33d-2afb-3321-b2c4-13b69440a334",
+        "consecutiveSentenceUUIDs": [
+          "754dbff1-97cd-3456-af56-52a1d1f8b84d"
+        ],
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2014-01-24",
+          "numberOfDays": 122,
+          "fromDate": "2013-09-24",
+          "toDate": "2014-01-23",
+          "additionalInfo": {
+            "type": "NONE"
+          }
+        }
+      ]
+    }
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2764-example-3.json
@@ -1,0 +1,124 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2018-08-08",
+          "offenceCode": "OF61017"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "MONTHS": 8,
+            "YEARS": 8
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "automaticRelease": false,
+        "sentencedAt": "2018-10-15",
+        "identifier": "e4c5d74c-cea6-33a5-ba59-20d35ba5d664",
+        "caseReference": null
+      },
+      {
+        "offence": {
+          "committedAt": "2018-08-07",
+          "offenceCode": "OF61102"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 18
+          }
+        },
+        "sentencedAt": "2018-10-15",
+        "identifier": "2411de62-f06c-38cc-ad00-22c8755ec244",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2017-11-06",
+          "offenceCode": "TH68036"
+        },
+        "duration": {
+          "durationElements": {
+            "WEEKS": 26
+          }
+        },
+        "sentencedAt": "2018-10-15",
+        "identifier": "588757ac-e419-3baf-9285-7c57bb97b6ff",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2024-06-04",
+          "offenceCode": "COML005"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 3
+          }
+        },
+        "sentencedAt": "2024-07-12",
+        "identifier": "a37b1d86-f191-36b6-8062-c262721087fd",
+        "consecutiveSentenceUUIDs": [
+          "e4c5d74c-cea6-33a5-ba59-20d35ba5d664"
+        ],
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2018-10-15",
+          "numberOfDays": 67,
+          "fromDate": "2018-08-09",
+          "toDate": "2018-10-14",
+          "additionalInfo": {
+            "type": "NONE"
+          }
+        }
+      ],
+      "UNLAWFULLY_AT_LARGE": [
+        {
+          "appliesToSentencesFrom": "2024-06-04",
+          "numberOfDays": 1,
+          "fromDate": "2024-06-04",
+          "toDate": "2024-06-04",
+          "additionalInfo": {
+            "type": "UAL"
+          }
+        }
+      ]
+    }
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-1.json
@@ -1,0 +1,15 @@
+{
+  "dates": {
+    "SLED": "2035-12-18",
+    "CRD": "2029-12-18",
+    "PED": "2024-10-30",
+    "ERSED": "2023-08-22",
+    "ESED": "2036-06-20"
+  },
+  "effectiveSentenceLength": "P23Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_10"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-2.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2033-11-18",
+    "CRD": "2028-10-12",
+    "PED": "2023-10-22",
+    "ESED": "2034-03-20"
+  },
+  "effectiveSentenceLength": "P20Y1M25D",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_10"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2764-example-3.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2029-07-10",
+    "CRD": "2027-05-11",
+    "PED": "2024-07-04",
+    "ESED": "2029-09-14"
+  },
+  "effectiveSentenceLength": "P10Y11M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_9"
+  },
+  "affectedByProgressionModel": true
+}


### PR DESCRIPTION
The "before tranche allocation" calculation for SDS40 was being overwritten by the one for Progression Model and the PM "before tranche allocation" calculation didn't have SDS40 defaulting rules applied.

This meant that where a pre-SDS40 date had been retained as part of SDS40 it was no longer retained for PM and therefore the date could be later than intended. This ensures pre-SDS40 dates can still be retained with PM defaulting.