### PR TITLE
CRS-2812: ERS30 bug and snapshot refactor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislation.kt
@@ -12,9 +12,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDa
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ReleaseMultiplier
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.ExternalMovementTimeline
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.ProgressionModelSnapshotTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDS40SnapshotTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSLegislationAmendmentTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSLegislationCommencementTimelineCalculationEvent
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheAllocationTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheRecalculationTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
@@ -53,8 +56,12 @@ sealed interface SDSLegislation : Legislation {
     override val legislationName = LegislationName.SDS_40
     override val trancheSelectionStrategy: SDSTrancheSelectionStrategy = SDS40TrancheSelectionStrategy()
 
-    override fun requiredTimelineCalculations(): List<TimelineCalculationEvent> = super.requiredTimelineCalculations() + tranches.map { tranche ->
-      SDSTrancheTimelineCalculationEvent(tranche.date, legislation = this, tranche)
+    override fun requiredTimelineCalculations(): List<TimelineCalculationEvent> = super.requiredTimelineCalculations() + tranches.flatMap { tranche ->
+      listOf(
+        SDSTrancheAllocationTimelineCalculationEvent(tranche.date, legislation = this, tranche),
+        SDS40SnapshotTimelineCalculationEvent(tranche.date, legislation = this, tranche),
+        SDSTrancheRecalculationTimelineCalculationEvent(tranche.date, legislation = this, tranche),
+      )
     }
 
     override fun commencementDate(): LocalDate = tranches.minOf { it.date }
@@ -106,8 +113,12 @@ sealed interface SDSLegislation : Legislation {
     override val legislationName = LegislationName.SDS_PROGRESSION_MODEL
     override val trancheSelectionStrategy: SDSTrancheSelectionStrategy = SDSProgressionModelTrancheSelectionStrategy()
 
-    override fun requiredTimelineCalculations(): List<TimelineCalculationEvent> = super.requiredTimelineCalculations() + tranches.map { tranche ->
-      SDSTrancheTimelineCalculationEvent(tranche.date, legislation = this, tranche)
+    override fun requiredTimelineCalculations(): List<TimelineCalculationEvent> = super.requiredTimelineCalculations() + tranches.flatMap { tranche ->
+      listOf(
+        SDSTrancheAllocationTimelineCalculationEvent(tranche.date, legislation = this, tranche),
+        ProgressionModelSnapshotTimelineCalculationEvent(tranche.date, legislation = this),
+        SDSTrancheRecalculationTimelineCalculationEvent(tranche.date, legislation = this, tranche),
+      )
     }
 
     override fun commencementDate(): LocalDate = tranches.minOf { it.date }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislationWithTranches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/earlyrelease/config/SDSLegislationWithTranches.kt
@@ -1,10 +1,19 @@
 package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
+import java.time.LocalDate
 
 interface SDSLegislationWithTranches :
   SDSLegislation,
   LegislationWithTranches {
   fun isSentenceSubjectToTraches(sentence: CalculableSentence): Boolean
   override val trancheSelectionStrategy: SDSTrancheSelectionStrategy
+
+  fun sentencesToModifyReleaseDates(
+    allSentences: List<CalculableSentence>,
+    timelineCalculationDate: LocalDate,
+  ): List<CalculableSentence> = allSentences.filter {
+    it.sentenceCalculation.adjustedDeterminateReleaseDate.isAfter(timelineCalculationDate)
+  }
+    .filter { sentence -> sentence.sentenceParts().any { this.appliesToSentence(it) } }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -33,6 +33,8 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCa
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.sentence.SentencesExtractionService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.sentence.oraAndNoneOraExtraction
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.CalculationSnapshot
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SnapshotName
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
 import java.time.Period
@@ -51,19 +53,21 @@ class BookingExtractionService(
     sentenceGroups: List<List<CalculableSentence>>,
     offender: Offender,
     returnToCustodyDate: LocalDate? = null,
+    snapshots: Map<SnapshotName, CalculationSnapshot>,
   ): CalculationResult = when (sentences.size) {
     0 -> throw NoSentencesProvidedException("At least one sentence must be provided")
-    1 -> extractSingle(sentences[0])
+    1 -> extractSingle(sentences[0], snapshots)
     else -> {
-      extractMultiple(sentences, sentenceGroups, offender, returnToCustodyDate)
+      extractMultiple(sentences, sentenceGroups, offender, returnToCustodyDate, snapshots)
     }
   }
 
-  private fun extractSingle(sentence: CalculableSentence): CalculationResult {
+  private fun extractSingle(sentence: CalculableSentence, snapshots: Map<SnapshotName, CalculationSnapshot>): CalculationResult {
     val dates: MutableMap<ReleaseDateType, LocalDate> = mutableMapOf()
     val sentenceCalculation = sentence.sentenceCalculation
     var historicalTusedSource: HistoricalTusedSource? = null
     val sentenceIsOrExclusivelyBotus = sentence.isOrExclusivelyBotus()
+    val breakdownByReleaseDateType = sentenceCalculation.breakdownByReleaseDateType.toMutableMap()
 
     if (sentence.releaseDateTypes.contains(SLED)) {
       dates[SLED] = sentenceCalculation.expiryDate
@@ -103,7 +107,16 @@ class BookingExtractionService(
     }
 
     if (sentenceCalculation.earlyReleaseSchemeEligibilityDate != null) {
-      dates[ERSED] = sentenceCalculation.earlyReleaseSchemeEligibilityDate!!
+      val latestErsedFromTimeline = sentenceCalculation.earlyReleaseSchemeEligibilityDate!!
+      val latestFromErs30Snapshot = snapshots[SnapshotName.BEFORE_ERS30]?.result?.dates?.get(ERSED)
+      if (latestFromErs30Snapshot == null || latestErsedFromTimeline.isAfterOrEqualTo(latestFromErs30Snapshot)) {
+        dates[ERSED] = latestErsedFromTimeline
+      } else {
+        dates[ERSED] = latestFromErs30Snapshot
+        snapshots[SnapshotName.BEFORE_ERS30]?.result?.breakdownByReleaseDateType?.get(ERSED)?.let { breakdownFromSnapshot ->
+          breakdownByReleaseDateType[ERSED] = breakdownFromSnapshot
+        }
+      }
     }
 
     if (sentenceCalculation.earlyTransferDate != null) {
@@ -130,7 +143,7 @@ class BookingExtractionService(
 
     return CalculationResult(
       dates.toMap(),
-      sentenceCalculation.breakdownByReleaseDateType.toMap(),
+      breakdownByReleaseDateType,
       emptyMap(),
       getEffectiveSentenceLength(sentence.sentencedAt, sentenceCalculation.unadjustedExpiryDate),
       false,
@@ -149,6 +162,7 @@ class BookingExtractionService(
     sentenceGroups: List<List<CalculableSentence>>,
     offender: Offender,
     returnToCustodyDate: LocalDate?,
+    snapshots: Map<SnapshotName, CalculationSnapshot>,
   ): CalculationResult {
     val dates: MutableMap<ReleaseDateType, LocalDate> = mutableMapOf()
     val otherDates: MutableMap<ReleaseDateType, LocalDate> = mutableMapOf()
@@ -353,6 +367,7 @@ class BookingExtractionService(
       breakdownByReleaseDateType,
       dates,
       sentenceGroups,
+      snapshots,
     )
 
     if (mostRecentSentencesByReleaseDate.any { it.isRecall() }) {
@@ -493,6 +508,7 @@ class BookingExtractionService(
     breakdownByReleaseDateType: MutableMap<ReleaseDateType, ReleaseDateCalculationBreakdown>,
     dates: MutableMap<ReleaseDateType, LocalDate>,
     sentenceGroups: List<List<CalculableSentence>>,
+    snapshots: Map<SnapshotName, CalculationSnapshot>,
   ): Boolean {
     val latestEarlyReleaseSchemeEligibilitySentence =
       extractionService.mostRecentSentenceOrNull(
@@ -500,9 +516,8 @@ class BookingExtractionService(
         SentenceCalculation::earlyReleaseSchemeEligibilityDate,
       ) { !it.sentenceCalculation.isImmediateRelease() }
 
-    if (latestEarlyReleaseSchemeEligibilitySentence != null) {
+    val notApplicableDueToDtoLaterThanCrdFlag = if (latestEarlyReleaseSchemeEligibilitySentence != null) {
       val sentenceGroup = sentenceGroups.find { it.contains(latestEarlyReleaseSchemeEligibilitySentence) }!!
-
       val noAFineOrBotusReleaseAfterLatestEarlyReleaseSchemeEligibilitySentence =
         extractionService.mostRecentSentenceOrNull(
           sentenceGroup.filter {
@@ -530,10 +545,10 @@ class BookingExtractionService(
             unadjustedDate = latestEarlyReleaseSchemeEligibilitySentence.sentenceCalculation.earlyReleaseSchemeEligibilityDate!!,
           )
           dates[ERSED] = latestAFineReleaseAfterErsed.sentenceCalculation.releaseDate
-          return false
+          false
         } else {
           if (sentences.any { it.isDto() }) {
-            return calculateErsedWhereDtoIsPresent(
+            calculateErsedWhereDtoIsPresent(
               dates,
               latestEarlyReleaseSchemeEligibilitySentence,
               breakdownByReleaseDateType,
@@ -543,12 +558,26 @@ class BookingExtractionService(
               latestEarlyReleaseSchemeEligibilitySentence.sentenceCalculation.breakdownByReleaseDateType[ERSED]!!
             dates[ERSED] =
               latestEarlyReleaseSchemeEligibilitySentence.sentenceCalculation.earlyReleaseSchemeEligibilityDate!!
-            return false
+            false
           }
         }
+      } else {
+        false
       }
+    } else {
+      false
     }
-    return false
+
+    val ersedFromErs30Snapshot = snapshots[SnapshotName.BEFORE_ERS30]?.result?.dates?.get(ERSED)
+    val ersedFromTimeline = dates[ERSED]
+    if (ersedFromErs30Snapshot != null && ersedFromTimeline != null && ersedFromErs30Snapshot.isAfter(ersedFromTimeline)) {
+      val snapshot = snapshots[SnapshotName.BEFORE_ERS30]!!
+      dates[ERSED] = ersedFromErs30Snapshot
+      snapshot.result.breakdownByReleaseDateType[ERSED]?.let { snapshotErsedBreadkdown -> breakdownByReleaseDateType[ERSED] = snapshotErsedBreadkdown }
+      return snapshot.result.ersedNotApplicableDueToDtoLaterThanCrd
+    }
+
+    return notApplicableDueToDtoLaterThanCrdFlag
   }
 
   private fun isTusedableDtos(sentences: List<CalculableSentence>, offender: Offender): Boolean = sentences.all { it.isDto() } &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/BookingTimelineService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.FTRLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationConfiguration
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.ADDITIONAL_DAYS_AWARDED
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.AdjustmentType.RECALL_REMAND
@@ -22,16 +23,25 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationOu
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ExternalMovement
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceGroup
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.ImportantDates
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.SDSProgressionModelFinalDatesService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.AwardedAdjustmentTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.ExternalMovementTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.FTR56TrancheTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.ProgressionModelSnapshotTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDS40SnapshotTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSLegislationAmendmentTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSLegislationCommencementTimelineCalculationEvent
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheAllocationTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheRecalculationTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SentenceTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SimpleSnapshotTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.UALTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.ProgressionModelSnapshotTimelineCalculationHandler
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.SDS40SnapshotTimelineCalculationHandler
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.SDSTrancheRecalculationTimelineCalculationHandler
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.SimpleSnapshotTimelineCalculationHandler
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.TimelineAwardedAdjustmentCalculationHandler
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.TimelineExternalMovementCalculationHandler
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers.TimelineFTR56TrancheCalculationHandler
@@ -58,6 +68,10 @@ class BookingTimelineService(
   private val timelineSDSLegislationAmendmentHandler: TimelineSDSLegislationAmendmentHandler,
   private val sdsLegislationConfiguration: SDSLegislationConfiguration,
   private val ftrLegislationConfiguration: FTRLegislationConfiguration,
+  private val sds40SnapshotTimelineCalculationHandler: SDS40SnapshotTimelineCalculationHandler,
+  private val progressionModelSnapshotTimelineCalculationHandler: ProgressionModelSnapshotTimelineCalculationHandler,
+  private val sdsTrancheRecalculationTimelineCalculationHandler: SDSTrancheRecalculationTimelineCalculationHandler,
+  private val simpleSnapshotTimelineCalculationHandler: SimpleSnapshotTimelineCalculationHandler,
 ) {
 
   fun calculate(
@@ -79,7 +93,7 @@ class BookingTimelineService(
       sentences = sentences.sortedBy { it.sentencedAt },
     )
 
-    val calculationsByDate = getCalculationsByDate(sentences, futureData, externalMovements)
+    val calculationsByDate = getCalculationsByDate(sentences, futureData, externalMovements, options.calculateErsed)
 
     val earliestSentence = futureData.sentences.minBy { it.sentencedAt }
 
@@ -102,13 +116,17 @@ class BookingTimelineService(
       val results = calculations.sortedBy { it.type.order }.map {
         when (it) {
           is SDSLegislationCommencementTimelineCalculationEvent -> timelineSDSLegislationCommencementHandler.handle(it, timelineTrackingData)
+          is SDS40SnapshotTimelineCalculationEvent -> sds40SnapshotTimelineCalculationHandler.handle(it, timelineTrackingData)
+          is ProgressionModelSnapshotTimelineCalculationEvent -> progressionModelSnapshotTimelineCalculationHandler.handle(it, timelineTrackingData)
+          is SDSTrancheRecalculationTimelineCalculationEvent -> sdsTrancheRecalculationTimelineCalculationHandler.handle(it, timelineTrackingData)
           is SentenceTimelineCalculationEvent -> timelineSentenceCalculationHandler.handle(it, timelineTrackingData)
           is AwardedAdjustmentTimelineCalculationEvent -> timelineAwardedAdjustmentCalculationHandler.handle(it, timelineTrackingData)
           is UALTimelineCalculationEvent -> timelineUalAdjustmentCalculationHandler.handle(it, timelineTrackingData)
-          is SDSTrancheTimelineCalculationEvent -> timelineSDSTrancheCalculationHandler.handle(it, timelineTrackingData)
+          is SDSTrancheAllocationTimelineCalculationEvent -> timelineSDSTrancheCalculationHandler.handle(it, timelineTrackingData)
           is FTR56TrancheTimelineCalculationEvent -> timelineFTR56TrancheCalculationHandler.handle(it, timelineTrackingData)
           is ExternalMovementTimelineCalculationEvent -> timelineExternalMovementCalculationHandler.handle(it, timelineTrackingData)
           is SDSLegislationAmendmentTimelineCalculationEvent -> timelineSDSLegislationAmendmentHandler.handle(it, timelineTrackingData)
+          is SimpleSnapshotTimelineCalculationEvent -> simpleSnapshotTimelineCalculationHandler.handle(it, timelineTrackingData)
         }
       }
       val anyCalculationRequired = results.any { it.requiresCalculation }
@@ -142,13 +160,16 @@ class BookingTimelineService(
           releasedSentenceGroups.map { it.sentences },
           offender,
           returnToCustodyDate,
+          snapshots,
         )
 
       val allSentences = releasedSentenceGroups.flatMap { it.sentences }
-      if (LegislationName.SDS_PROGRESSION_MODEL in beforeTrancheCalculations) {
-        latestCalculation = sdsProgressionModelFinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_PROGRESSION_MODEL]!!, adjustments)
-      } else if (LegislationName.SDS_40 in beforeTrancheCalculations) {
-        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, adjustments, allSentences)
+      if (applicableSdsLegislations.hasTrancheSet(LegislationName.SDS_PROGRESSION_MODEL) && SnapshotName.BEFORE_PROGRESSION_MODEL_TRANCHE in snapshots) {
+        val preLegislationCalculation = PreLegislationCalculation(snapshots[SnapshotName.BEFORE_PROGRESSION_MODEL_TRANCHE]!!.result, applicableSdsLegislations.getApplicableLegislation(LegislationName.SDS_PROGRESSION_MODEL)!!)
+        latestCalculation = sdsProgressionModelFinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments)
+      } else if (applicableSdsLegislations.hasTrancheSet(LegislationName.SDS_40) && SnapshotName.BEFORE_SDS40_TRANCHE in snapshots) {
+        val preLegislationCalculation = PreLegislationCalculation(snapshots[SnapshotName.BEFORE_SDS40_TRANCHE]!!.result, applicableSdsLegislations.getApplicableLegislation(LegislationName.SDS_40)!!)
+        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, adjustments, allSentences)
       }
 
       val sds40TrancheName = timelineTrackingData.trancheAllocationByLegislationName[LegislationName.SDS_40] ?: TrancheName.TRANCHE_0
@@ -199,7 +220,7 @@ class BookingTimelineService(
           }
           currentSentenceGroup.clear()
         }
-        latestCalculation = timelineCalculator.getLatestCalculation(releasedSentenceGroups.map { it.sentences }, offender, returnToCustodyDate)
+        latestCalculation = timelineCalculator.getLatestCalculation(releasedSentenceGroups.map { it.sentences }, offender, returnToCustodyDate, snapshots)
       }
       if (licenceSentences.isNotEmpty()) {
         val sentencesThatHaveExpired = licenceSentences.filter { date.isAfter(it.sentenceCalculation.licenceExpiryAtInitialRelease) }
@@ -209,18 +230,23 @@ class BookingTimelineService(
     }
   }
 
-  private fun getCalculationsByDate(sentences: List<CalculableSentence>, futureData: TimelineFutureData, externalMovements: List<ExternalMovement>): Map<LocalDate, List<TimelineCalculationEvent>> = (
-    sentences.flatMap { it.sentenceParts().map { part -> SentenceTimelineCalculationEvent(part.sentencedAt) } } +
-      futureData.additional.map { AwardedAdjustmentTimelineCalculationEvent(it.appliesToSentencesFrom, TimelineCalculationType.ADDITIONAL_DAYS) } +
-      futureData.restored.map { AwardedAdjustmentTimelineCalculationEvent(it.appliesToSentencesFrom, TimelineCalculationType.RESTORATION_DAYS) } +
-      futureData.ual.map { UALTimelineCalculationEvent(it.appliesToSentencesFrom) } +
-      sdsLegislationConfiguration.all().flatMap { legislation -> legislation.requiredTimelineCalculations() } +
-      ftrLegislationConfiguration.ftr56Legislation.requiredTimelineCalculations() +
-      externalMovements.map { ExternalMovementTimelineCalculationEvent(it.movementDate) }
-    )
-    .sortedBy { it.date }
-    .distinct()
-    .groupBy { it.date }
+  private fun getCalculationsByDate(sentences: List<CalculableSentence>, futureData: TimelineFutureData, externalMovements: List<ExternalMovement>, calculateErsed: Boolean): Map<LocalDate, List<TimelineCalculationEvent>> {
+    val sentenceParts = sentences.flatMap { it.sentenceParts() }
+    val ers30SnapshotIfRequired = if (calculateErsed && sentenceParts.any { it.sentencedAt.isAfter(ImportantDates.ERS30_COMMENCEMENT_DATE) }) SimpleSnapshotTimelineCalculationEvent(ImportantDates.ERS30_COMMENCEMENT_DATE, SnapshotName.BEFORE_ERS30) else null
+    return (
+      sentenceParts.map { part -> SentenceTimelineCalculationEvent(part.sentencedAt) } +
+        futureData.additional.map { AwardedAdjustmentTimelineCalculationEvent(it.appliesToSentencesFrom, TimelineCalculationType.ADDITIONAL_DAYS) } +
+        futureData.restored.map { AwardedAdjustmentTimelineCalculationEvent(it.appliesToSentencesFrom, TimelineCalculationType.RESTORATION_DAYS) } +
+        futureData.ual.map { UALTimelineCalculationEvent(it.appliesToSentencesFrom) } +
+        sdsLegislationConfiguration.all().flatMap { legislation -> legislation.requiredTimelineCalculations() } +
+        ftrLegislationConfiguration.ftr56Legislation.requiredTimelineCalculations() +
+        externalMovements.map { ExternalMovementTimelineCalculationEvent(it.movementDate) } +
+        listOfNotNull(ers30SnapshotIfRequired)
+      )
+      .sortedBy { it.date }
+      .distinct()
+      .groupBy { it.date }
+  }
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/CalculationSnapshot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/CalculationSnapshot.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline
+
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import java.time.LocalDate
+
+data class CalculationSnapshot(val name: SnapshotName, val result: CalculationResult, val dateAtWhichSnapshotTaken: LocalDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/SnapshotName.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/SnapshotName.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline
+
+enum class SnapshotName {
+  BEFORE_ERS30,
+  BEFORE_SDS40_TRANCHE,
+  BEFORE_PROGRESSION_MODEL_TRANCHE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculationEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculationEvent.kt
@@ -36,7 +36,23 @@ sealed interface TimelineCalculationEvent {
     override val type: TimelineCalculationType = TimelineCalculationType.SDS_LEGISLATION_COMMENCEMENT
   }
 
-  data class SDSTrancheTimelineCalculationEvent(override val date: LocalDate, val legislation: SDSLegislationWithTranches, val tranche: TrancheConfiguration) : TimelineCalculationEvent {
-    override val type: TimelineCalculationType = TimelineCalculationType.EARLY_RELEASE_TRANCHE
+  data class SDSTrancheAllocationTimelineCalculationEvent(override val date: LocalDate, val legislation: SDSLegislationWithTranches, val tranche: TrancheConfiguration) : TimelineCalculationEvent {
+    override val type: TimelineCalculationType = TimelineCalculationType.SDS_TRANCHE_ALLOCATION
+  }
+
+  data class SDS40SnapshotTimelineCalculationEvent(override val date: LocalDate, val legislation: SDSLegislationWithTranches, val tranche: TrancheConfiguration) : TimelineCalculationEvent {
+    override val type: TimelineCalculationType = TimelineCalculationType.SDS40_SNAPSHOT
+  }
+
+  data class ProgressionModelSnapshotTimelineCalculationEvent(override val date: LocalDate, val legislation: SDSLegislationWithTranches) : TimelineCalculationEvent {
+    override val type: TimelineCalculationType = TimelineCalculationType.PROGRESSION_MODEL_SNAPSHOT
+  }
+
+  data class SDSTrancheRecalculationTimelineCalculationEvent(override val date: LocalDate, val legislation: SDSLegislationWithTranches, val tranche: TrancheConfiguration) : TimelineCalculationEvent {
+    override val type: TimelineCalculationType = TimelineCalculationType.SDS_TRANCHE_RECALCULATION
+  }
+
+  data class SimpleSnapshotTimelineCalculationEvent(override val date: LocalDate, val snapshotName: SnapshotName) : TimelineCalculationEvent {
+    override val type: TimelineCalculationType = TimelineCalculationType.SIMPLE_SNAPSHOT
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculationType.kt
@@ -5,9 +5,13 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline
  * This is important in some scenarios such as whether someone is sentenced on the same day as SDS legislation commencement.
  */
 enum class TimelineCalculationType(val order: Int) {
+  SIMPLE_SNAPSHOT(5),
   SDS_LEGISLATION_COMMENCEMENT(10),
-  EARLY_RELEASE_TRANCHE(20),
+  SDS_TRANCHE_ALLOCATION(20),
   SDS_LEGISLATION_AMENDMENT(30),
+  SDS40_SNAPSHOT(35),
+  PROGRESSION_MODEL_SNAPSHOT(36),
+  SDS_TRANCHE_RECALCULATION(37),
   FTR56_TRANCHE(40),
   SENTENCED(50),
   EXTERNAL_MOVEMENT(60),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineCalculator.kt
@@ -21,7 +21,7 @@ class TimelineCalculator(
   private val bookingExtractionService: BookingExtractionService,
 ) {
 
-  fun getLatestCalculation(sentences: List<List<CalculableSentence>>, offender: Offender, returnToCustodyDate: LocalDate? = null): CalculationResult {
+  fun getLatestCalculation(sentences: List<List<CalculableSentence>>, offender: Offender, returnToCustodyDate: LocalDate? = null, snapshots: Map<SnapshotName, CalculationSnapshot>): CalculationResult {
     calculateUnusedAdas(sentences)
     sentences.flatten().forEach {
       sentenceAdjustedCalculationService.calculateDatesFromAdjustments(it, offender)
@@ -37,6 +37,7 @@ class TimelineCalculator(
       sentences,
       offender,
       returnToCustodyDate,
+      snapshots,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineTrackingData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/TimelineTrackingData.kt
@@ -4,7 +4,6 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableSDSLegislations
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.FTRLegislation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.enumerations.TrancheName
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Adjustments
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
@@ -31,7 +30,7 @@ data class TimelineTrackingData(
   val previousUalPeriods: MutableList<Pair<LocalDate, LocalDate>> = mutableListOf(),
 
   var padas: Long = 0,
-  var beforeTrancheCalculations: MutableMap<LegislationName, PreLegislationCalculation> = mutableMapOf(),
+  var snapshots: MutableMap<SnapshotName, CalculationSnapshot> = mutableMapOf(),
 
   var applicableFtrLegislation: ApplicableLegislation<FTRLegislation>? = null,
   val applicableSdsLegislations: ApplicableSDSLegislations = ApplicableSDSLegislations(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/ProgressionModelSnapshotTimelineCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/ProgressionModelSnapshotTimelineCalculationHandler.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.CalculationSnapshot
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SDS40FinalDatesService
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SnapshotName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.ProgressionModelSnapshotTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
+
+@Service
+class ProgressionModelSnapshotTimelineCalculationHandler(
+  timelineCalculator: TimelineCalculator,
+  private val sds40FinalDatesService: SDS40FinalDatesService,
+) : TimelineCalculationHandler<ProgressionModelSnapshotTimelineCalculationEvent>(timelineCalculator) {
+
+  override fun handle(
+    event: ProgressionModelSnapshotTimelineCalculationEvent,
+    timelineTrackingData: TimelineTrackingData,
+  ): TimelineHandleResult {
+    with(timelineTrackingData) {
+      val applicableLegislation = applicableSdsLegislations.getApplicableLegislation(event.legislation.legislationName)
+      val allSentences = releasedSentenceGroups.map { it.sentences }.plus(listOf(currentSentenceGroup))
+      val timelineCalculationDate = event.date
+      val currentTimelineDateIsTheAllocatedTrancheDate = timelineCalculationDate == applicableLegislation?.earliestApplicableDate
+      if (applicableLegislation != null && currentTimelineDateIsTheAllocatedTrancheDate && allSentences.flatten().isNotEmpty()) {
+        var latestCalculation = timelineCalculator.getLatestCalculation(allSentences, offender, returnToCustodyDate, snapshots)
+        if (applicableSdsLegislations.hasTrancheSet(LegislationName.SDS_40) && SnapshotName.BEFORE_SDS40_TRANCHE in snapshots) {
+          // if there was already an SDS40 tranche allocated then apply defaulting and adjustments at this point so that any SDS50 dates that were
+          // retained for SDS40 are used in the progression model defaulting and will likely still be retained then as well.
+          val preLegislationCalculation = PreLegislationCalculation(snapshots[SnapshotName.BEFORE_SDS40_TRANCHE]!!.result, applicableSdsLegislations.getApplicableLegislation(LegislationName.SDS_40)!!)
+          latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, preLegislationCalculation, originalAdjustments, allSentences.flatten())
+        }
+        snapshots[SnapshotName.BEFORE_PROGRESSION_MODEL_TRANCHE] = CalculationSnapshot(SnapshotName.BEFORE_PROGRESSION_MODEL_TRANCHE, latestCalculation, timelineCalculationDate)
+      }
+    }
+    return TimelineHandleResult()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SDS40SnapshotTimelineCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SDS40SnapshotTimelineCalculationHandler.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.CalculationSnapshot
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SnapshotName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDS40SnapshotTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
+
+@Service
+class SDS40SnapshotTimelineCalculationHandler(
+  timelineCalculator: TimelineCalculator,
+) : TimelineCalculationHandler<SDS40SnapshotTimelineCalculationEvent>(timelineCalculator) {
+
+  override fun handle(
+    event: SDS40SnapshotTimelineCalculationEvent,
+    timelineTrackingData: TimelineTrackingData,
+  ): TimelineHandleResult {
+    with(timelineTrackingData) {
+      val legislationToApply = event.legislation
+      val timelineCalculationDate = event.date
+      val applicableLegislation = applicableSdsLegislations.getApplicableLegislation(legislationToApply.legislationName)
+      val sentencesToModifyReleaseDates = legislationToApply.sentencesToModifyReleaseDates(timelineTrackingData.currentSentenceGroup + timelineTrackingData.licenceSentences, timelineCalculationDate)
+      val currentTimelineDateIsTheAllocatedTrancheDate = timelineCalculationDate == applicableLegislation?.earliestApplicableDate
+      if (applicableLegislation != null && currentTimelineDateIsTheAllocatedTrancheDate && sentencesToModifyReleaseDates.isNotEmpty()) {
+        val allSentences = releasedSentenceGroups.map { it.sentences }.plus(listOf(currentSentenceGroup))
+        val latestCalculation = timelineCalculator.getLatestCalculation(allSentences, offender, returnToCustodyDate, snapshots)
+        snapshots[SnapshotName.BEFORE_SDS40_TRANCHE] = CalculationSnapshot(SnapshotName.BEFORE_SDS40_TRANCHE, latestCalculation, timelineCalculationDate)
+      }
+    }
+    return TimelineHandleResult()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SDSTrancheRecalculationTimelineCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SDSTrancheRecalculationTimelineCalculationHandler.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableLegislation.Companion.applyToSentence
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheRecalculationTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
+
+@Service
+class SDSTrancheRecalculationTimelineCalculationHandler(
+  timelineCalculator: TimelineCalculator,
+) : TimelineCalculationHandler<SDSTrancheRecalculationTimelineCalculationEvent>(timelineCalculator) {
+
+  override fun handle(
+    event: SDSTrancheRecalculationTimelineCalculationEvent,
+    timelineTrackingData: TimelineTrackingData,
+  ): TimelineHandleResult {
+    with(timelineTrackingData) {
+      val legislationToApply = event.legislation
+      val timelineCalculationDate = event.date
+      val applicableLegislation = applicableSdsLegislations.getApplicableLegislation(legislationToApply.legislationName)
+      val sentencesToModifyReleaseDates = legislationToApply.sentencesToModifyReleaseDates(timelineTrackingData.currentSentenceGroup + timelineTrackingData.licenceSentences, timelineCalculationDate)
+      val currentTimelineDateIsTheAllocatedTrancheDate = timelineCalculationDate == applicableLegislation?.earliestApplicableDate
+      val anySentencesRequiringRecalculation = if (applicableLegislation != null && currentTimelineDateIsTheAllocatedTrancheDate && sentencesToModifyReleaseDates.isNotEmpty()) {
+        sentencesToModifyReleaseDates.forEach {
+          applicableLegislation.applyToSentence(it, timelineCalculationDate)
+          it.sentenceCalculation.adjustments = it.sentenceCalculation.adjustments.copy(
+            unusedAdaDays = 0,
+            unusedLicenceAdaDays = 0,
+          )
+        }
+        true
+      } else {
+        // No sentences at tranche date.
+        false
+      }
+      if (!anySentencesRequiringRecalculation) {
+        return TimelineHandleResult(requiresCalculation = false)
+      }
+    }
+    return TimelineHandleResult()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SimpleSnapshotTimelineCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/SimpleSnapshotTimelineCalculationHandler.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.handlers
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.CalculationSnapshot
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SimpleSnapshotTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
+
+@Service
+class SimpleSnapshotTimelineCalculationHandler(timelineCalculator: TimelineCalculator) : TimelineCalculationHandler<SimpleSnapshotTimelineCalculationEvent>(timelineCalculator) {
+
+  override fun handle(
+    event: SimpleSnapshotTimelineCalculationEvent,
+    timelineTrackingData: TimelineTrackingData,
+  ): TimelineHandleResult {
+    with(timelineTrackingData) {
+      val allSentenceGroups = releasedSentenceGroups.map { it.sentences }.plus(listOf(currentSentenceGroup))
+      if (allSentenceGroups.flatten().isNotEmpty()) {
+        val latestCalculation = timelineCalculator.getLatestCalculation(allSentenceGroups, offender, returnToCustodyDate, snapshots)
+        snapshots[event.snapshotName] = CalculationSnapshot(event.snapshotName, latestCalculation, event.date)
+      }
+    }
+    return TimelineHandleResult()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/timeline/handlers/TimelineSDSTrancheCalculationHandler.kt
@@ -2,91 +2,32 @@ package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.h
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableLegislation
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.ApplicableLegislation.Companion.applyToSentence
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.LegislationName
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.PreLegislationCalculation
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislation
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.earlyrelease.config.SDSLegislationWithTranches
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.TrancheAllocationService
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SDS40FinalDatesService
-import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheTimelineCalculationEvent
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculationEvent.SDSTrancheAllocationTimelineCalculationEvent
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineCalculator
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineHandleResult
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.TimelineTrackingData
-import java.time.LocalDate
 
 @Service
 class TimelineSDSTrancheCalculationHandler(
   timelineCalculator: TimelineCalculator,
   private val trancheAllocationService: TrancheAllocationService,
-  private val sds40FinalDatesService: SDS40FinalDatesService,
-) : TimelineCalculationHandler<SDSTrancheTimelineCalculationEvent>(timelineCalculator) {
+) : TimelineCalculationHandler<SDSTrancheAllocationTimelineCalculationEvent>(timelineCalculator) {
 
   override fun handle(
-    event: SDSTrancheTimelineCalculationEvent,
+    event: SDSTrancheAllocationTimelineCalculationEvent,
     timelineTrackingData: TimelineTrackingData,
   ): TimelineHandleResult {
     with(timelineTrackingData) {
-      allocateATrancheIfNoneSetYetForThisLegislation(event.legislation)
-
-      val anySentencesRequiringRecalculation = configureCalculationsForSentencesImpactedByThisTranche(event.legislation, event.date)
-      if (!anySentencesRequiringRecalculation) {
-        return TimelineHandleResult(requiresCalculation = false)
+      val legislationToApply = event.legislation
+      val requiresTrancheAllocation = !applicableSdsLegislations.hasTrancheSet(legislationToApply.legislationName)
+      if (requiresTrancheAllocation) {
+        trancheAllocationService.allocateTranche(this, legislationToApply)?.let { allocated ->
+          applicableSdsLegislations.setApplicableLegislation(ApplicableLegislation(legislationToApply, allocated.date))
+          trancheAllocationByLegislationName[legislationToApply.legislationName] = allocated.name
+        }
       }
     }
     return TimelineHandleResult()
   }
-
-  private fun TimelineTrackingData.configureCalculationsForSentencesImpactedByThisTranche(
-    legislationToApply: SDSLegislationWithTranches,
-    timelineCalculationDate: LocalDate,
-  ): Boolean {
-    val applicableLegislation = applicableSdsLegislations.getApplicableLegislation(legislationToApply.legislationName)
-    val sentencesToModifyReleaseDates = sentencesToModifyReleaseDates(this, timelineCalculationDate, legislationToApply)
-    val currentTimelineDateIsTheAllocatedTrancheDate = timelineCalculationDate == applicableLegislation?.earliestApplicableDate
-    return if (applicableLegislation != null && currentTimelineDateIsTheAllocatedTrancheDate && sentencesToModifyReleaseDates.isNotEmpty()) {
-      val allSentences = releasedSentenceGroups.map { it.sentences }.plus(listOf(currentSentenceGroup))
-      var latestCalculation = timelineCalculator.getLatestCalculation(allSentences, offender, returnToCustodyDate)
-      if (legislationToApply.legislationName == LegislationName.SDS_PROGRESSION_MODEL && LegislationName.SDS_40 in beforeTrancheCalculations) {
-        // if there was already an SDS40 tranche allocated then apply defaulting and adjustments at this point so that any SDS50 dates that were
-        // retained for SDS40 are used in the progression model defaulting and will likely still be retained then as well.
-        latestCalculation = sds40FinalDatesService.applyFinalDates(latestCalculation, beforeTrancheCalculations[LegislationName.SDS_40]!!, originalAdjustments, allSentences.flatten())
-      }
-      beforeTrancheCalculations[legislationToApply.legislationName] = PreLegislationCalculation(
-        latestCalculation,
-        applicableLegislation,
-      )
-      sentencesToModifyReleaseDates.forEach {
-        applicableLegislation.applyToSentence(it, timelineCalculationDate)
-        it.sentenceCalculation.adjustments = it.sentenceCalculation.adjustments.copy(
-          unusedAdaDays = 0,
-          unusedLicenceAdaDays = 0,
-        )
-      }
-      true
-    } else {
-      // No sentences at tranche date.
-      false
-    }
-  }
-
-  private fun TimelineTrackingData.allocateATrancheIfNoneSetYetForThisLegislation(legislationToApply: SDSLegislation) {
-    val requiresTrancheAllocation = !applicableSdsLegislations.hasTrancheSet(legislationToApply.legislationName)
-    if (requiresTrancheAllocation && legislationToApply is SDSLegislationWithTranches) {
-      trancheAllocationService.allocateTranche(this, legislationToApply)?.let { allocated ->
-        applicableSdsLegislations.setApplicableLegislation(ApplicableLegislation(legislationToApply, allocated.date))
-        trancheAllocationByLegislationName[legislationToApply.legislationName] = allocated.name
-      }
-    }
-  }
-
-  private fun sentencesToModifyReleaseDates(
-    timelineTrackingData: TimelineTrackingData,
-    timelineCalculationDate: LocalDate,
-    legislation: SDSLegislation,
-  ): List<CalculableSentence> = (timelineTrackingData.currentSentenceGroup + timelineTrackingData.licenceSentences).filter {
-    it.sentenceCalculation.adjustedDeterminateReleaseDate.isAfter(timelineCalculationDate)
-  }
-    .filter { sentence -> sentence.sentenceParts().any { legislation.appliesToSentence(it) } }
 }

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac1-1.json
@@ -1,0 +1,89 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-09-11"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 12
+          }
+        },
+        "sentencedAt": "2023-09-11",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2026-05-26"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 4
+          }
+        },
+        "sentencedAt": "2026-05-26",
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ],
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2023-09-11",
+          "numberOfDays": 219,
+          "fromDate": "2023-02-04",
+          "toDate": "2023-09-10"
+        }
+      ],
+      "TAGGED_BAIL": [
+        {
+          "appliesToSentencesFrom": "2023-09-11",
+          "numberOfDays": 45
+        }
+      ],
+      "UNLAWFULLY_AT_LARGE": [
+        {
+          "appliesToSentencesFrom": "2025-12-11",
+          "numberOfDays": 134,
+          "fromDate": "2025-12-11",
+          "toDate": "2026-04-23",
+          "additionalInfo": {
+            "type": "UAL",
+            "reason": "ESCAPE"
+          }
+        }
+      ]
+    }
+  },
+  "userInputs": {
+    "calculateErsed": true,
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model-october",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac1-2.json
@@ -1,0 +1,80 @@
+{
+  "booking": {
+    "offender": {
+      "reference": "ABC123",
+      "dateOfBirth": "2000-01-01",
+      "isActiveSexOffender": true
+    },
+    "sentences": [
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2023-09-11"
+        },
+        "duration": {
+          "durationElements": {
+            "YEARS": 11
+          }
+        },
+        "sentencedAt": "2023-09-11",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-10"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 4
+          }
+        },
+        "sentencedAt": "2025-10-10",
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ],
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      },
+      {
+        "type": "StandardSentence",
+        "offence": {
+          "committedAt": "2025-10-10"
+        },
+        "duration": {
+          "durationElements": {
+            "MONTHS": 12
+          }
+        },
+        "sentencedAt": "2025-10-10",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
+      }
+    ],
+    "adjustments": {}
+  },
+  "userInputs": {
+    "calculateErsed": true,
+    "useOffenceIndicators": true
+  },
+  "params": "sds-progression-model-october",
+  "featureToggles": {
+    "applyPostRecallRepealRules": true,
+    "routePreProgressionExtinguishedSentenceToManual": true
+  }
+}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2472-ac-01_01.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2472-ac-01_01.json
@@ -3,7 +3,7 @@
     "SLED": "2029-08-04",
     "CRD": "2026-09-11",
     "HDCED": "2025-09-12",
-    "ERSED": "2024-11-16",
+    "ERSED": "2025-02-05",
     "ESED": "2029-08-04"
   },
   "effectiveSentenceLength": "P5Y6M"

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac1-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac1-1.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2035-09-02",
+    "CRD": "2027-06-13",
+    "ERSED": "2025-09-23",
+    "ESED": "2036-01-10"
+  },
+  "effectiveSentenceLength": "P12Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_10"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac1-2.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac1-2.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2035-01-10",
+    "CRD": "2027-06-21",
+    "ERSED": "2025-11-23",
+    "ESED": "2035-01-10"
+  },
+  "effectiveSentenceLength": "P11Y4M",
+  "trancheAllocationByLegislationName": {
+    "SDS_40": "TRANCHE_2",
+    "SDS_PROGRESSION_MODEL": "TRANCHE_9"
+  },
+  "affectedByProgressionModel": true
+}


### PR DESCRIPTION
Separate out the responsibility of the tranche timeline handler into specific events for allocating, recalculating and taking snapshots.

Implement a snapshot for ERS30 commencement and then use the later of that snapshot or the current timeline value when extracting ERSED.

This is to handle the scenario where a sentence is imposed consecutively after ERS30 commencement. While the consecutive chain at the point of ERS30 commencement will have a shorter overall sentence length it can still produce a later ERSED as it would have been calculated using ERS50. We need to maintain that date as that is the ERSED that would have applied before the consecutive chain was extended but they must not have been released under ERS as a subsequent sentence was imposed. If we were to take the earlier of the two dates it would have been before they could've actually been released under ERS. This keeps it historically accurate and is the approach directed to us by policy.