### PR TITLE
CRS-2816: Reword PM excluded offence display name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSEarlyReleaseExclusionType.kt
@@ -21,7 +21,7 @@ enum class SDSEarlyReleaseExclusionType(
   DOMESTIC_ABUSE_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false, displayName = "Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)"),
   MURDER_T3(sds40Exclusion = false, sds40AdditionalExcludedOffence = true, progressionModelExclusion = false, displayName = "Murder (for prisoners in custody on or after the 16th Dec 2024)"),
   PROGRESSION_MODEL_SCHEDULE_13_PART_3(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true, displayName = "Schedule 13 Part 3"),
-  SA2026_PROGRESSION_MODEL_SCHEDULE(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true, displayName = "SA2026 Excluded Offences for Progression Model"),
+  SA2026_PROGRESSION_MODEL_SCHEDULE(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = true, displayName = "Excluded offence"),
   NO(sds40Exclusion = false, sds40AdditionalExcludedOffence = false, progressionModelExclusion = false, displayName = null),
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
@@ -24,7 +24,7 @@ class SDSMetaDataTest {
       SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> SDSDescriptions("Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)", null, null)
       SDSEarlyReleaseExclusionType.MURDER_T3 -> SDSDescriptions("Murder (for prisoners in custody on or after the 16th Dec 2024)", null, null)
       SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> SDSDescriptions(null, "Schedule 13 Part 3", null)
-      SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE -> SDSDescriptions(null, "SA2026 Excluded Offences for Progression Model", null)
+      SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE -> SDSDescriptions(null, "Excluded offence", null)
       SDSEarlyReleaseExclusionType.NO -> SDSDescriptions(null, null, null)
     }
     val result = SDSDescriptions.from(


### PR DESCRIPTION
So it shows "Excluded offence" on check sentence and offence info page.