### PR TITLE
CRS-2781: Ignore TUSED diff in bulk calc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/SentenceCalcDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/external/prisonapi/SentenceCalcDates.kt
@@ -79,7 +79,6 @@ data class SentenceCalcDates(
     ReleaseDateType.ETD to (etdOverrideDate ?: etdCalculatedDate),
     ReleaseDateType.MTD to (mtdOverrideDate ?: mtdCalculatedDate),
     ReleaseDateType.LTD to (ltdOverrideDate ?: ltdCalculatedDate),
-    ReleaseDateType.TUSED to (topupSupervisionExpiryOverrideDate ?: topupSupervisionExpiryCalculatedDate),
     ReleaseDateType.DPRRD to (dtoPostRecallReleaseDateOverride ?: dtoPostRecallReleaseDate),
     ReleaseDateType.ERSED to earlyRemovalSchemeEligibilityDate,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonEventHandlerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BulkComparisonEventHandlerService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculatedRel
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationUserInputs
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Mismatch
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.MismatchType
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceAndOffenceWithReleaseArrangements
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.CalculationSourceData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceCalculationType
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.prisonapi.SentenceCalcDates
@@ -163,7 +162,7 @@ class BulkComparisonEventHandlerService(
     val sdsPlusSentenceAndOffences = sourceData.sentenceAndOffences.filter { it.sdsReleaseArrangements?.isSDSPlus == true }
 
     val mismatchType =
-      determineMismatchType(validationResult, sourceData.prisonerDetails.sentenceDetail, sourceData.sentenceAndOffences)
+      determineMismatchType(validationResult, sourceData.prisonerDetails.sentenceDetail)
 
     val mismatch = Mismatch(
       isMatch = mismatchType == MismatchType.NONE,
@@ -248,7 +247,6 @@ class BulkComparisonEventHandlerService(
   fun determineMismatchType(
     validationResult: ValidationResult,
     sentenceCalcDates: SentenceCalcDates?,
-    sentenceAndOffenceWithReleaseArrangements: List<SentenceAndOffenceWithReleaseArrangements>,
   ): MismatchType {
     if (validationResult.messages.isEmpty()) {
       val datesMatch =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalcDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SentenceCalcDatesTest.kt
@@ -166,6 +166,83 @@ internal class SentenceCalcDatesTest {
     assertThat(sentenceCalcDates.isSameComparableCalculatedDates(differentEffectiveSentencedEndDate)).isTrue
   }
 
+  @Test
+  fun `a different TUSED should not cause a mismatch because of the PSS repeal, we no longer generate them but they may still be in the previous calculation`() {
+    val datesWithATused = SentenceCalcDates(
+      sentenceExpiryCalculatedDate = LocalDate.of(2023, 11, 22),
+      sentenceExpiryOverrideDate = null,
+      automaticReleaseDate = null,
+      automaticReleaseOverrideDate = null,
+      conditionalReleaseDate = null,
+      conditionalReleaseOverrideDate = null,
+      nonParoleDate = null,
+      nonParoleOverrideDate = null,
+      postRecallReleaseDate = null,
+      postRecallReleaseOverrideDate = null,
+      licenceExpiryCalculatedDate = null,
+      licenceExpiryOverrideDate = null,
+      homeDetentionCurfewEligibilityCalculatedDate = null,
+      homeDetentionCurfewEligibilityOverrideDate = null,
+      paroleEligibilityCalculatedDate = null,
+      paroleEligibilityOverrideDate = null,
+      homeDetentionCurfewActualDate = null,
+      actualParoleDate = null,
+      releaseOnTemporaryLicenceDate = null,
+      earlyRemovalSchemeEligibilityDate = null,
+      tariffEarlyRemovalSchemeEligibilityDate = null,
+      tariffDate = null,
+      etdCalculatedDate = null,
+      etdOverrideDate = null,
+      mtdCalculatedDate = null,
+      mtdOverrideDate = null,
+      ltdCalculatedDate = null,
+      ltdOverrideDate = null,
+      topupSupervisionExpiryCalculatedDate = LocalDate.of(2022, 5, 5),
+      topupSupervisionExpiryOverrideDate = null,
+      dtoPostRecallReleaseDate = null,
+      dtoPostRecallReleaseDateOverride = null,
+      effectiveSentenceEndDate = null,
+    )
+
+    val differentDatesWithNoTused = SentenceCalcDates(
+      sentenceExpiryCalculatedDate = LocalDate.of(2023, 11, 22),
+      sentenceExpiryOverrideDate = null,
+      automaticReleaseDate = null,
+      automaticReleaseOverrideDate = null,
+      conditionalReleaseDate = null,
+      conditionalReleaseOverrideDate = null,
+      nonParoleDate = null,
+      nonParoleOverrideDate = null,
+      postRecallReleaseDate = null,
+      postRecallReleaseOverrideDate = null,
+      licenceExpiryCalculatedDate = null,
+      licenceExpiryOverrideDate = null,
+      homeDetentionCurfewEligibilityCalculatedDate = null,
+      homeDetentionCurfewEligibilityOverrideDate = null,
+      paroleEligibilityCalculatedDate = null,
+      paroleEligibilityOverrideDate = null,
+      homeDetentionCurfewActualDate = null,
+      actualParoleDate = null,
+      releaseOnTemporaryLicenceDate = null,
+      earlyRemovalSchemeEligibilityDate = null,
+      tariffEarlyRemovalSchemeEligibilityDate = null,
+      tariffDate = null,
+      etdCalculatedDate = null,
+      etdOverrideDate = null,
+      mtdCalculatedDate = null,
+      mtdOverrideDate = null,
+      ltdCalculatedDate = null,
+      ltdOverrideDate = null,
+      topupSupervisionExpiryCalculatedDate = null,
+      topupSupervisionExpiryOverrideDate = null,
+      dtoPostRecallReleaseDate = null,
+      dtoPostRecallReleaseDateOverride = null,
+      effectiveSentenceEndDate = null,
+    )
+
+    assertThat(datesWithATused.isSameComparableCalculatedDates(differentDatesWithNoTused)).isTrue
+  }
+
   @ParameterizedTest
   @MethodSource("comparableDateModifiers")
   fun `different comparable calculated dates are not the same`(dateType: ReleaseDateType, modifier: (LocalDate, SentenceCalcDates) -> SentenceCalcDates) {
@@ -273,7 +350,6 @@ internal class SentenceCalcDatesTest {
       Arguments.of(ReleaseDateType.ETD, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(etdCalculatedDate = date) }),
       Arguments.of(ReleaseDateType.MTD, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(mtdCalculatedDate = date) }),
       Arguments.of(ReleaseDateType.LTD, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(ltdCalculatedDate = date) }),
-      Arguments.of(ReleaseDateType.TUSED, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(topupSupervisionExpiryCalculatedDate = date) }),
       Arguments.of(ReleaseDateType.DPRRD, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(dtoPostRecallReleaseDate = date) }),
       Arguments.of(ReleaseDateType.ERSED, { date: LocalDate, sentenceCalDates: SentenceCalcDates -> sentenceCalDates.copy(earlyRemovalSchemeEligibilityDate = date) }),
     )


### PR DESCRIPTION
Due to the PSS repeal we no longer generate TUSEDs. Many prisoners are showing up in bulk calc with a difference because their previous calculation produced a TUSED and now doesn't.  We're now ignoring the TUSED as a difference.