### PR TITLE
CRS-2812: Only use ERS30 snapshot if both pre and post consec chain

### DIFF
--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -28,6 +28,7 @@ generic-service:
     PROGRESSION_TRANCHE_ONE_MANUAL_JOURNEY: "false"
     PROGRESSION_MODEL_SCHEDULE_EXCLUSION_ENABLED: "true"
     ROUTE_PROGRESSION_MODEL_SCHEDULE_EXCLUSION_TO_MANUAL: "false"
+    USE_LATEST_ERSED_FROM_PRE_ERS_30_SNAPSHOT: "true"
 
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-alt-preprod.yaml
+++ b/helm_deploy/values-alt-preprod.yaml
@@ -27,6 +27,7 @@ generic-service:
     PROGRESSION_TRANCHE_ONE_MANUAL_JOURNEY: "false"
     PROGRESSION_MODEL_SCHEDULE_EXCLUSION_ENABLED: "true"
     ROUTE_PROGRESSION_MODEL_SCHEDULE_EXCLUSION_TO_MANUAL: "false"
+    USE_LATEST_ERSED_FROM_PRE_ERS_30_SNAPSHOT: "true"
 
   serviceAccountName: calculate-release-dates-api-preprod
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/calculatereleasedatesapi/service/BookingExtractionService.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.AbstractSente
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.BotusSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculableSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.CalculationResult
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ConsecutiveSentence
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.Offender
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.ReleaseDateCalculationBreakdown
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.SentenceCalculation
@@ -35,6 +36,7 @@ import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.sentence.Se
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.sentence.oraAndNoneOraExtraction
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.CalculationSnapshot
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.service.timeline.SnapshotName
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.hasSentencesBeforeAndAfter
 import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.util.isAfterOrEqualTo
 import java.time.LocalDate
 import java.time.Period
@@ -109,7 +111,8 @@ class BookingExtractionService(
     if (sentenceCalculation.earlyReleaseSchemeEligibilityDate != null) {
       val latestErsedFromTimeline = sentenceCalculation.earlyReleaseSchemeEligibilityDate!!
       val latestFromErs30Snapshot = snapshots[SnapshotName.BEFORE_ERS30]?.result?.dates?.get(ERSED)
-      if (latestFromErs30Snapshot == null || latestErsedFromTimeline.isAfterOrEqualTo(latestFromErs30Snapshot)) {
+      val hasSentencesBeforeAndAfterErs30 = (sentence is ConsecutiveSentence) && sentence.hasSentencesBeforeAndAfter(ImportantDates.ERS30_COMMENCEMENT_DATE)
+      if (!hasSentencesBeforeAndAfterErs30 || latestFromErs30Snapshot == null || latestErsedFromTimeline.isAfterOrEqualTo(latestFromErs30Snapshot)) {
         dates[ERSED] = latestErsedFromTimeline
       } else {
         dates[ERSED] = latestFromErs30Snapshot
@@ -570,7 +573,8 @@ class BookingExtractionService(
 
     val ersedFromErs30Snapshot = snapshots[SnapshotName.BEFORE_ERS30]?.result?.dates?.get(ERSED)
     val ersedFromTimeline = dates[ERSED]
-    if (ersedFromErs30Snapshot != null && ersedFromTimeline != null && ersedFromErs30Snapshot.isAfter(ersedFromTimeline)) {
+    val hasSentencesBeforeAndAfterErs30 = (latestEarlyReleaseSchemeEligibilitySentence is ConsecutiveSentence) && latestEarlyReleaseSchemeEligibilitySentence.hasSentencesBeforeAndAfter(ImportantDates.ERS30_COMMENCEMENT_DATE)
+    if (hasSentencesBeforeAndAfterErs30 && ersedFromErs30Snapshot != null && ersedFromTimeline != null && ersedFromErs30Snapshot.isAfter(ersedFromTimeline)) {
       val snapshot = snapshots[SnapshotName.BEFORE_ERS30]!!
       dates[ERSED] = ersedFromErs30Snapshot
       snapshot.result.breakdownByReleaseDateType[ERSED]?.let { snapshotErsedBreadkdown -> breakdownByReleaseDateType[ERSED] = snapshotErsedBreadkdown }

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac2-1.json
@@ -3,64 +3,74 @@
     "offender": {
       "reference": "ABC123",
       "dateOfBirth": "2000-01-01",
-      "isActiveSexOffender": false
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-05-12"
+          "committedAt": "2024-10-25"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 24
+            "YEARS": 12
           }
         },
-        "sentencedAt": "2025-05-12",
+        "sentencedAt": "2024-10-25",
         "releaseArrangements": {
-          "isSDSPlus": false,
-          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "isSDSPlus": true,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": true,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
+        }
       },
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-10-02"
+          "committedAt": "2026-06-17"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 12
+            "MONTHS": 20
           }
         },
-        "sentencedAt": "2025-10-02",
+        "sentencedAt": "2026-06-17",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "consecutiveSentenceUUIDs": [
-          "cb304745-d781-47d3-b931-4baa31551fc5"
-        ]
+        }
       },
       {
-        "type": "AFineSentence",
+        "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-11-11"
+          "committedAt": "2026-06-17"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 3
+            "MONTHS": 8
           }
         },
-        "sentencedAt": "2025-11-11",
-        "fineAmount": 99
+        "sentencedAt": "2026-06-17",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
       }
     ],
-    "adjustments": {}
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2024-10-25",
+          "numberOfDays": 25,
+          "fromDate": "2024-09-30",
+          "toDate": "2024-10-24"
+        }
+      ]
+    }
   },
   "userInputs": {
     "calculateErsed": true,

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac3-1.json
@@ -3,64 +3,83 @@
     "offender": {
       "reference": "ABC123",
       "dateOfBirth": "2000-01-01",
-      "isActiveSexOffender": false
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-05-12"
+          "committedAt": "2025-02-14"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 24
+            "YEARS": 3,
+            "MONTHS": 6
           }
         },
-        "sentencedAt": "2025-05-12",
+        "sentencedAt": "2025-02-14",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
+        }
       },
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-10-02"
+          "committedAt": "2025-02-14"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 12
+            "MONTHS": 6
           }
         },
-        "sentencedAt": "2025-10-02",
+        "sentencedAt": "2025-02-14",
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ],
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "consecutiveSentenceUUIDs": [
-          "cb304745-d781-47d3-b931-4baa31551fc5"
-        ]
+        }
       },
       {
-        "type": "AFineSentence",
+        "type": "ExtendedDeterminateSentence",
         "offence": {
-          "committedAt": "2025-11-11"
+          "committedAt": "2025-02-14",
+          "offenceCode": "OF61014"
         },
-        "duration": {
+        "custodialDuration": {
           "durationElements": {
-            "MONTHS": 3
+            "YEARS": 12
           }
         },
-        "sentencedAt": "2025-11-11",
-        "fineAmount": 99
+        "extensionDuration": {
+          "durationElements": {
+            "YEARS": 3
+          }
+        },
+        "sentencedAt": "2025-02-14",
+        "consecutiveSentenceUUIDs": [
+          "023e388e-1673-3bbc-9f13-1b1d915f3b73"
+        ]
       }
     ],
-    "adjustments": {}
+    "adjustments": {
+      "REMAND": [
+        {
+          "appliesToSentencesFrom": "2025-02-14",
+          "numberOfDays": 272,
+          "fromDate": "2024-05-18",
+          "toDate": "2025-02-13"
+        }
+      ]
+    }
   },
   "userInputs": {
     "calculateErsed": true,

--- a/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation/ers-30/crs-2812-ac4-1.json
@@ -3,61 +3,67 @@
     "offender": {
       "reference": "ABC123",
       "dateOfBirth": "2000-01-01",
-      "isActiveSexOffender": false
+      "isActiveSexOffender": true
     },
     "sentences": [
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-05-12"
+          "committedAt": "2026-06-06"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 24
+            "YEARS": 3
           }
         },
-        "sentencedAt": "2025-05-12",
+        "sentencedAt": "2026-06-06",
+        "identifier": "d211f333-aa1a-3e25-ac8d-0459c1f98868",
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "identifier": "cb304745-d781-47d3-b931-4baa31551fc5"
+        }
       },
       {
         "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-10-02"
+          "committedAt": "2026-06-06"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 12
+            "YEARS": 3
           }
         },
-        "sentencedAt": "2025-10-02",
+        "sentencedAt": "2026-06-06",
+        "identifier": "023e388e-1673-3bbc-9f13-1b1d915f3b73",
+        "consecutiveSentenceUUIDs": [
+          "d211f333-aa1a-3e25-ac8d-0459c1f98868"
+        ],
         "releaseArrangements": {
           "isSDSPlus": false,
           "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
           "sdsEarlyReleaseExclusions": [],
           "isSection250": false
-        },
-        "consecutiveSentenceUUIDs": [
-          "cb304745-d781-47d3-b931-4baa31551fc5"
-        ]
+        }
       },
       {
-        "type": "AFineSentence",
+        "type": "StandardSentence",
         "offence": {
-          "committedAt": "2025-11-11"
+          "committedAt": "2026-06-06"
         },
         "duration": {
           "durationElements": {
-            "MONTHS": 3
+            "YEARS": 3
           }
         },
-        "sentencedAt": "2025-11-11",
-        "fineAmount": 99
+        "sentencedAt": "2026-06-06",
+        "releaseArrangements": {
+          "isSDSPlus": false,
+          "isSDSPlusEligibleSentenceTypeLengthAndOffence": false,
+          "sdsEarlyReleaseExclusions": [],
+          "isSection250": false
+        }
       }
     ],
     "adjustments": {}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac2-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac2-1.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2036-09-29",
+    "CRD": "2030-09-30",
+    "ERSED": "2027-05-11",
+    "ESED": "2036-10-24"
+  },
+  "effectiveSentenceLength": "P12Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_9"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac3-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac3-1.json
@@ -1,0 +1,14 @@
+{
+  "dates": {
+    "SLED": "2043-05-17",
+    "CRD": "2037-09-16",
+    "PED": "2033-09-16",
+    "ERSED": "2029-09-16",
+    "ESED": "2044-02-13"
+  },
+  "effectiveSentenceLength": "P19Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_10"
+  },
+  "affectedByProgressionModel": true
+}

--- a/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac4-1.json
+++ b/src/test/resources/test_data/overall_calculation_response/ers-30/crs-2812-ac4-1.json
@@ -1,0 +1,13 @@
+{
+  "dates": {
+    "SLED": "2032-06-05",
+    "CRD": "2028-06-05",
+    "ERSED": "2027-02-09",
+    "ESED": "2032-06-05"
+  },
+  "effectiveSentenceLength": "P6Y",
+  "trancheAllocationByLegislationName": {
+    "SDS_PROGRESSION_MODEL": "TRANCHE_6"
+  },
+  "affectedByProgressionModel": true
+}


### PR DESCRIPTION
We only use the ERS30 snapshot if the latest ERSED is coming from an aggregate where there are sentences imposed both pre and post ERS30 commencement.

Switch on in alt envs