### PR TITLE
CRS-2828: PM exclusion metadata updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSDescriptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSDescriptions.kt
@@ -6,8 +6,12 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.Sent
 data class SDSDescriptions(
   @Schema(description = "Any reason this sentence might be excluded from SDS40", nullable = true)
   val sds40ExclusionDescription: String?,
-  @Schema(description = "Any reason this sentence might be excluded from Progression Model", nullable = true)
+  @Schema(description = "DEPRECATED - Use progressionModelDoesNotApplyDescription and progressionModelExcludedOffenceDescription", nullable = true, deprecated = true)
   val progressionModelExclusionDescription: String?,
+  @Schema(description = "Any reason this sentence might be excluded from Progression Model", nullable = true)
+  val progressionModelDoesNotApplyDescription: String?,
+  @Schema(description = "If this offence is excluded from progression model", nullable = true)
+  val progressionModelExcludedOffenceDescription: String?,
   @Schema(description = "The way to display SDS plus status for the sentence", allowableValues = ["SDS+", "YOI+", "S250+"], nullable = true)
   val sdsPlusDisplayName: String?,
 ) {
@@ -16,20 +20,27 @@ data class SDSDescriptions(
       val releaseArrangements = sentenceAndOffence.sdsReleaseArrangements
       val sentenceCalculationType = SentenceCalculationType.from(sentenceAndOffence.sentenceCalculationType)
       return if (releaseArrangements != null && sentenceCalculationType.isSDS()) {
-        val progressionModelExclusionDescription = if (sentenceCalculationType == SentenceCalculationType.SEC91_03 || sentenceCalculationType == SentenceCalculationType.SEC91_03_ORA) {
+        val progressionModelDoesNotApplyDescription = if (sentenceCalculationType == SentenceCalculationType.SEC91_03 || sentenceCalculationType == SentenceCalculationType.SEC91_03_ORA) {
           "Section 91"
         } else if (sentenceCalculationType.isSection250()) {
           "Section 250"
-        } else if (releaseArrangements.hasProgressionModelExclusion()) {
-          releaseArrangements.sdsEarlyReleaseExclusions.firstOrNull { it.progressionModelExclusion }?.displayName
+        } else if (SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 in releaseArrangements.sdsEarlyReleaseExclusions) {
+          SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3.displayName
         } else if (releaseArrangements.wouldBeSDSPlusIfSentencedToday()) {
           "Would be ${sentenceCalculationType.sdsPlusDisplayName}"
         } else {
           null
         }
+        val progressionModelExcludedOffenceDescription = if (SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE in releaseArrangements.sdsEarlyReleaseExclusions) {
+          SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE.displayName
+        } else {
+          null
+        }
         SDSDescriptions(
           sds40ExclusionDescription = releaseArrangements.sdsEarlyReleaseExclusions.firstOrNull { it.sds40Exclusion || it.sds40AdditionalExcludedOffence }?.displayName,
-          progressionModelExclusionDescription = progressionModelExclusionDescription,
+          progressionModelExclusionDescription = progressionModelDoesNotApplyDescription ?: progressionModelExcludedOffenceDescription,
+          progressionModelDoesNotApplyDescription = progressionModelDoesNotApplyDescription,
+          progressionModelExcludedOffenceDescription = progressionModelExcludedOffenceDescription,
           sdsPlusDisplayName = if (releaseArrangements.isSDSPlus) sentenceCalculationType.sdsPlusDisplayName else null,
         )
       } else {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/model/SDSMetaDataTest.kt
@@ -15,17 +15,17 @@ class SDSMetaDataTest {
   @EnumSource(SDSEarlyReleaseExclusionType::class)
   fun `should provide display name texts based on exclusions`(exclusion: SDSEarlyReleaseExclusionType) {
     val expected = when (exclusion) {
-      SDSEarlyReleaseExclusionType.SEXUAL -> SDSDescriptions("Sexual", null, null)
-      SDSEarlyReleaseExclusionType.VIOLENT -> SDSDescriptions("Violent", null, null)
-      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE -> SDSDescriptions("Domestic Abuse", null, null)
-      SDSEarlyReleaseExclusionType.NATIONAL_SECURITY -> SDSDescriptions("National Security", null, null)
-      SDSEarlyReleaseExclusionType.TERRORISM -> SDSDescriptions("Terrorism", null, null)
-      SDSEarlyReleaseExclusionType.SEXUAL_T3 -> SDSDescriptions("Sexual (for prisoners in custody on or after the 16th Dec 2024)", null, null)
-      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> SDSDescriptions("Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)", null, null)
-      SDSEarlyReleaseExclusionType.MURDER_T3 -> SDSDescriptions("Murder (for prisoners in custody on or after the 16th Dec 2024)", null, null)
-      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> SDSDescriptions(null, "Schedule 13 Part 3", null)
-      SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE -> SDSDescriptions(null, "Excluded offence", null)
-      SDSEarlyReleaseExclusionType.NO -> SDSDescriptions(null, null, null)
+      SDSEarlyReleaseExclusionType.SEXUAL -> SDSDescriptions("Sexual", null, null, null, null)
+      SDSEarlyReleaseExclusionType.VIOLENT -> SDSDescriptions("Violent", null, null, null, null)
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE -> SDSDescriptions("Domestic Abuse", null, null, null, null)
+      SDSEarlyReleaseExclusionType.NATIONAL_SECURITY -> SDSDescriptions("National Security", null, null, null, null)
+      SDSEarlyReleaseExclusionType.TERRORISM -> SDSDescriptions("Terrorism", null, null, null, null)
+      SDSEarlyReleaseExclusionType.SEXUAL_T3 -> SDSDescriptions("Sexual (for prisoners in custody on or after the 16th Dec 2024)", null, null, null, null)
+      SDSEarlyReleaseExclusionType.DOMESTIC_ABUSE_T3 -> SDSDescriptions("Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)", null, null, null, null)
+      SDSEarlyReleaseExclusionType.MURDER_T3 -> SDSDescriptions("Murder (for prisoners in custody on or after the 16th Dec 2024)", null, null, null, null)
+      SDSEarlyReleaseExclusionType.PROGRESSION_MODEL_SCHEDULE_13_PART_3 -> SDSDescriptions(null, "Schedule 13 Part 3", "Schedule 13 Part 3", null, null)
+      SDSEarlyReleaseExclusionType.SA2026_PROGRESSION_MODEL_SCHEDULE -> SDSDescriptions(null, "Excluded offence", null, "Excluded offence", null)
+      SDSEarlyReleaseExclusionType.NO -> SDSDescriptions(null, null, null, null, null)
     }
     val result = SDSDescriptions.from(
       ADIMP_SENTENCE.copy(
@@ -46,7 +46,7 @@ class SDSMetaDataTest {
     val result = SDSDescriptions.from(
       ADIMP_SENTENCE.copy(sentenceCalculationType = sentenceCalculationType),
     )
-    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 91", null))
+    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 91", "Section 91", null, null))
   }
 
   @ParameterizedTest
@@ -55,7 +55,7 @@ class SDSMetaDataTest {
     val result = SDSDescriptions.from(
       ADIMP_SENTENCE.copy(sentenceCalculationType = sentenceCalculationType),
     )
-    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 250", null))
+    assertThat(result).isEqualTo(SDSDescriptions(null, "Section 250", "Section 250", null, null))
   }
 
   @ParameterizedTest
@@ -77,7 +77,7 @@ class SDSMetaDataTest {
         ),
       ),
     )
-    assertThat(result).isEqualTo(SDSDescriptions(null, expected, null))
+    assertThat(result).isEqualTo(SDSDescriptions(null, expected, expected, null, null))
   }
 
   @ParameterizedTest
@@ -107,7 +107,7 @@ class SDSMetaDataTest {
   @Test
   fun `should have no exclusions`() {
     val result = SDSDescriptions.from(ADIMP_SENTENCE)
-    assertThat(result).isEqualTo(SDSDescriptions(null, null, null))
+    assertThat(result).isEqualTo(SDSDescriptions(null, null, null, null, null))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/resource/CalculationIntTest.kt
@@ -496,12 +496,12 @@ class CalculationIntTest(private val mockManageOffencesClient: MockManageOffence
 
     val sdsPlusFromBooking = bookingSentenceAndOffences.find { it.offence.offenceCode == "SX03001" }!!
     val sdsPlusFromCalculation = calculationSentenceAndOffences.find { it.offence.offenceCode == "SX03001" }!!
-    assertThat(sdsPlusFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions(null, null, "SDS+"))
+    assertThat(sdsPlusFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions(null, null, null, null, "SDS+"))
     assertThat(sdsPlusFromBooking).usingRecursiveComparison().ignoringFields("sentenceAndOffenceAnalysis").isEqualTo(sdsPlusFromCalculation)
 
     val sexualExclusionFromBooking = bookingSentenceAndOffences.find { it.offence.offenceCode == "TR68132" }!!
     val sexualExclusionFromCalculation = calculationSentenceAndOffences.find { it.offence.offenceCode == "TR68132" }!!
-    assertThat(sexualExclusionFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions("Sexual", null, null))
+    assertThat(sexualExclusionFromBooking.sdsDescriptions).isEqualTo(SDSDescriptions("Sexual", null, null, null, null))
     assertThat(sexualExclusionFromBooking).usingRecursiveComparison().ignoringFields("sentenceAndOffenceAnalysis").isEqualTo(sexualExclusionFromCalculation)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/SentenceAndOffenceServiceTest.kt
@@ -76,7 +76,7 @@ class SentenceAndOffenceServiceTest {
       isSDSPlus = false,
       hasAnSDSEarlyReleaseExclusion = SDSEarlyReleaseExclusionType.NO,
       sentenceAndOffenceAnalysis = SentenceAndOffenceAnalysis.NEW,
-      sdsDescriptions = SDSDescriptions(null, null, null),
+      sdsDescriptions = SDSDescriptions(null, null, null, null, null),
       revocationDates = listOf(LocalDate.of(2024, 1, 1)),
     )
     assertThat(response[0]).isEqualTo(analysedSentenceAndOffence)


### PR DESCRIPTION
Separate out "does not apply to" from "exclusion" which are subtly different (apparently) and to be shown as separate fields in the UI. Maintaining the old combined field for backwards compatability until the UI is updated.