### PR TITLE
CRS-2796: Fix PED defaulting issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDSProgressionModelFinalDatesService.kt
@@ -22,7 +22,6 @@ class SDSProgressionModelFinalDatesService {
     val earliestApplicableDate = preLegislationCalculation.legislationApplied.earliestApplicableDate
     val legislation = preLegislationCalculation.legislationApplied.legislation
     require(legislation is SDSLegislation.ProgressionModelLegislation) { "Using progression model defaulting rules for non-progression model legislation" }
-    val commencementDate = legislation.commencementDate()
 
     // default to the early release dates for when there is no applicable tranche or further adjustment of dates required
     val mergedDates = earlyReleaseCalculation.dates.toMutableMap()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
@@ -51,7 +51,7 @@ class TimelineSDSTrancheCalculationHandler(
       if (legislationToApply.legislationName == LegislationName.SDS_PROGRESSION_MODEL && LegislationName.SDS_40 in beforeTrancheCalculations) {
         // if there was already an SDS40 tranche allocated then apply defaulting and adjustments at this point so that any SDS50 dates that were
         // retained for SDS40 are used in the progression model defaulting and will likely still be retained then as well.
-        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, originalAdjustments, releasedSentenceGroups.flatMap { it.sentences })
+        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, originalAdjustments, allSentences.flatten())
       }
       beforeTrancheCalculations[legislationToApply.legislationName] = PreLegislationCalculation(
         latestCalculation,

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2796-bugfix.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2796-bugfix.json
@@ -1,0 +1,221 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "1990-01-01"
+    },
+    "sentences": [
+      {
+        "recall": {
+          "recallType": "FIXED_TERM_RECALL_28",
+          "revocationDate": "2020-06-17",
+          "returnToCustodyDate": "2020-09-17"
+        },
+        "offence": {
+          "committedAt": "2017-06-26",
+          "offenceCode": "TH68026"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        },
+        "identifier": "d8642e2a-84f7-3e6b-aae7-d50043550c73",
+        "sentencedAt": "2017-08-24",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        }
+      },
+      {
+        "recall": {
+          "recallType": "FIXED_TERM_RECALL_28",
+          "revocationDate": "2020-06-17",
+          "returnToCustodyDate": "2020-09-17"
+        },
+        "offence": {
+          "committedAt": "2017-06-02",
+          "offenceCode": "TH68007"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 6
+          }
+        },
+        "identifier": "7ff0215a-0cc7-31fd-bb3e-a606cb84f4e2",
+        "sentencedAt": "2017-08-24",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        }
+      },
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2020-05-11",
+          "offenceCode": "OF61017A"
+        },
+        "identifier": "a7ae2d24-fca2-353d-9987-d642218a5278",
+        "sentencedAt": "2020-09-17",
+        "caseReference": null,
+        "automaticRelease": false,
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 8
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 5
+          }
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2020-05-11",
+          "offenceCode": "PC53001"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 8
+          }
+        },
+        "identifier": "0c2b5dd2-24d2-3fc6-8070-70c9e82429a3",
+        "sentencedAt": "2020-09-17",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2020-05-11",
+          "offenceCode": "AS14001"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "identifier": "d942370a-0478-368c-b1af-b1066222984b",
+        "sentencedAt": "2020-09-17",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2020-05-11",
+          "offenceCode": "TH68050"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 4
+          }
+        },
+        "identifier": "bc529382-15af-31c4-b167-aa4122813ea3",
+        "sentencedAt": "2020-09-17",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        }
+      },
+      {
+        "offence": {
+          "committedAt": "2021-02-07",
+          "offenceCode": "OF61127"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 12
+          }
+        },
+        "identifier": "45b685fe-fda0-38d2-b976-cef30ffcc66a",
+        "sentencedAt": "2022-09-15",
+        "caseReference": null,
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSection250": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "a7ae2d24-fca2-353d-9987-d642218a5278"
+        ]
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "toDate": "2020-09-16",
+          "fromDate": "2020-08-11",
+          "numberOfDays": 37,
+          "additionalInfo": {
+            "type": "NONE"
+          },
+          "appliesToSentencesFrom": "2020-09-17"
+        }
+      ],
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "fromDate": "2025-07-31",
+          "numberOfDays": 21,
+          "additionalInfo": {
+            "type": "NONE"
+          },
+          "appliesToSentencesFrom": "2025-07-31"
+        },
+        {
+          "fromDate": "2026-01-16",
+          "numberOfDays": 28,
+          "additionalInfo": {
+            "type": "NONE"
+          },
+          "appliesToSentencesFrom": "2026-01-16"
+        }
+      ]
+    },
+    "externalMovements": [
+      {
+        "direction": "OUT",
+        "movementDate": "2020-01-31",
+        "movementReason": "CRD"
+      },
+      {
+        "direction": "IN",
+        "movementDate": "2020-07-14",
+        "movementReason": "REMAND"
+      }
+    ],
+    "returnToCustodyDate": "2020-09-17",
+    "fixedTermRecallDetails": {
+      "bookingId": 2645189,
+      "recallLength": 28,
+      "returnToCustodyDate": "2020-09-17"
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2796-bugfix.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2796-bugfix.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2034-08-10",
+    "CRD": "2029-01-28",
+    "PED": "2026-06-23",
+    "ESED": "2034-09-16"
+  },
+  "effectiveSentenceLength": "P17Y24D",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_10"
+  }
+}


### PR DESCRIPTION
When applying SDS40 defaulting for the "before tranche calculation" for PM we were only passing in the released sentence groups. This works when applied at the end of the timeline but not at the PM tranche dates. Include the current sentence group in the defaulting (which is the same as we do for the calculation itself).