### PR TITLE
CRS-2689: Post-progression consec sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SDS40EarlyReleaseDefaultingRulesService.kt
@@ -91,6 +91,7 @@ class SDS40EarlyReleaseDefaultingRulesService {
     otherDates = earlyReleaseResult.otherDates,
     effectiveSentenceLength = earlyReleaseResult.effectiveSentenceLength,
     affectedBySds40 = (dates != standardReleaseResult.dates) || standardReleaseResult.affectedBySds40,
+    affectedByProgressionModel = if (dates != standardReleaseResult.dates) earlyReleaseResult.affectedByProgressionModel else standardReleaseResult.affectedByProgressionModel,
     sentencesImpactingFinalReleaseDate = if (dates != standardReleaseResult.dates) earlyReleaseResult.sentencesImpactingFinalReleaseDate else standardReleaseResult.sentencesImpactingFinalReleaseDate,
   )
 

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-1.json
@@ -1,0 +1,69 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-02"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 34
+          }
+        },
+        "sentencedAt": "2025-10-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-23"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 17
+          }
+        },
+        "sentencedAt": "2026-09-23",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-10-02",
+          "numberOfDays": 48,
+          "fromDate": "2025-08-15",
+          "toDate": "2025-10-01"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-12.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-12.json
@@ -1,0 +1,60 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-05-24"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2026-05-24",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-12-02"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-12-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-2.json
@@ -1,0 +1,60 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-11-24"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 40
+          }
+        },
+        "sentencedAt": "2025-11-24",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-10-12"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 12
+          }
+        },
+        "sentencedAt": "2026-10-12",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-3.json
@@ -1,0 +1,68 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2024-05-07"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2024-05-07",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-03"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 2
+          }
+        },
+        "sentencedAt": "2026-09-03",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2025-01-13",
+          "numberOfDays": 5,
+          "fromDate": "2025-01-13"
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-4.json
@@ -1,0 +1,82 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "SopcSentence",
+        "offence": {
+          "committedAt": "2023-03-26"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 1
+          }
+        },
+        "sentencedAt": "2023-03-26",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-03-26"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 30
+          }
+        },
+        "sentencedAt": "2023-03-26",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-12-08"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 20
+          }
+        },
+        "sentencedAt": "2026-12-08",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "calculateErsed": true,
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-5.json
@@ -1,0 +1,82 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2021-12-16"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2021-12-16",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2021-12-16"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 24
+          }
+        },
+        "sentencedAt": "2021-12-16",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-08"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 3
+          }
+        },
+        "sentencedAt": "2026-09-08",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "calculateErsed": true,
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-6.json
@@ -1,0 +1,82 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-02-11"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 7
+          }
+        },
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": ["VIOLENT"],
+          "isSection250": false
+        },
+        "sentencedAt": "2022-02-11",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-03-11"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-03-11",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-13"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2026-09-13",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-7.json
@@ -1,0 +1,60 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2022-12-16"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 69
+          }
+        },
+        "sentencedAt": "2022-12-16",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-16"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 48
+          }
+        },
+        "sentencedAt": "2026-09-16",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-8.json
@@ -1,0 +1,59 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "ExtendedDeterminateSentence",
+        "offence": {
+          "committedAt": "2026-03-12"
+        },
+        "custodialDuration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 2
+          }
+        },
+        "sentencedAt": "2026-03-12",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-10-06"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 4
+          }
+        },
+        "sentencedAt": "2026-10-06",
+        "releaseArrangements": {
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-9.json
@@ -1,0 +1,60 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2009-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-08-14"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2026-08-14",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": true
+        },
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-09-16"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 18
+          }
+        },
+        "sentencedAt": "2026-09-16",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ]
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-1.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2029-11-14",
+    "CRD": "2027-01-14",
+    "ESED": "2030-01-01"
+  },
+  "effectiveSentenceLength": "P4Y3M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-12.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-12.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2031-05-23",
+    "CRD": "2028-01-22",
+    "ESED": "2031-05-23"
+  },
+  "effectiveSentenceLength": "P5Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_3"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-2.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2030-03-23",
+    "CRD": "2027-05-04",
+    "ESED": "2030-03-23"
+  },
+  "effectiveSentenceLength": "P4Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_4"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-3.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-3.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-07-06",
+    "CRD": "2026-12-13",
+    "ESED": "2028-07-06"
+  },
+  "effectiveSentenceLength": "P4Y2M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_4"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-4.json
@@ -1,0 +1,15 @@
+{
+  "dates": {
+    "SLED": "2031-05-25",
+    "CRD": "2027-08-14",
+    "PED": "2026-10-15",
+    "ERSED": "2025-09-23",
+    "ESED": "2031-05-25"
+  },
+  "effectiveSentenceLength": "P8Y2M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-5.json
@@ -1,0 +1,15 @@
+{
+  "dates": {
+    "SLED": "2031-03-15",
+    "CRD": "2026-11-03",
+    "PED": "2025-07-04",
+    "ERSED": "2025-09-23",
+    "ESED": "2031-03-15"
+  },
+  "effectiveSentenceLength": "P9Y3M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_8"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-6.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-6.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2036-02-10",
+    "CRD": "2027-12-13",
+    "ESED": "2036-02-10"
+  },
+  "effectiveSentenceLength": "P14Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_8"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-7.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-7.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2032-09-15",
+    "CRD": "2027-10-31",
+    "ESED": "2032-09-15"
+  },
+  "effectiveSentenceLength": "P9Y9M",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_5"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-8.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-8.json
@@ -1,0 +1,11 @@
+{
+  "dates": {
+    "SLED": "2036-03-11",
+    "CRD": "2032-03-11",
+    "PED": "2030-11-10",
+    "ESED": "2036-03-11"
+  },
+  "effectiveSentenceLength": "P10Y",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-9.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-9.json
@@ -1,0 +1,10 @@
+{
+  "dates": {
+    "SLED": "2031-02-13",
+    "CRD": "2028-04-26",
+    "ESED": "2031-02-13"
+  },
+  "effectiveSentenceLength": "P4Y6M",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": true
+}


### PR DESCRIPTION
Tests for sentences imposed consecutively post-progression. Fixed small issue with affected by progression model where there is  SDS40 defaulting required but not PM defaulting.