### PR TITLE
crs-2765-ersed-bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ErsedCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ErsedCalculator.kt
@@ -123,8 +123,9 @@ class ErsedCalculator(
       params.sentenceCalculation.adjustedDeterminateReleaseDate
     }
 
-    val unadjustedEffectiveRelease = params.sentenceCalculation.unadjustedExtendedDeterminateParoleEligibilityDate
-      ?: params.sentenceCalculation.unadjustedReleaseDate.unadjustedDeterminateReleaseDate
+    val unadjustedEffectiveRelease =
+      params.sentenceCalculation.unadjustedExtendedDeterminateParoleEligibilityDate
+        ?: params.sentenceCalculation.unadjustedReleaseDate.unadjustedDeterminateReleaseDate
 
     val maxEffectiveErsed = effectiveRelease.minus(params.maxPeriodAmount, params.maxPeriodUnit)
 
@@ -141,11 +142,15 @@ class ErsedCalculator(
       ),
     )
 
-    val daysUntilRelease = ChronoUnit.DAYS.between(params.sentence.sentencedAt, unadjustedEffectiveRelease).plus(1).toInt()
+    val daysUntilRelease =
+      ChronoUnit.DAYS.between(params.sentence.sentencedAt, unadjustedEffectiveRelease).plus(1).toInt()
+
     val unadjustedMinimumErsed = params.sentence.sentencedAt
       .plusDays(BigDecimal.valueOf(daysUntilRelease.toLong()).multiply(params.releaseMultiplier).toLongReleaseDays())
+
     val minimumEffectiveErsed = unadjustedMinimumErsed
       .plusDays(params.sentenceCalculation.adjustments.adjustmentsForInitialRelease())
+      .coerceAtMost(effectiveRelease)
 
     val minimumEffectiveErsedBreakdown = ReleaseDateCalculationBreakdown(
       rules = setOf(CalculationRule.ERSED_MIN_EFFECTIVE_DATE),

--- a/src/test/resources/test_data/overall_calculation/custom-examples/crs-2765.json
+++ b/src/test/resources/test_data/overall_calculation/custom-examples/crs-2765.json
@@ -1,0 +1,50 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-06-17",
+          "offenceCode": "BA76001"
+        },
+        "duration": {
+          "durationElements": {
+            "DAYS": 2,
+            "WEEKS": 0,
+            "MONTHS": 0,
+            "YEARS": 0
+          }
+        },
+        "sentencedAt": "2026-06-18",
+        "identifier": "91827262-2a89-3fe5-bfe7-e9e46103dc92",
+        "consecutiveSentenceUUIDs": [],
+        "caseSequence": 1,
+        "lineSequence": 1,
+        "externalSentenceId": {
+          "sentenceSequence": 1,
+          "bookingId": 100000
+        },
+        "recall": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {},
+    "returnToCustodyDate": null,
+    "fixedTermRecallDetails": null,
+    "bookingId": 100000,
+    "historicalTusedData": null,
+    "externalMovements": []
+  },
+  "userInputs": {
+    "calculateErsed": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2765.json
+++ b/src/test/resources/test_data/overall_calculation_response/custom-examples/crs-2765.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "CRD": "2026-06-18",
+    "SLED": "2026-06-19",
+    "ERSED": "2026-06-18",
+    "TUSED": "2027-06-18",
+    "ESED": "2026-06-19"
+  },
+  "effectiveSentenceLength": "P2D"
+}


### PR DESCRIPTION
Ensure ERSED date does not exceed the sentence release date. Early release multiplier can push minimum ERSED date past the release date.