### PR TITLE
CRS-2810: Post-ERS30 sentences should not default

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ErsedCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/ErsedCalculator.kt
@@ -31,7 +31,8 @@ class ErsedCalculator(
   }
 
   private fun calculateUsingBothERS30AndERS50(sentence: CalculableSentence, sentenceCalculation: SentenceCalculation) {
-    val ers50Result = if (isSentencedOnOrAfterCommencement(sentence) || isConsecutiveSentenceWithSentencesBeforeAndAfterCommencement(sentence)) {
+    val isConsideredPostERS30Sentence = isSentencedOnOrAfterCommencement(sentence) || isConsecutiveSentenceWithSentencesBeforeAndAfterCommencement(sentence)
+    val ers50Result = if (isConsideredPostERS30Sentence) {
       null
     } else {
       calculate(
@@ -56,7 +57,7 @@ class ErsedCalculator(
 
     if (ers50Result != null && ers50Result.adjustedDateExcludingAwarded.isBefore(ImportantDates.ERS30_COMMENCEMENT_DATE)) {
       sentenceCalculation.breakdownByReleaseDateType[ReleaseDateType.ERSED] = ers50Result.breakdown
-    } else if (ers30Result.adjustedDateExcludingAwarded.isAfterOrEqualTo(ImportantDates.ERS30_COMMENCEMENT_DATE)) {
+    } else if (isConsideredPostERS30Sentence || ers30Result.adjustedDateExcludingAwarded.isAfterOrEqualTo(ImportantDates.ERS30_COMMENCEMENT_DATE)) {
       sentenceCalculation.breakdownByReleaseDateType[ReleaseDateType.ERSED] = ers30Result.breakdown
     } else {
       val daysToBeAddedExcludingUAL = sentenceCalculation.adjustments.awardedDuringCustody -

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2810-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2810-ac1-1.json
@@ -2,61 +2,40 @@
   "booking": {
     "offender": {
       "reference": "ABC123",
-      "dateOfBirth": "2009-01-01",
-      "isActiveSexOffender": true
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": false
     },
     "sentences": [
       {
-        "type": "SopcSentence",
+        "type": "StandardSentence",
         "offence": {
-          "committedAt": "2023-03-26"
+          "committedAt": "2025-03-10"
         },
-        "custodialDuration": {
+        "duration": {
           "durationElements": {
-            "YEARS": 3
+            "MONTHS": 18
           }
         },
-        "extensionDuration": {
-          "durationElements": {
-            "YEARS": 1
-          }
+        "sentencedAt": "2025-03-10",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
         },
-        "sentencedAt": "2023-03-26",
-        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
       },
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2023-03-26"
+          "committedAt": "2025-09-30"
         },
         "duration": {
           "durationElements": {
             "MONTHS": 30
           }
         },
-        "sentencedAt": "2023-03-26",
-        "releaseArrangements": {
-          "isSDSPlus": false,
-          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
-          "sdsEarlyReleaseExclusions": [],
-          "isSection250": false
-        },
-        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
-        "consecutiveSentenceUUIDs": [
-          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
-        ]
-      },
-      {
-        "type": "StandardSentence",
-        "offence": {
-          "committedAt": "2026-12-08"
-        },
-        "duration": {
-          "durationElements": {
-            "MONTHS": 20
-          }
-        },
-        "sentencedAt": "2026-12-08",
+        "sentencedAt": "2025-09-30",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
@@ -64,13 +43,22 @@
           "isSection250": false
         },
         "consecutiveSentenceUUIDs": [
-          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+          "cb304745-d781-47d3-b931-4baa31551fc5"
         ]
       }
     ],
-    "adjustments": {}
+    "adjustments": {
+      "ADDITIONAL_DAYS_AWARDED": [
+        {
+          "appliesToSentencesFrom": "2025-06-03",
+          "numberOfDays": 2,
+          "fromDate": "2025-06-03"
+        }
+      ]
+    }
   },
   "userInputs": {
+    "calculateErsed": true,
     "useOffenceIndicators": true
   },
   "params": "sds-progression-model",

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2810-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2810-ac1-2.json
@@ -1,0 +1,74 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": false
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-05-12"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 24
+          }
+        },
+        "sentencedAt": "2025-05-12",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-02"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 12
+          }
+        },
+        "sentencedAt": "2025-10-02",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        },
+        "consecutiveSentenceUUIDs": [
+          "cb304745-d781-47d3-b931-4baa31551fc5"
+        ]
+      },
+      {
+        "type": "AFineSentence",
+        "offence": {
+          "committedAt": "2025-11-11"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 3
+          }
+        },
+        "sentencedAt": "2025-11-11",
+        "fineAmount": 99
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "calculateErsed": true,
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation/progression-model/crs-2689-ac1-5.json
@@ -71,7 +71,6 @@
     "adjustments": {}
   },
   "userInputs": {
-    "calculateErsed": true,
     "useOffenceIndicators": true
   },
   "params": "sds-progression-model",

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2472-ac-01_01.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2472-ac-01_01.json
@@ -3,7 +3,7 @@
     "SLED": "2029-08-04",
     "CRD": "2026-09-11",
     "HDCED": "2025-09-12",
-    "ERSED": "2025-09-23",
+    "ERSED": "2024-11-16",
     "ESED": "2029-08-04"
   },
   "effectiveSentenceLength": "P5Y6M"

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2810-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2810-ac1-1.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2029-03-09",
+    "CRD": "2026-10-17",
+    "HDCED": "2025-12-30",
+    "ERSED": "2025-09-04",
+    "ESED": "2029-03-09"
+  },
+  "effectiveSentenceLength": "P4Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_4"
+  },
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2810-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2810-ac1-2.json
@@ -1,0 +1,12 @@
+{
+  "dates": {
+    "SLED": "2028-05-11",
+    "CRD": "2026-07-24",
+    "HDCED": "2025-12-26",
+    "ERSED": "2025-12-26",
+    "ESED": "2028-05-11"
+  },
+  "effectiveSentenceLength": "P3Y",
+  "trancheAllocationByLegislationName": {},
+  "affectedByProgressionModel": false
+}

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-4.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-4.json
@@ -3,7 +3,6 @@
     "SLED": "2031-05-25",
     "CRD": "2027-08-14",
     "PED": "2026-10-15",
-    "ERSED": "2025-09-23",
     "ESED": "2031-05-25"
   },
   "effectiveSentenceLength": "P8Y2M",

--- a/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-5.json
+++ b/src/test/resources/test_data/overall_calculation_response/progression-model/crs-2689-ac1-5.json
@@ -3,7 +3,6 @@
     "SLED": "2031-03-15",
     "CRD": "2026-11-03",
     "PED": "2025-07-04",
-    "ERSED": "2025-09-23",
     "ESED": "2031-03-15"
   },
   "effectiveSentenceLength": "P9Y3M",


### PR DESCRIPTION
Sentences that are post-ERS30 or, in the case of consecutive sentences, contain both pre and post-ERS30 commencement sentences should not be subject to defaulting to the ERS30 commencement date even if the date is earlier.

There are further changes to be made in relation to ERSED and progression model which will be addressed in a future ticket and ERSED calculation has been temporarily disabled for now. Fixes coming with CRS-2689.