### PR TITLE
CRS-2802: Separate HDC clean stop from progression commencement

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HdcedExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/HdcedExtractionService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCa
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.StandardDeterminateSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Term
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.PROGRESSION_COMMENCEMENT_DATE
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates.HDC_CLEAN_STOP_DATE
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.sentence.SentencesExtractionService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
@@ -94,7 +94,7 @@ class HdcedExtractionService(
     hdcedSentence: CalculableSentence,
   ): Boolean = featureToggles.applyPostHdcedRepealRules &&
     sentences.any { isAdultSentence(it) } &&
-    (hdcedDate.isAfterOrEqualTo(PROGRESSION_COMMENCEMENT_DATE) || hdcedSentence.isAffectedBySdsProgressionModel())
+    (hdcedDate.isAfterOrEqualTo(HDC_CLEAN_STOP_DATE) || hdcedSentence.isAffectedBySdsProgressionModel())
 
   private fun isAdultSentence(sentence: CalculableSentence): Boolean = !(sentence is StandardDeterminateSentence && sentence.releaseArrangements.isSection250 || sentence is Term)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ImportantDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ImportantDates.kt
@@ -21,5 +21,5 @@ object ImportantDates {
   val SHPO_BREACH_OFFENCE_FROM_DATE: LocalDate = LocalDate.of(2020, 12, 1)
   val FTR_48_COMMENCEMENT_DATE: LocalDate = LocalDate.of(2025, 9, 2)
   val ERS30_COMMENCEMENT_DATE: LocalDate = LocalDate.of(2025, 9, 23)
-  val PROGRESSION_COMMENCEMENT_DATE: LocalDate = LocalDate.of(2026, 9, 2)
+  val HDC_CLEAN_STOP_DATE: LocalDate = LocalDate.of(2026, 9, 2)
 }


### PR DESCRIPTION
Turns out it was already separated so just renamed the constant to make it clear.