### PR TITLE
CRS-2737: Enable Progression Model for operational window

### DIFF
--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -15,7 +15,7 @@ generic-service:
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
-    SPRING_PROFILES_ACTIVE: "calculation-params,sds-progression-model"
+    SPRING_PROFILES_ACTIVE: "calculation-params"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
@@ -23,8 +23,6 @@ generic-service:
     MANAGE-OFFENCES_API_URL: https://manage-offences-api-dev.hmpps.service.justice.gov.uk
     NOMIS-SYNC-MAPPING_API_URL: https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk
     MANAGE-USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
-    APPLY_POST_HDCED_REPEAL_RULES: "true"
-    ROUTE_PRE_PROGRESSION_EXTINGUISHED_SENTENCE_TO_MANUAL: "true"
 
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,7 @@ generic-service:
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
-    SPRING_PROFILES_ACTIVE: "calculation-params"
+    SPRING_PROFILES_ACTIVE: "calculation-params,sds-progression-model"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
@@ -23,6 +23,8 @@ generic-service:
     NOMIS-SYNC-MAPPING_API_URL: https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk
     MANAGE-USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
     STORE_OPERATIVE_SENTENCE_ENVELOPE: "true"
+    APPLY_POST_HDCED_REPEAL_RULES: "true"
+    ROUTE_PRE_PROGRESSION_EXTINGUISHED_SENTENCE_TO_MANUAL: "true"
 
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,7 +7,7 @@ generic-service:
     host: calculate-release-dates-api.hmpps.service.justice.gov.uk
 
   env:
-    SPRING_PROFILES_ACTIVE: "calculation-params"
+    SPRING_PROFILES_ACTIVE: "calculation-params,sds-progression-model"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api.prison.service.justice.gov.uk
@@ -15,6 +15,8 @@ generic-service:
     MANAGE-OFFENCES_API_URL: https://manage-offences-api.hmpps.service.justice.gov.uk
     NOMIS-SYNC-MAPPING_API_URL: https://nomis-sync-prisoner-mapping.hmpps.service.justice.gov.uk
     MANAGE-USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk
+    APPLY_POST_HDCED_REPEAL_RULES: "true"
+    ROUTE_PRE_PROGRESSION_EXTINGUISHED_SENTENCE_TO_MANUAL: "true"
 
   serviceAccountName: calculate-release-dates-api-prod
 


### PR DESCRIPTION
Enabling progression model in prod for the operational window where HDC will still be available if the date is before progression commencement but all other calculations will be performed using progression model release parameters. This is to allow recalculations to take place before commencement and the first tranche of releases.

Also switching dev and alt-dev around.